### PR TITLE
feat: GitHub OAuth sign-in (PKCE + loopback)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-# GitHub personal access token (optional — can also be set in the app's settings UI)
-# Create at: https://github.com/settings/tokens
-# Required scopes: repo (or public_repo for public repositories only)
-GITHUB_TOKEN=ghp_your_token_here
+# GitHub App client secret — required to exchange OAuth codes for tokens.
+# Get it from: github.com/settings/apps/gnosis-app → Client secrets
+GH_CLIENT_SECRET=your_client_secret_here

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,4 +53,5 @@ jobs:
       - name: Publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
         run: npm run publish

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain, safeStorage, shell } from 'electron';
 import path from 'path';
 import fs from 'fs';
+import http from 'http';
+import crypto from 'crypto';
 import { Octokit } from '@octokit/rest';
 import {
   parsePrUrl,
@@ -18,6 +20,197 @@ import type { GenerateReviewRequest, ReviewGuide, ReviewHistoryEntry } from '../
 // Injected by Electron Forge Vite plugin
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string;
 declare const MAIN_WINDOW_VITE_NAME: string;
+
+// Injected by Vite define
+declare const __GH_CLIENT_SECRET__: string;
+
+const GITHUB_CLIENT_ID = 'Ov23lifGr1yrXtcZD5Og';
+const GITHUB_CLIENT_SECRET: string = typeof __GH_CLIENT_SECRET__ !== 'undefined' ? __GH_CLIENT_SECRET__ : '';
+
+// ── In-memory cache ─────────────────────────────────────────────
+
+let cachedToken: string | null = null;
+let cachedLogin: string | null = null;
+
+// ── Token storage helpers ────────────────────────────────────────
+
+function getTokenPath() {
+  return path.join(app.getPath('userData'), 'token.enc');
+}
+
+function loadStoredToken(): string | null {
+  try {
+    const enc = fs.readFileSync(getTokenPath());
+    return safeStorage.decryptString(enc);
+  } catch {
+    return null;
+  }
+}
+
+function persistToken(token: string) {
+  const enc = safeStorage.encryptString(token);
+  fs.writeFileSync(getTokenPath(), enc);
+}
+
+function deleteStoredToken() {
+  const p = getTokenPath();
+  if (fs.existsSync(p)) fs.unlinkSync(p);
+}
+
+function getResolvedToken(): string | null {
+  if (cachedToken) return cachedToken;
+  return loadStoredToken();
+}
+
+// ── Migration ────────────────────────────────────────────────────
+
+function migrateTokenIfNeeded() {
+  const tokenPath = getTokenPath();
+  if (fs.existsSync(tokenPath)) return; // already migrated
+
+  const configPath = path.join(app.getPath('userData'), 'config.json');
+  if (!fs.existsSync(configPath)) return;
+
+  try {
+    const cfg = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+    if (cfg.githubToken && typeof cfg.githubToken === 'string') {
+      persistToken(cfg.githubToken);
+      console.log('[main] Migrated PAT from config.json to safeStorage');
+    }
+  } catch {
+    // ignore
+  }
+}
+
+// ── OAuth flow ──────────────────────────────────────────────────
+
+async function exchangeCodeForToken(code: string, codeVerifier: string, redirectUri: string): Promise<string> {
+  const body = new URLSearchParams({
+    client_id: GITHUB_CLIENT_ID,
+    client_secret: GITHUB_CLIENT_SECRET,
+    code,
+    code_verifier: codeVerifier,
+    redirect_uri: redirectUri,
+  });
+
+  const res = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+
+  const data = (await res.json()) as { access_token?: string; error?: string; error_description?: string };
+  if (!data.access_token) {
+    throw new Error(data.error_description ?? data.error ?? 'OAuth token exchange failed');
+  }
+  return data.access_token;
+}
+
+async function fetchGitHubLogin(token: string): Promise<string> {
+  const res = await fetch('https://api.github.com/user', {
+    headers: {
+      Authorization: `token ${token}`,
+      'User-Agent': 'Gnosis-App',
+    },
+  });
+  const data = (await res.json()) as { login?: string };
+  return data.login ?? 'unknown';
+}
+
+function generatePkce(): { verifier: string; challenge: string } {
+  const verifier = crypto.randomBytes(32).toString('base64url');
+  const challenge = crypto.createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge };
+}
+
+function runOAuthFlow(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const state = crypto.randomBytes(20).toString('hex');
+    const { verifier, challenge } = generatePkce();
+
+    const server = http.createServer(async (req, res) => {
+      const url = new URL(req.url ?? '/', `http://localhost`);
+      if (url.pathname !== '/callback') {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+
+      const returnedState = url.searchParams.get('state');
+      const code = url.searchParams.get('code');
+      const errorParam = url.searchParams.get('error');
+
+      if (returnedState !== state) {
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end('<html><body><p>Invalid state parameter. Please try again.</p></body></html>');
+        server.close();
+        reject(new Error('OAuth state mismatch'));
+        return;
+      }
+
+      if (errorParam || !code) {
+        const desc = url.searchParams.get('error_description') ?? errorParam ?? 'Unknown error';
+        res.writeHead(400, { 'Content-Type': 'text/html' });
+        res.end(`<html><body><p>Sign-in failed: ${desc}</p></body></html>`);
+        server.close();
+        reject(new Error(desc));
+        return;
+      }
+
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      const redirectUri = `http://127.0.0.1:${port}/callback`;
+
+      try {
+        const token = await exchangeCodeForToken(code, verifier, redirectUri);
+        const login = await fetchGitHubLogin(token);
+        persistToken(token);
+        cachedToken = token;
+        cachedLogin = login;
+
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end('<html><body><p>You are now signed in to Gnosis. You can close this tab.</p></body></html>');
+        server.close();
+        resolve();
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'text/html' });
+        res.end('<html><body><p>Authentication failed. Please try again.</p></body></html>');
+        server.close();
+        reject(err);
+      }
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        server.close();
+        reject(new Error('Failed to start OAuth callback server'));
+        return;
+      }
+
+      const port = addr.port;
+      const redirectUri = `http://127.0.0.1:${port}/callback`;
+      const params = new URLSearchParams({
+        client_id: GITHUB_CLIENT_ID,
+        redirect_uri: redirectUri,
+        scope: 'repo',
+        state,
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+      });
+      shell.openExternal(`https://github.com/login/oauth/authorize?${params}`);
+    });
+
+    const timeout = setTimeout(() => {
+      server.close();
+      reject(new Error('OAuth sign-in timed out after 5 minutes'));
+    }, 5 * 60 * 1000);
+
+    server.on('close', () => clearTimeout(timeout));
+  });
+}
+
+// ── Window ───────────────────────────────────────────────────────
 
 function createWindow() {
   const mainWindow = new BrowserWindow({
@@ -42,6 +235,7 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
+  migrateTokenIfNeeded();
   createWindow();
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
@@ -51,28 +245,6 @@ app.whenReady().then(() => {
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit();
 });
-
-// ── Config helpers ──────────────────────────────────────────────
-
-function getConfigPath() {
-  return path.join(app.getPath('userData'), 'config.json');
-}
-
-function readConfig(): { githubToken: string | null } {
-  if (process.env.GITHUB_TOKEN) {
-    return { githubToken: process.env.GITHUB_TOKEN };
-  }
-  try {
-    const raw = fs.readFileSync(getConfigPath(), 'utf-8');
-    return JSON.parse(raw);
-  } catch {
-    return { githubToken: null };
-  }
-}
-
-function writeConfig(config: { githubToken: string | null }) {
-  fs.writeFileSync(getConfigPath(), JSON.stringify(config, null, 2), 'utf-8');
-}
 
 // ── Review history helpers ───────────────────────────────────────
 
@@ -123,12 +295,36 @@ function saveReviewToHistory(review: ReviewGuide): void {
 
 // ── IPC handlers ────────────────────────────────────────────────
 
+// Backward-compat shim — renderer still calls getConfig to check if signed in
 ipcMain.handle('get-config', async () => {
-  return readConfig();
+  const token = getResolvedToken();
+  return { githubToken: token };
 });
 
-ipcMain.handle('save-config', async (_event, config: { githubToken: string | null }) => {
-  writeConfig(config);
+ipcMain.handle('start-oauth', async () => {
+  await runOAuthFlow();
+});
+
+ipcMain.handle('get-auth-state', async () => {
+  const token = getResolvedToken();
+  if (!token) return { authenticated: false, login: null };
+
+  if (!cachedLogin) {
+    try {
+      cachedLogin = await fetchGitHubLogin(token);
+    } catch {
+      // token may be invalid
+      return { authenticated: false, login: null };
+    }
+  }
+
+  return { authenticated: true, login: cachedLogin };
+});
+
+ipcMain.handle('sign-out', async () => {
+  cachedToken = null;
+  cachedLogin = null;
+  deleteStoredToken();
 });
 
 ipcMain.handle('list-reviews', async () => {
@@ -148,8 +344,8 @@ ipcMain.handle('delete-review', async (_event, id: string) => {
 });
 
 ipcMain.handle('generate-review', async (_event, { prUrl, model, instructions }: GenerateReviewRequest) => {
-  const config = readConfig();
-  const octokit = new Octokit({ auth: config.githubToken ?? undefined });
+  const token = getResolvedToken();
+  const octokit = new Octokit({ auth: token ?? undefined });
 
   const { owner, repo, pullNumber } = parsePrUrl(prUrl);
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -10,6 +10,8 @@ interface Props {
   onReviewReady: (review: ReviewGuide) => void;
 }
 
+type AuthStatus = 'checking' | 'unauthenticated' | 'signing-in' | { login: string };
+
 const riskConfig = {
   low:    { label: 'Low',    className: 'bg-zinc-700 text-zinc-200 border-zinc-600' },
   medium: { label: 'Medium', className: 'bg-blue-900 text-blue-200 border-blue-700' },
@@ -29,33 +31,38 @@ function timeAgo(iso: string): string {
 }
 
 export function HomePage({ onReviewReady }: Props) {
+  const [authStatus, setAuthStatus] = useState<AuthStatus>('checking');
   const [prUrl, setPrUrl] = useState('');
   const [model, setModel] = useState<'opus' | 'sonnet'>('opus');
   const [instructions, setInstructions] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [githubToken, setGithubToken] = useState('');
-  const [tokenSaved, setTokenSaved] = useState(false);
-  const [showSettings, setShowSettings] = useState(false);
+  const [authError, setAuthError] = useState<string | null>(null);
   const [history, setHistory] = useState<ReviewHistoryEntry[]>([]);
 
   useEffect(() => {
-    window.electronAPI.getConfig().then((cfg) => {
-      if (cfg.githubToken) {
-        setGithubToken(cfg.githubToken);
-        setTokenSaved(true);
-      } else {
-        setShowSettings(true);
-      }
+    window.electronAPI.getAuthState().then(({ authenticated, login }) => {
+      setAuthStatus(authenticated && login ? { login } : 'unauthenticated');
     });
     window.electronAPI.listReviews().then(setHistory);
   }, []);
 
-  async function handleSaveToken(e: React.FormEvent) {
-    e.preventDefault();
-    await window.electronAPI.saveConfig({ githubToken: githubToken.trim() || null });
-    setTokenSaved(true);
-    setShowSettings(false);
+  async function handleSignIn() {
+    setAuthError(null);
+    setAuthStatus('signing-in');
+    try {
+      await window.electronAPI.startOAuth();
+      const { login } = await window.electronAPI.getAuthState();
+      setAuthStatus(login ? { login } : 'unauthenticated');
+    } catch (err) {
+      setAuthError(err instanceof Error ? err.message : 'Sign-in failed.');
+      setAuthStatus('unauthenticated');
+    }
+  }
+
+  async function handleSignOut() {
+    await window.electronAPI.signOut();
+    setAuthStatus('unauthenticated');
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -71,7 +78,6 @@ export function HomePage({ onReviewReady }: Props) {
         model,
         instructions: instructions.trim() || undefined,
       });
-      // Refresh history in the background
       window.electronAPI.listReviews().then(setHistory);
       onReviewReady(review);
     } catch (err) {
@@ -101,6 +107,8 @@ export function HomePage({ onReviewReady }: Props) {
     return <LoadingScreen message="Analyzing your PR with Claude... This takes 30–60 seconds for large PRs." />;
   }
 
+  const isAuthenticated = typeof authStatus === 'object';
+
   return (
     <main className="flex min-h-screen items-center justify-center p-8">
       <div className="w-full max-w-lg flex flex-col gap-8">
@@ -111,44 +119,57 @@ export function HomePage({ onReviewReady }: Props) {
           </p>
         </div>
 
-        {/* GitHub token settings */}
-        {showSettings ? (
-          <Card>
-            <CardContent className="pt-6">
-              <form onSubmit={handleSaveToken} className="flex flex-col gap-4">
-                <div className="flex flex-col gap-1.5">
-                  <label htmlFor="github-token" className="text-sm font-medium">
-                    GitHub Token
-                  </label>
-                  <p className="text-xs text-muted-foreground">
-                    Create a token at github.com/settings/tokens with{' '}
-                    <code className="font-mono bg-muted/70 rounded px-1">repo</code> read access.
-                  </p>
-                  <input
-                    id="github-token"
-                    type="password"
-                    placeholder="ghp_..."
-                    value={githubToken}
-                    onChange={(e) => setGithubToken(e.target.value)}
-                    className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                  />
-                </div>
-                <Button type="submit">Save Token</Button>
-              </form>
-            </CardContent>
-          </Card>
-        ) : (
-          <div className="flex justify-end">
+        {/* Auth section */}
+        {authStatus === 'checking' && (
+          <div className="flex justify-center">
+            <span className="text-sm text-muted-foreground animate-pulse">Loading…</span>
+          </div>
+        )}
+
+        {authStatus === 'unauthenticated' && (
+          <>
+            {authError && (
+              <Alert variant="destructive">
+                <AlertDescription>{authError}</AlertDescription>
+              </Alert>
+            )}
+            <Card>
+              <CardContent className="pt-6 flex flex-col gap-3 items-center text-center">
+                <p className="text-sm text-muted-foreground">
+                  Sign in with GitHub to generate PR reviews.
+                </p>
+                <Button onClick={handleSignIn} className="w-full">
+                  Sign in with GitHub
+                </Button>
+              </CardContent>
+            </Card>
+          </>
+        )}
+
+        {authStatus === 'signing-in' && (
+          <div className="flex flex-col items-center gap-2 text-center">
+            <span className="text-sm text-muted-foreground animate-pulse">
+              Waiting for GitHub… complete sign-in in your browser.
+            </span>
+          </div>
+        )}
+
+        {isAuthenticated && (
+          <div className="flex justify-end items-center gap-2">
+            <span className="text-xs text-muted-foreground">
+              ✓ Signed in as @{(authStatus as { login: string }).login}
+            </span>
             <button
-              onClick={() => setShowSettings(true)}
+              onClick={handleSignOut}
               className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2"
             >
-              {tokenSaved ? '✓ GitHub token saved · change' : 'Set GitHub token'}
+              Sign out
             </button>
           </div>
         )}
 
-        {!showSettings && (
+        {/* PR form — only shown when authenticated */}
+        {isAuthenticated && (
           <Card>
             <CardContent className="pt-6">
               <form onSubmit={handleSubmit} className="flex flex-col gap-4">

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -6,8 +6,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('generate-review', req),
   getConfig: (): Promise<{ githubToken: string | null }> =>
     ipcRenderer.invoke('get-config'),
-  saveConfig: (cfg: { githubToken: string | null }): Promise<void> =>
-    ipcRenderer.invoke('save-config', cfg),
+  startOAuth: (): Promise<void> =>
+    ipcRenderer.invoke('start-oauth'),
+  getAuthState: (): Promise<{ authenticated: boolean; login: string | null }> =>
+    ipcRenderer.invoke('get-auth-state'),
+  signOut: (): Promise<void> =>
+    ipcRenderer.invoke('sign-out'),
   listReviews: (): Promise<ReviewHistoryEntry[]> =>
     ipcRenderer.invoke('list-reviews'),
   loadReview: (id: string): Promise<ReviewGuide> =>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,7 +5,9 @@ declare global {
     electronAPI: {
       generateReview: (req: GenerateReviewRequest) => Promise<ReviewGuide>;
       getConfig: () => Promise<{ githubToken: string | null }>;
-      saveConfig: (cfg: { githubToken: string | null }) => Promise<void>;
+      startOAuth: () => Promise<void>;
+      getAuthState: () => Promise<{ authenticated: boolean; login: string | null }>;
+      signOut: () => Promise<void>;
       listReviews: () => Promise<ReviewHistoryEntry[]>;
       loadReview: (id: string) => Promise<ReviewGuide>;
       deleteReview: (id: string) => Promise<void>;

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -1,20 +1,27 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import path from 'path';
 import { builtinModules } from 'module';
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, '.'),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  return {
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, '.'),
+      },
     },
-  },
-  build: {
-    rollupOptions: {
-      external: [
-        'electron',
-        ...builtinModules,
-        ...builtinModules.map((m) => `node:${m}`),
-      ],
+    define: {
+      __GH_CLIENT_SECRET__: JSON.stringify(env.GH_CLIENT_SECRET ?? ''),
     },
-  },
+    build: {
+      rollupOptions: {
+        external: [
+          'electron',
+          ...builtinModules,
+          ...builtinModules.map((m) => `node:${m}`),
+        ],
+      },
+    },
+  };
 });


### PR DESCRIPTION
## Summary

- Replaces the GitHub PAT settings form with a one-click OAuth sign-in flow
- Loopback HTTP server on a random port receives the callback; no fixed redirect URI needed
- PKCE (S256) used per flow for code-interception protection
- Token persisted encrypted via Electron `safeStorage` (OS keychain on macOS, DPAPI on Windows)
- Existing PAT in `config.json` migrated to `safeStorage` automatically on first launch
- `GH_CLIENT_SECRET` injected at build time via Vite `define`; never in source

## Test plan

- [ ] `npm start` → "Sign in with GitHub" button shown (no token form)
- [ ] Click button → browser opens GitHub OAuth consent
- [ ] Approve → browser shows "You are now signed in to Gnosis"
- [ ] App shows `✓ Signed in as @username`
- [ ] Quit and relaunch → still signed in
- [ ] Sign out → back to unauthenticated state
- [ ] `npm run make` → packaged app works with secret baked in