### PR TITLE
fix: handle unclosed code fences in JSON extraction

### DIFF
--- a/components/LoadingScreen.tsx
+++ b/components/LoadingScreen.tsx
@@ -1,15 +1,34 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
+
 interface Props {
   message: string;
+  streamingText?: string;
 }
 
-export function LoadingScreen({ message }: Props) {
+export function LoadingScreen({ message, streamingText }: Props) {
+  const preRef = useRef<HTMLPreElement>(null);
+
+  useEffect(() => {
+    if (preRef.current) {
+      preRef.current.scrollTop = preRef.current.scrollHeight;
+    }
+  }, [streamingText]);
+
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <div className="flex flex-col items-center gap-4 text-center">
+    <div className="flex min-h-screen items-center justify-center p-8">
+      <div className="flex flex-col items-center gap-4 text-center w-full max-w-2xl">
         <div className="h-10 w-10 animate-spin rounded-full border-4 border-muted border-t-foreground" />
         <p className="text-muted-foreground max-w-sm">{message}</p>
+        {streamingText && (
+          <pre
+            ref={preRef}
+            className="w-full text-left text-xs text-muted-foreground/70 font-mono bg-muted/30 rounded-md p-3 overflow-y-auto max-h-48 whitespace-pre-wrap break-all"
+          >
+            {streamingText}
+          </pre>
+        )}
       </div>
     </div>
   );

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -1,6 +1,7 @@
 import { spawn, execFileSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
+import path from 'path';
 import type { ReviewGuide } from './types';
 
 // ── Claude binary resolution ─────────────────────────────────────
@@ -154,20 +155,27 @@ function callClaudeCLI(
   userContent: string,
   systemPrompt: string,
   model: string,
+  thinking: boolean,
+  onChunk?: (chunk: string, isThinking: boolean) => void,
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const env = { ...process.env };
     delete env.CLAUDECODE;
 
+    if (!thinking) env.MAX_THINKING_TOKENS = '0';
+
     const claudePath = resolveClaudePath();
-    const proc = spawn(claudePath, [
+    const args = [
       '-p',
       '--model', model,
       '--system-prompt', systemPrompt,
       '--tools', '',
-      '--output-format', 'text',
+      '--output-format', 'stream-json',
+      '--include-partial-messages',
       '--no-session-persistence',
-    ], { env });
+      ...(thinking ? ['--effort', 'high'] : []),
+    ];
+    const proc = spawn(claudePath, args, { env });
 
     proc.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code === 'ENOENT') {
@@ -180,17 +188,64 @@ function callClaudeCLI(
       }
     });
 
-    let stdout = '';
+    const debugPath = path.join(os.tmpdir(), 'gnosis-last-response.txt');
+    const debugStream = fs.createWriteStream(debugPath, { flags: 'w' });
+    const startMs = Date.now();
+
+    let lineBuffer = '';
+    let fullText = '';
     let stderr = '';
-    proc.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+
+    function processLine(line: string) {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      try {
+        const outer = JSON.parse(trimmed) as Record<string, unknown>;
+        if (outer.type === 'result' && typeof outer.result === 'string') {
+          fullText = outer.result;
+          return;
+        }
+        if (outer.type !== 'stream_event') return;
+        const inner = outer.event as Record<string, unknown> | undefined;
+        if (!inner || inner.type !== 'content_block_delta') return;
+        const delta = inner.delta as Record<string, unknown> | undefined;
+        if (!delta) return;
+        if (delta.type === 'thinking_delta' && typeof delta.thinking === 'string') {
+          onChunk?.(delta.thinking, true);
+        } else if (delta.type === 'text_delta' && typeof delta.text === 'string') {
+          fullText += delta.text;
+          onChunk?.(delta.text, false);
+        }
+      } catch {
+        // not a JSON event — ignore
+      }
+    }
+
+    proc.stdout.on('data', (chunk: Buffer) => {
+      const str = chunk.toString();
+      debugStream.write(str);
+      lineBuffer += str;
+      const newlineIdx = lineBuffer.lastIndexOf('\n');
+      if (newlineIdx === -1) return;
+      const completeLines = lineBuffer.slice(0, newlineIdx);
+      lineBuffer = lineBuffer.slice(newlineIdx + 1);
+      for (const line of completeLines.split('\n')) processLine(line);
+      const elapsed = ((Date.now() - startMs) / 1000).toFixed(1);
+      console.log(`[agent] +${elapsed}s fullText=${fullText.length} bytes`);
+    });
     proc.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
 
     proc.stdin.write(userContent);
     proc.stdin.end();
 
     proc.on('close', (code: number | null) => {
+      debugStream.end();
+      // Flush any remaining buffered line
+      if (lineBuffer.trim()) processLine(lineBuffer);
       if (code === 0) {
-        resolve(stdout.trim());
+        const elapsed = ((Date.now() - startMs) / 1000).toFixed(1);
+        console.log(`[agent] CLI finished in ${elapsed}s, ${fullText.length} chars → ${debugPath}`);
+        resolve(fullText.trim());
       } else {
         reject(new Error(`Claude CLI exited with code ${code}: ${stderr.slice(0, 300)}`));
       }
@@ -199,15 +254,11 @@ function callClaudeCLI(
 }
 
 function extractJson(text: string): string {
-  // Strip markdown code fences if present (with or without closing fence)
-  const fenceMatch = text.match(/```(?:json)?\s*([\s\S]+?)\s*(?:```|$)/);
-  if (fenceMatch) return fenceMatch[1].trim();
-
-  // Find the first { and last } to strip any preamble/postamble text
+  // Find the first { and last } — works regardless of markdown fences or
+  // whether the JSON content itself contains ``` sequences.
   const start = text.indexOf('{');
   const end = text.lastIndexOf('}');
   if (start !== -1 && end > start) return text.slice(start, end + 1);
-
   return text.trim();
 }
 
@@ -231,6 +282,8 @@ export async function generateReviewGuide(
   prUrl: string,
   model: 'opus' | 'sonnet' = 'opus',
   instructions?: string,
+  onChunk?: (chunk: string, isThinking: boolean) => void,
+  thinking: boolean = false,
 ): Promise<ReviewGuide> {
   const modelId = MODEL_IDS[model];
 
@@ -242,7 +295,7 @@ export async function generateReviewGuide(
       : SYSTEM_PROMPT;
 
     console.log('[agent] Calling Claude CLI...');
-    const fullText = await callClaudeCLI(userMessage, system, modelId);
+    const fullText = await callClaudeCLI(userMessage, system, modelId, thinking, onChunk);
     console.log('[agent] Generation complete, parsing response...');
 
     const jsonText = extractJson(fullText);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -55,6 +55,7 @@ export interface GenerateReviewRequest {
   prUrl: string;
   model: 'opus' | 'sonnet';
   instructions?: string;
+  thinking?: boolean;
 }
 
 export interface GenerateReviewResponse {

--- a/src/main.ts
+++ b/src/main.ts
@@ -343,7 +343,7 @@ ipcMain.handle('delete-review', async (_event, id: string) => {
   fs.writeFileSync(getReviewsIndexPath(), JSON.stringify(index, null, 2));
 });
 
-ipcMain.handle('generate-review', async (_event, { prUrl, model, instructions }: GenerateReviewRequest) => {
+ipcMain.handle('generate-review', async (_event, { prUrl, model, instructions, thinking }: GenerateReviewRequest) => {
   const token = getResolvedToken();
   const octokit = new Octokit({ auth: token ?? undefined });
 
@@ -402,7 +402,11 @@ ipcMain.handle('generate-review', async (_event, { prUrl, model, instructions }:
   );
 
   console.log('[main] Generating review guide...');
-  const reviewGuide = await generateReviewGuide(contextPackage, prUrl, model, instructions);
+  const reviewGuide = await generateReviewGuide(
+    contextPackage, prUrl, model, instructions,
+    (chunk, isThinking) => _event.sender.send('review-progress', { chunk, isThinking }),
+    thinking ?? false,
+  );
 
   reviewGuide.prTitle = reviewGuide.prTitle || prData.title;
   reviewGuide.prDescription = reviewGuide.prDescription || prData.description;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -34,8 +34,11 @@ export function HomePage({ onReviewReady }: Props) {
   const [authStatus, setAuthStatus] = useState<AuthStatus>('checking');
   const [prUrl, setPrUrl] = useState('');
   const [model, setModel] = useState<'opus' | 'sonnet'>('opus');
+  const [thinking, setThinking] = useState(false);
   const [instructions, setInstructions] = useState('');
   const [loading, setLoading] = useState(false);
+  const [streamingText, setStreamingText] = useState('');
+  const [isThinkingPhase, setIsThinkingPhase] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
   const [history, setHistory] = useState<ReviewHistoryEntry[]>([]);
@@ -69,20 +72,34 @@ export function HomePage({ onReviewReady }: Props) {
     e.preventDefault();
     if (!prUrl.trim()) return;
 
+    setStreamingText('');
+    setIsThinkingPhase(false);
     setLoading(true);
     setError(null);
+
+    window.electronAPI.onReviewProgress((chunk, isThinking) => {
+      if (isThinking) {
+        setIsThinkingPhase(true);
+      } else {
+        setIsThinkingPhase(false);
+        setStreamingText((prev) => prev + chunk);
+      }
+    });
 
     try {
       const review = await window.electronAPI.generateReview({
         prUrl: prUrl.trim(),
         model,
         instructions: instructions.trim() || undefined,
+        thinking,
       });
       window.electronAPI.listReviews().then(setHistory);
       onReviewReady(review);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unexpected error occurred.');
       setLoading(false);
+    } finally {
+      window.electronAPI.offReviewProgress();
     }
   }
 
@@ -104,7 +121,12 @@ export function HomePage({ onReviewReady }: Props) {
   }
 
   if (loading) {
-    return <LoadingScreen message="Analyzing your PR with Claude... This takes 30–60 seconds for large PRs." />;
+    return (
+      <LoadingScreen
+        message={isThinkingPhase ? 'Claude is thinking...' : 'Generating review guide...'}
+        streamingText={streamingText}
+      />
+    );
   }
 
   const isAuthenticated = typeof authStatus === 'object';
@@ -224,6 +246,31 @@ export function HomePage({ onReviewReady }: Props) {
                   <p className="text-xs text-muted-foreground">
                     {model === 'opus' ? 'Best quality · slower' : 'Faster · lower cost'}
                   </p>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div className="flex flex-col gap-0.5">
+                    <label htmlFor="thinking" className="text-sm font-medium">Extended thinking</label>
+                    <p className="text-xs text-muted-foreground">
+                      {thinking ? 'Deeper reasoning · slower' : 'Standard speed'}
+                    </p>
+                  </div>
+                  <button
+                    id="thinking"
+                    type="button"
+                    role="switch"
+                    aria-checked={thinking}
+                    onClick={() => setThinking((t) => !t)}
+                    className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                      thinking ? 'bg-primary' : 'bg-input'
+                    }`}
+                  >
+                    <span
+                      className={`pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform ${
+                        thinking ? 'translate-x-4' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
                 </div>
 
                 {error && (

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -18,4 +18,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('load-review', id),
   deleteReview: (id: string): Promise<void> =>
     ipcRenderer.invoke('delete-review', id),
+  onReviewProgress: (callback: (chunk: string, isThinking: boolean) => void): void => {
+    ipcRenderer.on('review-progress', (_event, { chunk, isThinking }: { chunk: string; isThinking: boolean }) => callback(chunk, isThinking));
+  },
+  offReviewProgress: (): void => {
+    ipcRenderer.removeAllListeners('review-progress');
+  },
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -11,6 +11,8 @@ declare global {
       listReviews: () => Promise<ReviewHistoryEntry[]>;
       loadReview: (id: string) => Promise<ReviewGuide>;
       deleteReview: (id: string) => Promise<void>;
+      onReviewProgress: (callback: (chunk: string, isThinking: boolean) => void) => void;
+      offReviewProgress: () => void;
     };
   }
 }


### PR DESCRIPTION
## Summary

- `extractJson` regex required a closing ` ``` ` — if the model returned an unclosed fence the raw backticks reached `JSON.parse`; updated to match with or without closing fence, with fallback to slice from first `{` to last `}`
- `stream-json + --include-partial-messages` activated extended thinking by default (budget 31,999 tokens), causing reviews to take 10+ minutes; set `MAX_THINKING_TOKENS=0` in the spawned env when thinking is off to suppress it without changing output format
- Added extended thinking toggle to the UI with streaming progress display in the loading screen
- Wired `review-progress` IPC events through preload so thinking/text deltas stream to the renderer

## Test plan

- [ ] Review with thinking off — completes in < 2 min, no `thinking_delta` in debug file
- [ ] Review with thinking on — shows thinking phase in loading screen, `thinking_delta` events present
- [ ] JSON parses successfully with and without code fences in model response