### PR TITLE
fix: validate review ID to prevent path traversal

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -457,6 +457,7 @@ ipcMain.handle('list-reviews', () => {
 });
 
 ipcMain.handle('load-review', async (_event, id: string) => {
+  if (!/^\d+$/.test(id)) throw new Error('Invalid review ID');
   const reviewPath = path.join(getReviewsDir(), `${id}.json`);
   const review = JSON.parse(fs.readFileSync(reviewPath, 'utf-8')) as ReviewGuide;
   const prefs = loadPreferences();
@@ -471,6 +472,7 @@ ipcMain.handle('re-render-hunks', async (_event, review: ReviewGuide) => {
 });
 
 ipcMain.handle('delete-review', (_event, id: string) => {
+  if (!/^\d+$/.test(id)) throw new Error('Invalid review ID');
   const filePath = path.join(getReviewsDir(), `${id}.json`);
   if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
   const index = readReviewsIndex().filter((e) => e.id !== id);


### PR DESCRIPTION
## Summary
- Validates the `id` parameter in `load-review` and `delete-review` IPC handlers to contain only digits
- Prevents path traversal attacks where an id like `../../.ssh/id_rsa` could read/delete arbitrary files

## Test plan
- [ ] Verify loading a saved review still works normally
- [ ] Verify deleting a saved review still works normally
- [ ] Confirm that non-numeric IDs are rejected with an error