### PR TITLE
fix: set restrictive permissions on plaintext token file

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -76,7 +76,7 @@ function persistToken(token: string) {
   if (safeStorage.isEncryptionAvailable()) {
     fs.writeFileSync(getTokenPath(), safeStorage.encryptString(token));
   } else {
-    fs.writeFileSync(getPlainTokenPath(), token, 'utf-8');
+    fs.writeFileSync(getPlainTokenPath(), token, { encoding: 'utf-8', mode: 0o600 });
   }
 }
 


### PR DESCRIPTION
## Summary
- Sets file mode `0o600` (owner read/write only) when writing the plaintext GitHub token fallback
- Prevents the token from being world-readable on systems where `safeStorage` encryption is unavailable

## Test plan
- [ ] On a system without safeStorage, verify the token file is created with `-rw-------` permissions
- [ ] Verify sign-in/sign-out flow still works correctly