### PR TITLE
fix: validate riskLevel against expected enum values

### DIFF
--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -134,7 +134,7 @@ function validateReviewGuide(obj: unknown): obj is ReviewGuide {
   return (
     typeof o.prTitle === 'string' &&
     typeof o.summary === 'string' &&
-    typeof o.riskLevel === 'string' &&
+    typeof o.riskLevel === 'string' && ['low', 'medium', 'high'].includes(o.riskLevel as string) &&
     Array.isArray(o.slides)
   );
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -506,7 +506,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                 <CardContent className="p-0 flex-1 overflow-y-auto min-h-0">
                   <ul className="divide-y">
                     {prGroups.map((group) => {
-                      const risk = riskConfig[group.latestReview.riskLevel];
+                      const risk = riskConfig[group.latestReview.riskLevel] ?? riskConfig.medium;
                       const hasMultiple = group.reviews.length > 1;
                       const isExpanded = expandedPRs.has(group.prUrl);
 
@@ -566,7 +566,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                           {hasMultiple && isExpanded && (
                             <ul className="border-t border-border/50">
                               {group.reviews.map((review) => {
-                                const reviewRisk = riskConfig[review.riskLevel];
+                                const reviewRisk = riskConfig[review.riskLevel] ?? riskConfig.medium;
                                 return (
                                   <li key={review.id}>
                                     <button


### PR DESCRIPTION
## Summary
- Validates `riskLevel` is one of `'low' | 'medium' | 'high'` in `validateReviewGuide()` (agent will retry if AI returns an unexpected value)
- Adds defensive fallback to `'medium'` in HomePage history list for saved reviews with unexpected riskLevel values

## Test plan
- [ ] Generate a review and verify risk badge still renders correctly
- [ ] Verify history list still renders correctly with existing saved reviews