### PR TITLE
fix: cache token after loading from storage

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -89,7 +89,8 @@ function deleteStoredToken() {
 
 function getResolvedToken(): string | null {
   if (cachedToken) return cachedToken;
-  return loadStoredToken();
+  cachedToken = loadStoredToken();
+  return cachedToken;
 }
 
 // ── OAuth flow ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `getResolvedToken()` fell back to `loadStoredToken()` but never assigned the result to `cachedToken`
- Every call when `cachedToken` was null caused a disk read and decryption
- Now caches the result for subsequent calls

## Test plan
- [ ] Verify sign-in persists across app restart (token loaded from disk and cached)
- [ ] Verify sign-out still clears the cached token