### PR TITLE
fix: prevent event listener accumulation on repeated submits

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -203,6 +203,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
     setIsThinkingPhase(false);
     setLoading(true);
 
+    window.electronAPI.offReviewProgress();
     window.electronAPI.onReviewProgress((chunk, isThinking) => {
       if (isThinking) {
         setIsThinkingPhase(true);


### PR DESCRIPTION
## Summary
- `onReviewProgress` added a new IPC listener each time `handleSubmit` ran
- If the user clicked Generate multiple times, listeners stacked and each duplicate appended chunks
- Call `offReviewProgress()` before registering a new listener to clear any existing one

## Test plan
- [ ] Click Generate, then click it again while loading — verify no duplicate streaming text
- [ ] Verify normal single-submit flow still works correctly