### PR TITLE
feat: add Content Security Policy and explicit security settings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, safeStorage, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, safeStorage, session, shell } from 'electron';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
@@ -232,6 +232,8 @@ function createWindow() {
     height: 900,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
+      nodeIntegration: false,
+      contextIsolation: true,
     },
   });
 
@@ -275,6 +277,16 @@ function startUpdateChecks() {
 }
 
 void app.whenReady().then(() => {
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [
+          "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://api.github.com",
+        ],
+      },
+    });
+  });
   applyBinaryOverrides(loadPreferences());
   createWindow();
   startUpdateChecks();


### PR DESCRIPTION
## Summary
- Adds CSP via `session.webRequest.onHeadersReceived` to restrict loaded resources (blocks external scripts, allows inline styles for Tailwind)
- Explicitly sets `nodeIntegration: false` and `contextIsolation: true` on BrowserWindow to document security intent

## Test plan
- [ ] Verify the app loads and renders correctly with CSP active
- [ ] Verify no CSP violations in DevTools console during normal use
- [ ] Verify diff rendering (Shiki) still works (inline styles allowed)
- [ ] Check DevTools console for any blocked resource warnings