### PR TITLE
fix: write debug file to userData instead of predictable temp path

### DIFF
--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -1,4 +1,5 @@
 import { spawn, execFileSync } from 'child_process';
+import { app } from 'electron';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -188,7 +189,9 @@ function callClaudeCLI(
       }
     });
 
-    const debugPath = path.join(os.tmpdir(), 'gnosis-last-response.txt');
+    const debugDir = path.join(app.getPath('userData'), 'debug');
+    if (!fs.existsSync(debugDir)) fs.mkdirSync(debugDir, { recursive: true });
+    const debugPath = path.join(debugDir, 'last-response.txt');
     const debugStream = fs.createWriteStream(debugPath, { flags: 'w' });
     const startMs = Date.now();
 


### PR DESCRIPTION
## Summary
- Moves the debug response file from `/tmp/gnosis-last-response.txt` to `userData/debug/last-response.txt`
- The predictable temp path allowed any local process to read the full AI response (including PR code)
- The userData directory has user-scoped permissions

## Test plan
- [ ] Generate a review and verify debug file is created in the userData/debug directory
- [ ] Verify no file is created in /tmp/