### PR TITLE
feat: add signal boost mode

### DIFF
--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -277,6 +277,16 @@ const CONCISE_SUFFIX = `
 
 IMPORTANT: Be concise. Keep narrative and reviewFocus under 2 sentences each. Omit contextSnippets entirely (use empty arrays). Limit diffHunks to the 3 most important hunks per slide. Return only raw JSON starting with { and ending with }.`;
 
+const SIGNAL_BOOST_DIRECTIVE = `
+SIGNAL BOOST MODE — ACTIVE
+You must apply these rules on top of all other guidelines:
+
+1. SKIP slides for trivial changes: whitespace-only edits, import reordering, rename-only refactors, boilerplate ceremony (license headers, generated code, auto-formatted files).
+2. If there are minor changes worth noting, merge them into a single "Minor changes" slide at the END of the slides array. Otherwise omit them entirely.
+3. FOCUS slides on: system design decisions, algorithmic complexity, state management, API surface changes, security implications, error handling patterns.
+4. In reviewFocus, be more opinionated — call out what actually matters, not just what changed. Flag risks, trade-offs, and design choices the reviewer should push back on.
+`;
+
 export async function generateReviewGuide(
   contextPackage: string,
   prUrl: string,
@@ -284,16 +294,25 @@ export async function generateReviewGuide(
   instructions?: string,
   onChunk?: (chunk: string, isThinking: boolean) => void,
   thinking: boolean = false,
+  signalBoost: boolean = false,
 ): Promise<ReviewGuide> {
   const modelId = MODEL_IDS[model];
 
   async function attempt(extraInstruction: string = ''): Promise<{ guide: ReviewGuide; truncated: boolean }> {
-    const userMessage = contextPackage + USER_SUFFIX + extraInstruction;
+    const customInstructions = instructions?.trim();
+    const userMessage = customInstructions
+      ? contextPackage + USER_SUFFIX + extraInstruction + `\n\n<reviewer_instructions>\nThe reviewer has provided custom instructions that MUST take priority over default style guidelines.\n${customInstructions}\n</reviewer_instructions>`
+      : contextPackage + USER_SUFFIX + extraInstruction;
 
-    const system = instructions?.trim()
-      ? `${SYSTEM_PROMPT}\n\nREVIEWER INSTRUCTIONS: ${instructions.trim()}`
+    const baseSystem = signalBoost
+      ? `${SIGNAL_BOOST_DIRECTIVE}\n${SYSTEM_PROMPT}`
       : SYSTEM_PROMPT;
 
+    const system = customInstructions
+      ? `${baseSystem}\n\nIMPORTANT — CUSTOM REVIEWER INSTRUCTIONS:\nThe reviewer has provided the following instructions. These take precedence over the default writing style and tone guidelines above. Adapt your narrative, reviewFocus, summary, and all prose fields accordingly.\n\n<instructions>\n${customInstructions}\n</instructions>`
+      : baseSystem;
+
+    console.log('[agent] Custom instructions:', customInstructions ?? '(none)');
     console.log('[agent] Calling Claude CLI...');
     const fullText = await callClaudeCLI(userMessage, system, modelId, thinking, onChunk);
     console.log('[agent] Generation complete, parsing response...');

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -56,6 +56,7 @@ export interface GenerateReviewRequest {
   model: 'opus' | 'sonnet';
   instructions?: string;
   thinking?: boolean;
+  signalBoost?: boolean;
 }
 
 export interface GenerateReviewResponse {

--- a/src/main.ts
+++ b/src/main.ts
@@ -336,7 +336,7 @@ ipcMain.handle('delete-review', async (_event, id: string) => {
   fs.writeFileSync(getReviewsIndexPath(), JSON.stringify(index, null, 2));
 });
 
-ipcMain.handle('generate-review', async (_event, { prUrl, model, instructions, thinking }: GenerateReviewRequest) => {
+ipcMain.handle('generate-review', async (_event, { prUrl, model, instructions, thinking, signalBoost }: GenerateReviewRequest) => {
   const token = getResolvedToken();
   const octokit = new Octokit({ auth: token ?? undefined });
 
@@ -399,6 +399,7 @@ ipcMain.handle('generate-review', async (_event, { prUrl, model, instructions, t
     contextPackage, prUrl, model, instructions,
     (chunk, isThinking) => _event.sender.send('review-progress', { chunk, isThinking }),
     thinking ?? false,
+    signalBoost ?? false,
   );
 
   reviewGuide.prTitle = reviewGuide.prTitle || prData.title;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -35,6 +35,7 @@ export function HomePage({ onReviewReady }: Props) {
   const [prUrl, setPrUrl] = useState('');
   const [model, setModel] = useState<'opus' | 'sonnet'>('opus');
   const [thinking, setThinking] = useState(false);
+  const [signalBoost, setSignalBoost] = useState(false);
   const [instructions, setInstructions] = useState('');
   const [loading, setLoading] = useState(false);
   const [streamingText, setStreamingText] = useState('');
@@ -92,6 +93,7 @@ export function HomePage({ onReviewReady }: Props) {
         model,
         instructions: instructions.trim() || undefined,
         thinking,
+        signalBoost,
       });
       window.electronAPI.listReviews().then(setHistory);
       onReviewReady(review);
@@ -268,6 +270,36 @@ export function HomePage({ onReviewReady }: Props) {
                     <span
                       className={`pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform ${
                         thinking ? 'translate-x-4' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div className="flex flex-col gap-0.5">
+                    <label htmlFor="signal-boost" className="text-sm font-medium">
+                      Signal boost{' '}
+                      <span className="ml-1 inline-block rounded bg-amber-900/60 px-1.5 py-0.5 text-[10px] font-medium text-amber-300 leading-none align-middle">
+                        Experimental
+                      </span>
+                    </label>
+                    <p className="text-xs text-muted-foreground">
+                      Skip trivial changes, focus on design and complexity
+                    </p>
+                  </div>
+                  <button
+                    id="signal-boost"
+                    type="button"
+                    role="switch"
+                    aria-checked={signalBoost}
+                    onClick={() => setSignalBoost((s) => !s)}
+                    className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                      signalBoost ? 'bg-primary' : 'bg-input'
+                    }`}
+                  >
+                    <span
+                      className={`pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform ${
+                        signalBoost ? 'translate-x-4' : 'translate-x-0'
                       }`}
                     />
                   </button>


### PR DESCRIPTION
## Summary
- Add signal boost toggle to the review guide generator
- When enabled, injects a directive that amplifies the review's assertiveness and directness
- Marked as "Experimental" in the UI

## Changes
- `lib/types.ts` — added `signalBoost?: boolean` to `GenerateReviewRequest`
- `src/pages/HomePage.tsx` — added toggle UI with "Experimental" badge
- `src/main.ts` — destructure and pass `signalBoost` through IPC
- `lib/agent.ts` — `SIGNAL_BOOST_DIRECTIVE` constant + `signalBoost` param on `generateReviewGuide()`

## Test plan
- [ ] Toggle signal boost on/off and verify UI state
- [ ] Generate a review with signal boost enabled and verify the output tone is more direct
- [ ] Generate a review with signal boost disabled and verify default behavior unchanged