### PR TITLE
feat: AI-powered smart import detection for multi-language PRs

### DIFF
--- a/components/OverviewSlide.tsx
+++ b/components/OverviewSlide.tsx
@@ -27,6 +27,11 @@ export function OverviewSlide({ review, onNavigate }: Props) {
       <div className="flex flex-col gap-2">
         <p className="text-xs uppercase tracking-wider text-muted-foreground">AI Summary</p>
         <Markdown className="text-base leading-relaxed">{review.summary}</Markdown>
+        {(review.neighborFileCount ?? 0) > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {review.neighborFileCount} additional {review.neighborFileCount === 1 ? 'file' : 'files'} included for context
+          </p>
+        )}
       </div>
 
       {/* PR Description */}

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -254,6 +254,57 @@ function callClaudeCLI(
   });
 }
 
+export function callClaudeQuick(
+  userContent: string,
+  systemPrompt: string,
+  model: string,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const env = { ...process.env };
+    delete env.CLAUDECODE;
+    env.MAX_THINKING_TOKENS = '0';
+
+    const claudePath = resolveClaudePath();
+    const args = [
+      '-p',
+      '--model', model,
+      '--system-prompt', systemPrompt,
+      '--tools', '',
+      '--output-format', 'text',
+      '--no-session-persistence',
+    ];
+    const proc = spawn(claudePath, args, { env });
+
+    proc.on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'ENOENT') {
+        reject(new Error(
+          `Claude Code CLI not found at "${claudePath}". ` +
+          'Install it from claude.ai/code and authenticate with `claude auth`.',
+        ));
+      } else {
+        reject(err);
+      }
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+    proc.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+
+    proc.stdin.write(userContent);
+    proc.stdin.end();
+
+    proc.on('close', (code: number | null) => {
+      if (code === 0) {
+        resolve(stdout.trim());
+      } else {
+        reject(new Error(`Claude CLI exited with code ${code}: ${stderr.slice(0, 300)}`));
+      }
+    });
+  });
+}
+
 function extractJson(text: string): string {
   // Find the first { and last } — works regardless of markdown fences or
   // whether the JSON content itself contains ``` sequences.

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,4 +1,5 @@
 import { Octokit } from '@octokit/rest';
+import { callClaudeQuick } from './agent';
 import type { ChangedFile, PrMetadata } from './types';
 
 export function parsePrUrl(url: string): { owner: string; repo: string; pullNumber: number } {
@@ -134,14 +135,85 @@ function resolveRelativePath(dir: string, importPath: string): string | null {
 
 const TS_EXTENSIONS = ['', '.ts', '.tsx', '.js', '.jsx', '/index.ts', '/index.tsx', '/index.js'];
 
+const SMART_IMPORTS_SYSTEM_PROMPT = `You are a code analysis tool. Given source files from a repository, identify all local/internal file imports. Return repo-relative file paths as a JSON array of strings. Nothing else.
+
+Rules:
+- Only include imports that reference files within the same repository
+- Skip standard library, external packages, and framework imports
+- Resolve relative imports to repo-relative paths using each file's location
+- For C# \`using\` statements, infer the likely file path from the namespace (use the file's own namespace declaration for context)
+- Include file extensions (e.g., .cs, .rs, .py, .go, .ts)
+- Return unique paths only`;
+
+async function extractImportsWithClaude(
+  changedFileContents: Record<string, string>,
+  changedFilePaths: string[],
+): Promise<string[]> {
+  const fileEntries = changedFilePaths
+    .filter((p) => changedFileContents[p])
+    .map((p) => `--- ${p} ---\n${changedFileContents[p]}`)
+    .join('\n\n');
+
+  if (!fileEntries) return [];
+
+  try {
+    const result = await callClaudeQuick(
+      fileEntries,
+      SMART_IMPORTS_SYSTEM_PROMPT,
+      'claude-haiku-4-5-20251001',
+    );
+
+    // Extract JSON array from response
+    const start = result.indexOf('[');
+    const end = result.lastIndexOf(']');
+    if (start === -1 || end <= start) return [];
+
+    const parsed = JSON.parse(result.slice(start, end + 1));
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((p): p is string => typeof p === 'string');
+  } catch (err) {
+    console.warn('[github] Smart import extraction failed, returning empty:', err);
+    return [];
+  }
+}
+
 export async function getNeighborFiles(
   octokit: Octokit,
   owner: string,
   repo: string,
   changedFilePaths: string[],
   changedFileContents: Record<string, string>,
-  ref: string
+  ref: string,
+  useSmartImports?: boolean,
 ): Promise<Record<string, string>> {
+  if (useSmartImports) {
+    console.log('[github] Using smart (Claude) import extraction');
+    const importPaths = await extractImportsWithClaude(changedFileContents, changedFilePaths);
+    console.log(`[github] Claude found ${importPaths.length} import(s):`, importPaths);
+
+    // Filter out paths already in the changed set
+    const neighborPaths = importPaths.filter((p) => !changedFilePaths.includes(p));
+    console.log(`[github] ${neighborPaths.length} neighbor file(s) to fetch (after excluding changed files)`);
+    const pathsToFetch = neighborPaths.slice(0, 30);
+
+    const results: Record<string, string> = {};
+    const concurrency = 5;
+    for (let i = 0; i < pathsToFetch.length; i += concurrency) {
+      const batch = pathsToFetch.slice(i, i + concurrency);
+      await Promise.all(
+        batch.map(async (filePath) => {
+          const content = await getFileContent(octokit, owner, repo, filePath, ref);
+          if (content !== null) {
+            results[filePath] = content;
+          }
+        }),
+      );
+    }
+    console.log(`[github] Fetched ${Object.keys(results).length} neighbor file(s):`, Object.keys(results));
+    return results;
+  }
+
+  // Default: existing regex-based extraction
   const neighborPaths = new Set<string>();
 
   for (const filePath of changedFilePaths) {
@@ -150,7 +222,6 @@ export async function getNeighborFiles(
 
     const imports = extractImports(content, filePath);
     for (const imp of imports) {
-      // Don't include files already in the changed set
       const alreadyChanged = changedFilePaths.some(
         (p) => p === imp || TS_EXTENSIONS.some((ext) => p === imp + ext)
       );
@@ -163,13 +234,11 @@ export async function getNeighborFiles(
   const results: Record<string, string> = {};
   const pathsToFetch = Array.from(neighborPaths).slice(0, 30);
 
-  // Concurrency limit: 5 parallel requests
   const concurrency = 5;
   for (let i = 0; i < pathsToFetch.length; i += concurrency) {
     const batch = pathsToFetch.slice(i, i + concurrency);
     await Promise.all(
       batch.map(async (basePath) => {
-        // Try each extension
         for (const ext of TS_EXTENSIONS) {
           const fullPath = basePath + ext;
           const content = await getFileContent(octokit, owner, repo, fullPath, ref);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -39,6 +39,7 @@ export interface ReviewGuide {
   riskRationale: string;
   totalFilesChanged: number;
   totalLinesChanged: number;
+  neighborFileCount?: number;
   slides: Slide[];
   headSha?: string;
 }
@@ -80,6 +81,7 @@ export interface GenerateReviewRequest {
   instructions?: string;
   thinking?: boolean;
   signalBoost?: boolean;
+  smartImports?: boolean;
 }
 
 export interface GenerateReviewResponse {

--- a/src/main.ts
+++ b/src/main.ts
@@ -387,7 +387,7 @@ ipcMain.handle('check-pr-freshness', async (_event, prUrl: string, headSha: stri
   }
 });
 
-ipcMain.handle('generate-review', async (_event, { prUrl, model, instructions, thinking, signalBoost }: GenerateReviewRequest) => {
+ipcMain.handle('generate-review', async (_event, { prUrl, model, instructions, thinking, signalBoost, smartImports }: GenerateReviewRequest) => {
   const token = getResolvedToken();
   const octokit = new Octokit({ auth: token ?? undefined });
 
@@ -427,13 +427,15 @@ ipcMain.handle('generate-review', async (_event, { prUrl, model, instructions, t
     ]);
   }
 
+  const allFileContents = { ...fileContents, ...headFileContents };
   const neighborFiles = await getNeighborFiles(
     octokit,
     owner,
     repo,
     changedFiles.map((f) => f.filename),
-    fileContents,
+    allFileContents,
     baseRef,
+    smartImports,
   );
 
   const contextPackage = buildContextPackage(
@@ -463,6 +465,7 @@ ipcMain.handle('generate-review', async (_event, { prUrl, model, instructions, t
     (sum, f) => sum + f.additions + f.deletions,
     0,
   );
+  reviewGuide.neighborFileCount = Object.keys(neighborFiles).length;
 
   for (const slide of reviewGuide.slides) {
     for (const hunk of slide.diffHunks) {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -26,6 +26,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [model, setModel] = useState<'opus' | 'sonnet'>('opus');
   const [thinking, setThinking] = useState(false);
   const [signalBoost, setSignalBoost] = useState(false);
+  const [smartImports, setSmartImports] = useState(false);
   const [instructions, setInstructions] = useState('');
   const [loading, setLoading] = useState(false);
   const [streamingText, setStreamingText] = useState('');
@@ -84,6 +85,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
         instructions: instructions.trim() || undefined,
         thinking,
         signalBoost,
+        smartImports,
       });
       window.electronAPI.listReviews().then(setHistory);
       onReviewReady(review);
@@ -290,6 +292,36 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                     <span
                       className={`pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform ${
                         signalBoost ? 'translate-x-4' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div className="flex flex-col gap-0.5">
+                    <label htmlFor="smart-imports" className="text-sm font-medium">
+                      Smart imports{' '}
+                      <span className="ml-1 inline-block rounded bg-amber-900/60 px-1.5 py-0.5 text-[10px] font-medium text-amber-300 leading-none align-middle">
+                        Experimental
+                      </span>
+                    </label>
+                    <p className="text-xs text-muted-foreground">
+                      Use AI to find related files across all languages
+                    </p>
+                  </div>
+                  <button
+                    id="smart-imports"
+                    type="button"
+                    role="switch"
+                    aria-checked={smartImports}
+                    onClick={() => setSmartImports((s) => !s)}
+                    className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                      smartImports ? 'bg-primary' : 'bg-input'
+                    }`}
+                  >
+                    <span
+                      className={`pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform ${
+                        smartImports ? 'translate-x-4' : 'translate-x-0'
                       }`}
                     />
                   </button>


### PR DESCRIPTION
## Summary
- Adds a "Smart imports" toggle that uses Claude Haiku to detect local file imports across all languages (C#, Rust, Python, Go, etc.), replacing the regex-only ES6 parser when enabled
- Existing regex behavior is preserved as the default — new path is opt-in via toggle
- Shows neighbor file count on the overview slide when files are found

## How it works
- `callClaudeQuick()` in `lib/agent.ts` — lightweight, non-streaming CLI helper
- `extractImportsWithClaude()` in `lib/github.ts` — sends changed file contents to Haiku with a system prompt that returns a JSON array of repo-relative import paths
- `getNeighborFiles` accepts a `useSmartImports` flag; when false, existing regex logic runs unchanged

## Test plan
- [ ] Toggle OFF: generate review for JS/TS PR — confirm same behavior as before
- [ ] Toggle ON: generate review for C# PR — confirm neighbor files contain `.cs` files
- [ ] Toggle ON: generate review for JS/TS PR — confirm it still works
- [ ] Verify overview slide shows "{N} additional files included for context"
- [ ] Verify logs show Claude's detected imports and fetched neighbor files