### PR TITLE
fix: add --verbose flag required for stream-json output format

### DIFF
--- a/lib/providers/claude.ts
+++ b/lib/providers/claude.ts
@@ -65,6 +65,7 @@ export const claudeProvider: LLMProvider = {
         '',
         '--output-format',
         'stream-json',
+        '--verbose',
         '--include-partial-messages',
         '--no-session-persistence',
         ...(thinking ? ['--effort', 'high'] : []),


### PR DESCRIPTION
## Problem

Attempt fix at breaking error upon clicking "generate review"

<img width="738" height="844" alt="Screenshot 2026-02-20 at 16 34 29" src="https://github.com/user-attachments/assets/c4308745-0aa4-4f65-85ea-140652d31216" />


Claude CLI 2.x introduced a requirement that `--verbose` must be passed when using `--output-format=stream-json` with `--print` (`-p`). Without it, the CLI exits with code 1:

```
Error: When using --print, --output-format=stream-json requires --verbose
```

This causes the "Generate Review" button to fail with:

```
Error invoking remote method 'generate-review': Error: AI review generation failed after retry: Claude CLI exited with code 1: Error: When using --print, --output-format=stream-json requires --verbose
```

## Fix

Add `--verbose` to the args in `lib/providers/claude.ts` for the streaming path.

## Testing

Verified with Claude CLI `2.1.49`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)