### PR TITLE
feat: configurable CLI paths with not-found dialog

### DIFF
--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -19,13 +19,21 @@ export function applyCodeFont(fontId: string) {
 export function SettingsDialog({ open, onOpenChange, onThemeChange }: Props) {
   const [codeTheme, setCodeTheme] = useState<CodeTheme>('aurora-x');
   const [codeFont, setCodeFont] = useState<CodeFont>('jetbrains-mono');
+  const [claudePath, setClaudePath] = useState('');
+  const [geminiPath, setGeminiPath] = useState('');
+  const [claudeDetected, setClaudeDetected] = useState('');
+  const [geminiDetected, setGeminiDetected] = useState('');
 
   useEffect(() => {
     if (!open) return;
     void window.electronAPI.loadPreferences().then((prefs) => {
       if (prefs.codeTheme) setCodeTheme(prefs.codeTheme as CodeTheme);
       if (prefs.codeFont) setCodeFont(prefs.codeFont as CodeFont);
+      setClaudePath(prefs.claudePath || '');
+      setGeminiPath(prefs.geminiPath || '');
     });
+    void window.electronAPI.detectBinaryPath('claude').then(setClaudeDetected);
+    void window.electronAPI.detectBinaryPath('gemini').then(setGeminiDetected);
   }, [open]);
 
   function saveField(overrides: Record<string, string>) {
@@ -94,6 +102,32 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange }: Props) {
                 </button>
               ))}
             </div>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Claude CLI path</label>
+            <input
+              type="text"
+              value={claudePath}
+              placeholder={claudeDetected || 'auto-detect'}
+              onChange={(e) => setClaudePath(e.target.value)}
+              onBlur={() => saveField({ claudePath })}
+              className="rounded-md border border-input bg-transparent px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+            <p className="text-xs text-muted-foreground">Leave empty to auto-detect</p>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">Gemini CLI path</label>
+            <input
+              type="text"
+              value={geminiPath}
+              placeholder={geminiDetected || 'auto-detect'}
+              onChange={(e) => setGeminiPath(e.target.value)}
+              onBlur={() => saveField({ geminiPath })}
+              className="rounded-md border border-input bg-transparent px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+            <p className="text-xs text-muted-foreground">Leave empty to auto-detect</p>
           </div>
         </div>
       </DialogContent>

--- a/lib/providers/shared.ts
+++ b/lib/providers/shared.ts
@@ -4,26 +4,33 @@ import os from 'os';
 import path from 'path';
 
 const cache = new Map<string, string>();
+const overrides = new Map<string, string>();
 
 function cacheAndReturn(name: string, resolved: string): string {
   cache.set(name, resolved);
   return resolved;
 }
 
-/**
- * Resolve the absolute path to a CLI binary. On macOS/Linux the user's
- * login shell is invoked so that profile-managed paths (Homebrew, Volta,
- * nvm, etc.) are visible even when the app is launched from Finder/Dock.
- */
-export function resolveBinaryPath(name: string, extraCandidates: string[] = []): string {
-  const cached = cache.get(name);
-  if (cached) return cached;
+export function setBinaryOverride(name: string, overridePath: string): void {
+  if (overridePath) {
+    overrides.set(name, overridePath);
+  } else {
+    overrides.delete(name);
+  }
+  cache.delete(name);
+}
 
+/**
+ * Auto-detect the absolute path to a CLI binary, ignoring overrides and cache.
+ * On macOS/Linux the user's login shell is invoked so that profile-managed
+ * paths (Homebrew, Volta, nvm, etc.) are visible even when launched from Finder/Dock.
+ */
+export function detectBinaryPath(name: string, extraCandidates: string[] = []): string {
   if (process.platform === 'win32') {
     try {
       const raw = execFileSync('where.exe', [name], { encoding: 'utf-8', timeout: 5000 });
       const result = raw.trim().split('\n')[0].trim();
-      if (result) return cacheAndReturn(name, result);
+      if (result) return result;
     } catch {
       /* fall through */
     }
@@ -32,7 +39,7 @@ export function resolveBinaryPath(name: string, extraCandidates: string[] = []):
       if (!fs.existsSync(shell)) continue;
       try {
         const result = execFileSync(shell, ['-lc', `which ${name}`], { encoding: 'utf-8', timeout: 5000 }).trim();
-        if (result) return cacheAndReturn(name, result);
+        if (result) return result;
       } catch {
         /* try next */
       }
@@ -47,11 +54,47 @@ export function resolveBinaryPath(name: string, extraCandidates: string[] = []):
     `${home}/.nvm/current/bin/${name}`,
     ...extraCandidates,
   ];
-  for (const p of candidates) {
-    if (fs.existsSync(p)) return cacheAndReturn(name, p);
+
+  // Scan nvm versioned directories (newest first)
+  const nvmVersionsDir = path.join(home, '.nvm', 'versions', 'node');
+  if (fs.existsSync(nvmVersionsDir)) {
+    try {
+      const versions = fs
+        .readdirSync(nvmVersionsDir)
+        .filter((d) => d.startsWith('v'))
+        .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+      for (const v of versions) {
+        candidates.push(path.join(nvmVersionsDir, v, 'bin', name));
+      }
+    } catch {
+      /* ignore */
+    }
   }
 
-  return cacheAndReturn(name, name);
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      console.log(`[detect] ${name} → ${p}`);
+      return p;
+    }
+  }
+
+  console.log(`[detect] ${name} → fallback (not found)`);
+  return name;
+}
+
+/**
+ * Resolve the absolute path to a CLI binary. Checks user overrides first,
+ * then cache, then falls back to auto-detection.
+ */
+export function resolveBinaryPath(name: string, extraCandidates: string[] = []): string {
+  const override = overrides.get(name);
+  if (override) return override;
+
+  const cached = cache.get(name);
+  if (cached) return cached;
+
+  const detected = detectBinaryPath(name, extraCandidates);
+  return cacheAndReturn(name, detected);
 }
 
 // ── Shared CLI spawn helpers ────────────────────────────────────

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -121,6 +121,8 @@ export interface Preferences {
   smartImports: boolean;
   codeTheme: string;
   codeFont: string;
+  claudePath: string;
+  geminiPath: string;
 }
 
 export interface GenerateReviewRequest {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain, safeStorage, shell } from 'electron';
 import path from 'path';
 import fs from 'fs';
+import os from 'os';
 import http from 'http';
 import crypto from 'crypto';
 import { Octokit } from '@octokit/rest';
@@ -21,6 +22,7 @@ import { generateReviewGuide } from '../lib/agent';
 import { checkForUpdate } from '../lib/updater';
 import { renderDiffHunk, inferLanguage, reRenderAllHunks } from '../lib/highlight';
 import { parsePatchValidLines } from '../lib/diff-lines';
+import { setBinaryOverride, detectBinaryPath, resolveBinaryPath } from '../lib/providers/shared';
 import type {
   GenerateReviewRequest,
   ModelId,
@@ -273,6 +275,7 @@ function startUpdateChecks() {
 }
 
 void app.whenReady().then(() => {
+  applyBinaryOverrides(loadPreferences());
   createWindow();
   startUpdateChecks();
 
@@ -351,7 +354,14 @@ const DEFAULT_PREFERENCES: Preferences = {
   smartImports: true,
   codeTheme: 'aurora-x',
   codeFont: 'jetbrains-mono',
+  claudePath: '',
+  geminiPath: '',
 };
+
+function applyBinaryOverrides(prefs: Preferences): void {
+  setBinaryOverride('claude', prefs.claudePath);
+  setBinaryOverride('gemini', prefs.geminiPath);
+}
 
 function loadPreferences(): Preferences {
   try {
@@ -427,6 +437,19 @@ ipcMain.handle('load-preferences', () => {
 
 ipcMain.handle('save-preferences', (_event, prefs: Preferences) => {
   savePreferences(prefs);
+  applyBinaryOverrides(prefs);
+});
+
+ipcMain.handle('detect-binary-path', (_event, name: string) => {
+  const extra = name === 'claude' ? [`${os.homedir()}/.volta/bin/claude`] : [];
+  return detectBinaryPath(name, extra);
+});
+
+ipcMain.handle('check-cli-installed', (_event, provider: string) => {
+  const extra = provider === 'claude' ? [`${os.homedir()}/.volta/bin/claude`] : [];
+  const resolved = resolveBinaryPath(provider, extra);
+  const installed = path.isAbsolute(resolved) && fs.existsSync(resolved);
+  return { installed, resolvedPath: resolved };
 });
 
 ipcMain.handle('list-reviews', () => {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -19,6 +19,7 @@ import { Badge } from '../../components/ui/badge';
 import { LoadingScreen } from '../../components/LoadingScreen';
 import { PRPickerDialog } from '../../components/PRPickerDialog';
 import { SettingsDialog } from '../../components/SettingsDialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../components/ui/dialog';
 import { riskConfig } from '../../lib/constants';
 import type { ModelId, Preferences, Provider, ReviewGuide, ReviewHistoryEntry } from '../../lib/types';
 import { timeAgo, formatDuration, groupReviewsByPR } from '../../lib/utils';
@@ -123,6 +124,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [history, setHistory] = useState<ReviewHistoryEntry[]>([]);
   const [prPickerOpen, setPrPickerOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [cliNotFound, setCliNotFound] = useState<{ provider: string } | null>(null);
   const [expandedPRs, setExpandedPRs] = useState<Set<string>>(new Set());
 
   const prGroups = useMemo(() => groupReviewsByPR(history), [history]);
@@ -189,11 +191,17 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
     if (!prUrl.trim()) return;
 
     savePrefs();
+    setError(null);
+
+    const { installed } = await window.electronAPI.checkCliInstalled(provider);
+    if (!installed) {
+      setCliNotFound({ provider });
+      return;
+    }
 
     setStreamingText('');
     setIsThinkingPhase(false);
     setLoading(true);
-    setError(null);
 
     window.electronAPI.onReviewProgress((chunk, isThinking) => {
       if (isThinking) {
@@ -350,6 +358,43 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                   </div>
                   <PRPickerDialog open={prPickerOpen} onOpenChange={setPrPickerOpen} onSelect={setPrUrl} />
                   <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
+
+                  <Dialog open={cliNotFound !== null} onOpenChange={() => setCliNotFound(null)}>
+                    <DialogContent className="bg-card sm:max-w-md">
+                      <DialogHeader>
+                        <DialogTitle>
+                          {cliNotFound?.provider === 'claude' ? 'Claude' : 'Gemini'} CLI not found
+                        </DialogTitle>
+                      </DialogHeader>
+                      <div className="flex flex-col gap-3 text-sm text-muted-foreground">
+                        <p>
+                          The {cliNotFound?.provider === 'claude' ? 'Claude' : 'Gemini'} CLI could not be found on your
+                          system. Gnosis uses the CLI to generate reviews.
+                        </p>
+                        <p>
+                          {cliNotFound?.provider === 'claude'
+                            ? 'Install it from claude.ai/code and authenticate with `claude auth`.'
+                            : 'Install it from github.com/google-gemini/gemini-cli and authenticate.'}
+                        </p>
+                        <p>
+                          If the CLI is already installed but not detected, you can set the path manually in Settings.
+                        </p>
+                      </div>
+                      <div className="flex gap-2 justify-end pt-2">
+                        <Button variant="outline" onClick={() => setCliNotFound(null)}>
+                          Dismiss
+                        </Button>
+                        <Button
+                          onClick={() => {
+                            setCliNotFound(null);
+                            setSettingsOpen(true);
+                          }}
+                        >
+                          Open Settings
+                        </Button>
+                      </div>
+                    </DialogContent>
+                  </Dialog>
 
                   <div className="flex flex-col gap-1.5">
                     <label htmlFor="instructions" className="text-sm font-medium flex items-center gap-1.5">

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -45,5 +45,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   dismissUpdate: (version: string): Promise<void> => ipcRenderer.invoke('dismiss-update', version),
   openExternal: (url: string): Promise<void> => ipcRenderer.invoke('open-external', url),
+  detectBinaryPath: (name: string): Promise<string> => ipcRenderer.invoke('detect-binary-path', name),
+  checkCliInstalled: (provider: string): Promise<{ installed: boolean; resolvedPath: string }> =>
+    ipcRenderer.invoke('check-cli-installed', provider),
   platform: process.platform,
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -34,6 +34,8 @@ declare global {
       offUpdateAvailable: () => void;
       dismissUpdate: (version: string) => Promise<void>;
       openExternal: (url: string) => Promise<void>;
+      detectBinaryPath: (name: string) => Promise<string>;
+      checkCliInstalled: (provider: string) => Promise<{ installed: boolean; resolvedPath: string }>;
       platform: NodeJS.Platform;
     };
   }


### PR DESCRIPTION
## Summary
- Add `claudePath` and `geminiPath` to preferences so users can explicitly set CLI binary locations
- Refactor `resolveBinaryPath` into `detectBinaryPath` (auto-detection) and `resolveBinaryPath` (override → cache → detect)
- Pre-flight check before review generation: if the selected provider's CLI isn't found, show a dialog with install instructions and a button to open Settings
- Settings dialog gains two path inputs with auto-detected paths as placeholders

## Test plan
- [ ] Open Settings → auto-detected paths appear as placeholders
- [ ] Set custom paths, reopen Settings → values persist
- [ ] Clear fields → reverts to auto-detect
- [ ] Remove/rename CLI binary, click Generate → "CLI not found" dialog appears
- [ ] Click "Open Settings" in dialog → Settings opens with path fields
- [ ] Set correct path in Settings, retry Generate → works
- [ ] `npx tsc --noEmit && npx eslint .` passes clean