### PR TITLE
feat: add Linux build to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         os:
           - macos-latest # arm64 (Apple Silicon)
           - windows-latest # x64
+          - ubuntu-latest # x64
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `ubuntu-latest` to the release workflow build matrix
- Forge config already has `MakerDeb` and `MakerRpm` makers configured

## Test plan
- [ ] Trigger workflow manually, verify Linux runner produces .deb and .rpm artifacts