### PR TITLE
fix: set executableName for Linux packaging

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -11,6 +11,7 @@ import { FuseV1Options, FuseVersion } from '@electron/fuses';
 const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
+    executableName: 'gnosis',
   },
   rebuildConfig: {},
   makers: [


### PR DESCRIPTION
## Summary
- Set `executableName: 'gnosis'` in Electron Packager config
- Fixes `could not find the Electron app binary` error on Linux builds where the deb/rpm makers expect lowercase binary name but `productName` produces capitalized output

## Test plan
- [ ] Trigger release workflow, verify Ubuntu job succeeds and produces .deb/.rpm artifacts