### PR TITLE
fix: add MIT license for RPM packaging

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -18,7 +18,7 @@ const config: ForgeConfig = {
     new MakerSquirrel({ authors: 'Oddur Magnusson' }),
     new MakerZIP({}, ['darwin']),
     new MakerDeb({}),
-    new MakerRpm({}),
+    new MakerRpm({ options: { license: 'MIT' } }),
   ],
   publishers: [
     new PublisherGithub({

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "productName": "Gnosis",
   "version": "0.1.2",
   "description": "AI-guided code review. Understand the story before you read the diff.",
+  "license": "MIT",
   "private": true,
   "main": ".vite/build/main.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Add `license: 'MIT'` to `MakerRpm` config — `rpmbuild` requires a License field in the spec
- Add `license` field to `package.json` for consistency

## Test plan
- [ ] Trigger release workflow, verify Ubuntu job produces .deb and .rpm artifacts