### PR TITLE
Cap mermaid diagram height in slide view

### DIFF
--- a/components/MermaidDiagram.tsx
+++ b/components/MermaidDiagram.tsx
@@ -57,7 +57,7 @@ export function MermaidDiagram({ chart }: Props) {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="group relative w-full rounded-md bg-muted/30 p-3 cursor-pointer transition-colors hover:bg-muted/50 text-left"
+        className="group relative w-full rounded-md bg-muted/30 p-3 cursor-pointer transition-colors hover:bg-muted/50 text-left max-h-[600px] overflow-y-auto"
       >
         <div ref={ref} />
         <span className="absolute top-2 right-2 rounded-md bg-background/60 p-1 opacity-0 group-hover:opacity-100 transition-opacity">


### PR DESCRIPTION
## Summary
- Add `max-h-[600px]` and `overflow-y-auto` to the inline mermaid diagram container
- Tall diagrams now scroll within their box instead of dominating the slide panel
- Fullscreen dialog (`max-h-[90vh]`) is unchanged

## Test plan
- [ ] Generate a review with a tall mermaid diagram (e.g. long flowchart)
- [ ] Verify the inline diagram is capped at ~600px with a scrollbar
- [ ] Click fullscreen and confirm the full diagram still renders at 90vh