### PR TITLE
feat: make review suggestions optional

### DIFF
--- a/components/SlideChatSheet.tsx
+++ b/components/SlideChatSheet.tsx
@@ -12,13 +12,13 @@ interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   slideTitle: string;
-  reviewFocus: string;
+  reviewFocus: string | null;
   messages: ChatMessage[];
   isStreaming: boolean;
   onSend: (text: string) => void;
 }
 
-function SuggestedQuestions({ reviewFocus, onSelect }: { reviewFocus: string; onSelect: (q: string) => void }) {
+function SuggestedQuestions({ reviewFocus, onSelect }: { reviewFocus: string | null; onSelect: (q: string) => void }) {
   const suggestions = buildSuggestions(reviewFocus);
   if (suggestions.length === 0) return null;
 
@@ -40,9 +40,9 @@ function SuggestedQuestions({ reviewFocus, onSelect }: { reviewFocus: string; on
   );
 }
 
-function buildSuggestions(reviewFocus: string): string[] {
+function buildSuggestions(reviewFocus: string | null): string[] {
   const suggestions: string[] = [];
-  const lower = reviewFocus.toLowerCase();
+  const lower = (reviewFocus ?? '').toLowerCase();
 
   if (lower.includes('error') || lower.includes('edge case') || lower.includes('validation')) {
     suggestions.push('What edge cases could break this code?');

--- a/components/SlideView.tsx
+++ b/components/SlideView.tsx
@@ -69,13 +69,15 @@ export function SlideView({ slide, slideNumber, pendingComments, commentCallback
           <Markdown className="text-sm text-muted-foreground leading-relaxed">{slide.narrative}</Markdown>
 
           {/* Review focus */}
-          <div className="review-focus-callout rounded-lg border-l-2 border-l-primary bg-primary/[0.06] px-4 py-3">
-            <p className="text-xs uppercase tracking-wider text-primary/70 flex items-center gap-1.5 mb-2">
-              <Eye className="h-3 w-3" />
-              What to check
-            </p>
-            <Markdown className="text-sm review-focus-content">{slide.reviewFocus}</Markdown>
-          </div>
+          {slide.reviewFocus && (
+            <div className="review-focus-callout rounded-lg border-l-2 border-l-primary bg-primary/[0.06] px-4 py-3">
+              <p className="text-xs uppercase tracking-wider text-primary/70 flex items-center gap-1.5 mb-2">
+                <Eye className="h-3 w-3" />
+                What to check
+              </p>
+              <Markdown className="text-sm review-focus-content">{slide.reviewFocus}</Markdown>
+            </div>
+          )}
 
           {/* Affected files */}
           {slide.affectedFiles.length > 0 && (

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -86,7 +86,7 @@ The JSON must match this schema exactly:
       "title": string,
       "slideType": "foundation" | "feature" | "refactor" | "bugfix" | "test" | "config" | "docs",
       "narrative": string,
-      "reviewFocus": string,
+      "reviewFocus": string | null,
       "diffHunks": [
         {
           "filePath": string,
@@ -151,7 +151,8 @@ export async function generateReviewGuide(
   thinking: boolean = false,
   signalBoost: boolean = false,
   mcpConfigPath?: string,
-  allowedTools?: string[]
+  allowedTools?: string[],
+  reviewSuggestions: boolean = true
 ): Promise<ReviewGuide> {
   const provider = getProvider(providerName);
 
@@ -164,7 +165,13 @@ export async function generateReviewGuide(
         `\n\n<reviewer_instructions>\nThe reviewer has provided custom instructions that MUST take priority over default style guidelines.\n${customInstructions}\n</reviewer_instructions>`
       : contextPackage + USER_SUFFIX + extraInstruction;
 
-    const baseSystem = signalBoost ? `${SIGNAL_BOOST_DIRECTIVE}\n${SYSTEM_PROMPT}` : SYSTEM_PROMPT;
+    const reviewSuggestionsDirective = reviewSuggestions
+      ? ''
+      : `\nREVIEW SUGGESTIONS DISABLED: The reviewer has turned off review suggestions. Set "reviewFocus" to null for every slide. Do not generate any review focus content.\n`;
+
+    const baseSystem = signalBoost
+      ? `${SIGNAL_BOOST_DIRECTIVE}\n${SYSTEM_PROMPT}${reviewSuggestionsDirective}`
+      : `${SYSTEM_PROMPT}${reviewSuggestionsDirective}`;
 
     const system = customInstructions
       ? `${baseSystem}\n\nIMPORTANT — CUSTOM REVIEWER INSTRUCTIONS:\nThe reviewer has provided the following instructions. These take precedence over the default writing style and tone guidelines above. Adapt your narrative, reviewFocus, summary, and all prose fields accordingly.\n\n<instructions>\n${customInstructions}\n</instructions>`

--- a/lib/chat-agent.ts
+++ b/lib/chat-agent.ts
@@ -20,7 +20,7 @@ Description: ${req.prDescription}
   parts.push(`<slide_context>
 Title: ${req.slideTitle}
 Narrative: ${req.slideNarrative}
-Review focus: ${req.slideReviewFocus}
+Review focus: ${req.slideReviewFocus ?? 'N/A'}
 Affected files: ${req.affectedFiles.join(', ')}
 </slide_context>`);
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -26,7 +26,7 @@ export interface Slide {
   title: string;
   slideType: SlideType;
   narrative: string;
-  reviewFocus: string;
+  reviewFocus: string | null;
   diffHunks: DiffHunk[];
   contextSnippets: string[];
   affectedFiles: string[];
@@ -119,6 +119,7 @@ export interface Preferences {
   thinking: boolean;
   signalBoost: boolean;
   smartImports: boolean;
+  reviewSuggestions: boolean;
   enableTools: boolean;
   codeTheme: string;
   codeFont: string;
@@ -132,7 +133,7 @@ export interface SendSlideChatRequest {
   summary: string;
   slideTitle: string;
   slideNarrative: string;
-  slideReviewFocus: string;
+  slideReviewFocus: string | null;
   affectedFiles: string[];
   diffContent: string;
   history: Array<{ role: 'user' | 'assistant'; content: string }>;
@@ -149,6 +150,7 @@ export interface GenerateReviewRequest {
   thinking?: boolean;
   signalBoost?: boolean;
   smartImports?: boolean;
+  reviewSuggestions?: boolean;
 }
 
 export interface GenerateReviewResponse {

--- a/src/main.ts
+++ b/src/main.ts
@@ -356,6 +356,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   thinking: true,
   signalBoost: true,
   smartImports: true,
+  reviewSuggestions: true,
   enableTools: false,
   codeTheme: 'aurora-x',
   codeFont: 'jetbrains-mono',
@@ -603,7 +604,16 @@ ipcMain.handle(
   'generate-review',
   async (
     _event,
-    { prUrl, provider, model, instructions, thinking, signalBoost, smartImports }: GenerateReviewRequest
+    {
+      prUrl,
+      provider,
+      model,
+      instructions,
+      thinking,
+      signalBoost,
+      smartImports,
+      reviewSuggestions,
+    }: GenerateReviewRequest
   ) => {
     const token = getResolvedToken();
     const octokit = new Octokit({ auth: token ?? undefined });
@@ -692,7 +702,8 @@ ipcMain.handle(
         thinking ?? false,
         signalBoost ?? false,
         mcpConfigPath,
-        allowedTools
+        allowedTools,
+        reviewSuggestions ?? true
       );
     } finally {
       if (mcpConfigPath) cleanupMcpConfig(mcpConfigPath);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -114,6 +114,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [thinking, setThinking] = useState(true);
   const [signalBoost, setSignalBoost] = useState(true);
   const [smartImports, setSmartImports] = useState(true);
+  const [reviewSuggestions, setReviewSuggestions] = useState(true);
   const [instructions, setInstructions] = useState('');
   const [prefsLoaded, setPrefsLoaded] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -141,6 +142,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       setThinking(prefs.thinking);
       setSignalBoost(prefs.signalBoost);
       setSmartImports(prefs.smartImports);
+      setReviewSuggestions(prefs.reviewSuggestions);
       setPrefsLoaded(true);
     });
   }, []);
@@ -156,17 +158,18 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
           thinking,
           signalBoost,
           smartImports,
+          reviewSuggestions,
           ...overrides,
         });
       });
     },
-    [instructions, provider, model, thinking, signalBoost, smartImports]
+    [instructions, provider, model, thinking, signalBoost, smartImports, reviewSuggestions]
   );
 
   // Auto-save when toggles or model/provider change (skip initial load)
   useEffect(() => {
     if (prefsLoaded) savePrefs();
-  }, [prefsLoaded, provider, model, thinking, signalBoost, smartImports, savePrefs]);
+  }, [prefsLoaded, provider, model, thinking, signalBoost, smartImports, reviewSuggestions, savePrefs]);
 
   async function handleSignIn() {
     setAuthError(null);
@@ -222,6 +225,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
         thinking,
         signalBoost,
         smartImports,
+        reviewSuggestions,
       });
       void window.electronAPI.listReviews().then(setHistory);
       onReviewReady(review);
@@ -485,6 +489,14 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                     checked={smartImports}
                     onToggle={() => setSmartImports((s) => !s)}
                     badge="Experimental"
+                  />
+
+                  <ToggleSwitch
+                    id="review-suggestions"
+                    label="Review suggestions"
+                    description="Generate 'What to check' for each slide"
+                    checked={reviewSuggestions}
+                    onToggle={() => setReviewSuggestions((r) => !r)}
                   />
 
                   {error && (


### PR DESCRIPTION
## Summary
- Add a "Review suggestions" toggle to skip generating `reviewFocus` content per slide
- When disabled, the AI sets `reviewFocus` to `null` and the "What to check" section is hidden
- Toggle persists across sessions via preferences

## Changes
- **`lib/types.ts`** — `Slide.reviewFocus` and `SendSlideChatRequest.slideReviewFocus` accept `null`; added `reviewSuggestions` to `Preferences` and `GenerateReviewRequest`
- **`src/pages/HomePage.tsx`** — New `ToggleSwitch` for "Review suggestions", wired to state/prefs/generation call
- **`src/main.ts`** — Default `reviewSuggestions: true` in preferences; pass flag through to agent
- **`lib/agent.ts`** — When disabled, append directive to system prompt and allow `null` in schema
- **`components/SlideView.tsx`** — Conditionally render "What to check" block
- **`components/SlideChatSheet.tsx`** — Handle `null` reviewFocus in suggestions and prop types
- **`lib/chat-agent.ts`** — Render `N/A` when reviewFocus is null in chat context

## Test plan
- [ ] Generate a review with "Review suggestions" ON — slides show "What to check" as before
- [ ] Generate a review with "Review suggestions" OFF — no "What to check" section on slides
- [ ] Toggle persists after restarting the app
- [ ] Chat sheet works without errors when reviewFocus is null