### PR TITLE
feat: deterministic diff hunk assignment

### DIFF
--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -1,5 +1,5 @@
 import { getProvider } from './provider';
-import type { ModelId, Provider, ReviewGuide } from './types';
+import type { AIReviewGuide, ModelId, Provider } from './types';
 
 // ── System prompt & schema constants ─────────────────────────────
 
@@ -53,14 +53,20 @@ RISK: Assess overall risk based on:
 - Docs and config = low risk
 
 You are given:
-- <full_diff>: the complete unified diff with expanded context (up to 10 lines around each change)
+- <full_diff>: the complete unified diff with expanded context (up to 15 lines around each change)
+- <hunk_index>: a list of all diff hunks with unique IDs, file paths, and change counts
 - <file_contents_before>: full file contents at base ref (before the PR)
 - <file_contents_after>: full file contents at head ref (after the PR)
 - <neighbor_files>: files imported by the changed files
 
 Use file_contents_before and file_contents_after to understand the full shape of each changed file, not just the lines in the diff. Reference surrounding functions, types, and patterns when writing narratives to give the reviewer genuine codebase context.
 
-When generating diffHunks.content, use unified diff format: each line MUST start with '+' (added), '-' (removed), or ' ' (space, for context). Include 10 lines of context before and after each change. Draw from the file contents if the diff context is shorter.
+HUNK ASSIGNMENT: The <hunk_index> lists all diff hunks with unique IDs. For each slide, assign relevant hunk IDs to "diffHunkIds". Rules:
+- Each hunk ID must appear in exactly one slide
+- Every hunk ID must be assigned to some slide
+- If a hunk doesn't fit a specific slide, include it in a final "Other changes" slide
+- Order IDs within each slide by file path (alphabetical), then hunk number (ascending)
+- Do NOT generate diff content — just reference hunks by ID
 
 You must respond with valid JSON matching the ReviewGuide schema exactly. No explanation outside the JSON.`;
 
@@ -87,15 +93,7 @@ The JSON must match this schema exactly:
       "slideType": "foundation" | "feature" | "refactor" | "bugfix" | "test" | "config" | "docs",
       "narrative": string,
       "reviewFocus": string | null,
-      "diffHunks": [
-        {
-          "filePath": string,
-          "hunkHeader": string,
-          "content": string,
-          "language": string,
-          "renderedHtml": ""
-        }
-      ],
+      "diffHunkIds": ["hunk-0", "hunk-3", ...],
       "contextSnippets": string[],
       "affectedFiles": string[],
       "dependsOn": string[],
@@ -106,7 +104,7 @@ The JSON must match this schema exactly:
 
 const CONCISE_SUFFIX = `
 
-IMPORTANT: Be concise. Keep narrative and reviewFocus under 2 sentences each. Omit contextSnippets entirely (use empty arrays). Limit diffHunks to the 3 most important hunks per slide. Return only raw JSON starting with { and ending with }.`;
+IMPORTANT: Be concise. Keep narrative and reviewFocus under 2 sentences each. Omit contextSnippets entirely (use empty arrays). Limit diffHunkIds to the 5 most important hunk IDs per slide. Return only raw JSON starting with { and ending with }.`;
 
 const SIGNAL_BOOST_DIRECTIVE = `
 SIGNAL BOOST MODE — ACTIVE
@@ -128,7 +126,7 @@ function extractJson(text: string): string {
   return text.trim();
 }
 
-function validateReviewGuide(obj: unknown): obj is ReviewGuide {
+function validateAIReviewGuide(obj: unknown): obj is AIReviewGuide {
   if (typeof obj !== 'object' || obj === null) return false;
   const o = obj as Record<string, unknown>;
   return (
@@ -153,10 +151,10 @@ export async function generateReviewGuide(
   mcpConfigPath?: string,
   allowedTools?: string[],
   reviewSuggestions: boolean = true
-): Promise<ReviewGuide> {
+): Promise<AIReviewGuide> {
   const provider = getProvider(providerName);
 
-  async function attempt(extraInstruction: string = ''): Promise<ReviewGuide> {
+  async function attempt(extraInstruction: string = ''): Promise<AIReviewGuide> {
     const customInstructions = instructions?.trim();
     const userMessage = customInstructions
       ? contextPackage +
@@ -203,7 +201,7 @@ export async function generateReviewGuide(
       throw new Error(`JSON parse failed: ${err instanceof Error ? err.message : String(err)}`);
     }
 
-    if (!validateReviewGuide(parsed)) {
+    if (!validateAIReviewGuide(parsed)) {
       throw new Error('Response is missing required fields (prTitle, summary, riskLevel, slides)');
     }
 

--- a/lib/context-builder.ts
+++ b/lib/context-builder.ts
@@ -4,7 +4,6 @@ const CHARS_PER_TOKEN = 4;
 const MAX_TOKENS = 150_000;
 const MAX_CHARS = MAX_TOKENS * CHARS_PER_TOKEN;
 const MAX_FILE_LINES = 200;
-const DIFF_CONTEXT_LINES = 10;
 
 function truncateFileContent(content: string, maxLines: number): string {
   const lines = content.split('\n');
@@ -12,115 +11,14 @@ function truncateFileContent(content: string, maxLines: number): string {
   return lines.slice(0, maxLines).join('\n') + `\n... [truncated after ${maxLines} lines]`;
 }
 
-/**
- * Expands the context lines around each hunk in a unified diff from the
- * GitHub default (3 lines) up to `targetContext` lines, using the base-ref
- * file contents that we already have in memory.
- */
-function expandDiffContext(
-  diff: string,
-  fileContents: Record<string, string>,
-  targetContext = DIFF_CONTEXT_LINES
-): string {
-  const result: string[] = [];
-  let currentBasePath: string | null = null;
-  const lines = diff.split('\n');
-  let i = 0;
-
-  while (i < lines.length) {
-    const line = lines[i];
-
-    if (line.startsWith('--- a/')) {
-      currentBasePath = line.slice('--- a/'.length);
-      result.push(line);
-      i++;
-      continue;
-    }
-
-    if (line.startsWith('--- /dev/null')) {
-      currentBasePath = null; // new file — no base content to expand from
-      result.push(line);
-      i++;
-      continue;
-    }
-
-    if (!line.startsWith('@@ ')) {
-      result.push(line);
-      i++;
-      continue;
-    }
-
-    // Hunk header: @@ -baseStart[,baseCount] +headStart[,headCount] @@ [suffix]
-    const match = line.match(/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)/);
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Record index may be undefined at runtime
-    const fileLines = currentBasePath ? fileContents[currentBasePath]?.split('\n') : undefined;
-
-    if (!match || !fileLines) {
-      result.push(line);
-      i++;
-      continue;
-    }
-
-    const baseStart = parseInt(match[1]);
-    const baseCount = parseInt(match[2]) || 1;
-    const headStart = parseInt(match[3]);
-    const headCount = parseInt(match[4]) || 1;
-    const suffix = match[5]; // e.g. " function foo() {"
-
-    // Collect hunk body
-    i++;
-    const body: string[] = [];
-    while (i < lines.length && !lines[i].startsWith('@@ ') && !lines[i].startsWith('diff ')) {
-      body.push(lines[i]);
-      i++;
-    }
-    // Drop trailing empty line artifact from split
-    while (body.length > 0 && body[body.length - 1] === '') body.pop();
-
-    // Count existing leading/trailing context lines
-    let leadCtx = 0;
-    for (const bl of body) {
-      if (bl.startsWith(' ')) leadCtx++;
-      else break;
-    }
-    let trailCtx = 0;
-    for (let j = body.length - 1; j >= 0; j--) {
-      if (body[j].startsWith(' ')) trailCtx++;
-      else break;
-    }
-
-    // --- Prepend extra leading context ---
-    const extraLead = Math.max(0, targetContext - leadCtx);
-    const hunkStart0 = baseStart - 1; // 0-indexed first line of existing hunk
-    const prependFrom = Math.max(0, hunkStart0 - extraLead);
-    const prepend = fileLines.slice(prependFrom, hunkStart0).map((l) => ' ' + l);
-
-    // --- Append extra trailing context ---
-    const extraTrail = Math.max(0, targetContext - trailCtx);
-    const hunkEnd0 = hunkStart0 + baseCount; // exclusive, 0-indexed
-    const appendTo = Math.min(fileLines.length, hunkEnd0 + extraTrail);
-    const append = fileLines.slice(hunkEnd0, appendTo).map((l) => ' ' + l);
-
-    // --- Rebuild hunk header ---
-    const newBaseStart = prependFrom + 1;
-    const newBaseCount = prepend.length + baseCount + append.length;
-    const newHeadStart = Math.max(1, headStart - prepend.length);
-    const newHeadCount = prepend.length + headCount + append.length;
-
-    result.push(`@@ -${newBaseStart},${newBaseCount} +${newHeadStart},${newHeadCount} @@${suffix}`);
-    result.push(...prepend, ...body, ...append);
-  }
-
-  return result.join('\n');
-}
-
 export function buildContextPackage(
   prData: PrMetadata,
-  diff: string,
+  expandedDiff: string,
   changedFiles: ChangedFile[],
   fileContents: Record<string, string>,
   headFileContents: Record<string, string>,
-  neighborFiles: Record<string, string>
+  neighborFiles: Record<string, string>,
+  hunkIndex: string
 ): string {
   const totalAdditions = changedFiles.reduce((s, f) => s + f.additions, 0);
   const totalDeletions = changedFiles.reduce((s, f) => s + f.deletions, 0);
@@ -133,10 +31,11 @@ Base branch: ${prData.baseBranch}
 Files changed: ${changedFiles.length} | Lines added: ${totalAdditions} | Lines deleted: ${totalDeletions}
 </pr_metadata>`;
 
-  const expandedDiff = expandDiffContext(diff, fileContents);
   const diffSection = `<full_diff>
 ${expandedDiff}
 </full_diff>`;
+
+  const hunkIndexSection = hunkIndex;
 
   // Build file_contents (before) section
   let fileContentsSection = '<file_contents_before>\n';
@@ -170,6 +69,8 @@ ${expandedDiff}
       4 +
       diffStr.length +
       4 +
+      hunkIndexSection.length +
+      4 +
       fileContentsStr.length +
       4 +
       headContentsStr.length +
@@ -182,7 +83,13 @@ ${expandedDiff}
   if (totalSize() > MAX_CHARS) {
     const neighborBudget = Math.max(
       0,
-      MAX_CHARS - metaSection.length - diffStr.length - fileContentsStr.length - headContentsStr.length - 20
+      MAX_CHARS -
+        metaSection.length -
+        diffStr.length -
+        hunkIndexSection.length -
+        fileContentsStr.length -
+        headContentsStr.length -
+        20
     );
     let neighborChars = 0;
     const truncatedNeighbor: Record<string, string> = {};
@@ -230,7 +137,13 @@ ${expandedDiff}
 
   // Step 5: Truncate the diff itself as a last resort
   if (totalSize() > MAX_CHARS) {
-    const overhead = metaSection.length + fileContentsStr.length + headContentsStr.length + neighborStr.length + 20;
+    const overhead =
+      metaSection.length +
+      hunkIndexSection.length +
+      fileContentsStr.length +
+      headContentsStr.length +
+      neighborStr.length +
+      20;
     const diffBudget = MAX_CHARS - overhead;
     console.warn(
       `[context-builder] Diff too large (${expandedDiff.length} chars) — truncating to fit budget (${diffBudget} chars)`
@@ -240,11 +153,21 @@ ${expandedDiff}
   }
 
   const finalPackage =
-    metaSection + '\n\n' + diffStr + '\n\n' + fileContentsStr + '\n\n' + headContentsStr + '\n\n' + neighborStr;
+    metaSection +
+    '\n\n' +
+    diffStr +
+    '\n\n' +
+    hunkIndexSection +
+    '\n\n' +
+    fileContentsStr +
+    '\n\n' +
+    headContentsStr +
+    '\n\n' +
+    neighborStr;
   const estimatedTokens = Math.ceil(finalPackage.length / CHARS_PER_TOKEN);
 
   console.log(
-    `[context-builder] Section sizes (chars): diff=${expandedDiff.length}, fileBefore=${fileContentsStr.length}, fileAfter=${headContentsStr.length}, neighbors=${neighborStr.length}`
+    `[context-builder] Section sizes (chars): diff=${expandedDiff.length}, hunkIndex=${hunkIndexSection.length}, fileBefore=${fileContentsStr.length}, fileAfter=${headContentsStr.length}, neighbors=${neighborStr.length}`
   );
   console.log(
     `[context-builder] Total context: ${finalPackage.length} chars (~${estimatedTokens.toLocaleString()} tokens) | Budget: ${MAX_CHARS} chars (~${MAX_TOKENS.toLocaleString()} tokens)`

--- a/lib/diff-parse.ts
+++ b/lib/diff-parse.ts
@@ -1,0 +1,485 @@
+import type { DiffHunk } from './types';
+import { inferLanguage } from './highlight';
+
+// ── Types ────────────────────────────────────────────────────────
+
+export interface ParsedHunk {
+  id: string;
+  filePath: string;
+  fileStatus: 'added' | 'deleted' | 'modified' | 'renamed';
+  hunkHeader: string;
+  content: string;
+  additions: number;
+  deletions: number;
+  scopeName: string | null;
+}
+
+export interface IndexedHunk extends ParsedHunk {
+  language: string;
+  expandedHunkHeader: string;
+  expandedContent: string;
+}
+
+// ── Hunk header parsing ─────────────────────────────────────────
+
+const HUNK_HEADER_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)/;
+
+function parseHunkHeader(header: string) {
+  const m = header.match(HUNK_HEADER_RE);
+  if (!m) return null;
+  return {
+    baseStart: parseInt(m[1], 10),
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- regex optional group can be undefined at runtime
+    baseCount: m[2] !== undefined ? parseInt(m[2], 10) : 1,
+    headStart: parseInt(m[3], 10),
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- regex optional group can be undefined at runtime
+    headCount: m[4] !== undefined ? parseInt(m[4], 10) : 1,
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- regex optional group
+    suffix: m[5] ?? '',
+  };
+}
+
+function buildHunkHeader(
+  baseStart: number,
+  baseCount: number,
+  headStart: number,
+  headCount: number,
+  suffix: string
+): string {
+  return `@@ -${baseStart},${baseCount} +${headStart},${headCount} @@${suffix}`;
+}
+
+// ── Parse unified diff into per-hunk objects ─────────────────────
+
+export function parseUnifiedDiff(diff: string): ParsedHunk[] {
+  const hunks: ParsedHunk[] = [];
+  const lines = diff.split('\n');
+  let i = 0;
+  let hunkCounter = 0;
+
+  let currentFilePath: string | null = null;
+  let currentFileStatus: 'added' | 'deleted' | 'modified' | 'renamed' = 'modified';
+  let isRename = false;
+  let renameFrom: string | null = null;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // diff header
+    if (line.startsWith('diff --git')) {
+      isRename = false;
+      renameFrom = null;
+      i++;
+      continue;
+    }
+
+    // Detect rename markers
+    if (line.startsWith('rename from ')) {
+      renameFrom = line.slice('rename from '.length);
+      isRename = true;
+      i++;
+      continue;
+    }
+    if (line.startsWith('rename to ')) {
+      isRename = true;
+      i++;
+      continue;
+    }
+
+    // similarity / dissimilarity index, old mode, new mode, etc.
+    if (
+      line.startsWith('index ') ||
+      line.startsWith('old mode') ||
+      line.startsWith('new mode') ||
+      line.startsWith('new file mode') ||
+      line.startsWith('deleted file mode') ||
+      line.startsWith('similarity index') ||
+      line.startsWith('dissimilarity index') ||
+      line.startsWith('copy from') ||
+      line.startsWith('copy to') ||
+      line.startsWith('Binary files')
+    ) {
+      if (line.startsWith('new file mode')) currentFileStatus = 'added';
+      if (line.startsWith('deleted file mode')) currentFileStatus = 'deleted';
+      i++;
+      continue;
+    }
+
+    // --- a/path or --- /dev/null
+    if (line.startsWith('--- ')) {
+      if (line === '--- /dev/null') {
+        currentFileStatus = 'added';
+      }
+      i++;
+      continue;
+    }
+
+    // +++ b/path or +++ /dev/null
+    if (line.startsWith('+++ ')) {
+      if (line === '+++ /dev/null') {
+        currentFileStatus = 'deleted';
+      } else {
+        currentFilePath = line.slice('+++ b/'.length);
+        if (isRename && renameFrom) {
+          currentFileStatus = 'renamed';
+        } else if (currentFileStatus !== 'added' && currentFileStatus !== 'deleted') {
+          currentFileStatus = 'modified';
+        }
+      }
+      i++;
+      continue;
+    }
+
+    // Hunk header
+    if (line.startsWith('@@ ') && currentFilePath) {
+      const match = line.match(HUNK_HEADER_RE);
+      if (!match) {
+        i++;
+        continue;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- regex optional group
+      const suffix = match[5] ?? '';
+      const scopeName = suffix.trim() || null;
+
+      // Collect hunk body lines
+      i++;
+      const body: string[] = [];
+      while (i < lines.length) {
+        const bodyLine = lines[i];
+        if (bodyLine.startsWith('@@ ') || bodyLine.startsWith('diff --git')) {
+          break;
+        }
+        // Skip "\ No newline at end of file"
+        if (bodyLine.startsWith('\\')) {
+          i++;
+          continue;
+        }
+        body.push(bodyLine);
+        i++;
+      }
+
+      // Remove trailing empty lines from split artifact
+      while (body.length > 0 && body[body.length - 1] === '') body.pop();
+
+      const content = body.join('\n');
+
+      let additions = 0;
+      let deletions = 0;
+      for (const bl of body) {
+        if (bl.startsWith('+')) additions++;
+        else if (bl.startsWith('-')) deletions++;
+      }
+
+      hunks.push({
+        id: `hunk-${hunkCounter++}`,
+        filePath: currentFilePath,
+        fileStatus: currentFileStatus,
+        hunkHeader: line,
+        content,
+        additions,
+        deletions,
+        scopeName,
+      });
+
+      continue;
+    }
+
+    i++;
+  }
+
+  return hunks;
+}
+
+// ── Expand context for a single hunk ─────────────────────────────
+
+export function expandHunkContext(
+  hunk: ParsedHunk,
+  filesBefore: Record<string, string>,
+  filesAfter: Record<string, string>,
+  targetContext = 15
+): { expandedHunkHeader: string; expandedContent: string } {
+  const parsed = parseHunkHeader(hunk.hunkHeader);
+  if (!parsed) {
+    return { expandedHunkHeader: hunk.hunkHeader, expandedContent: hunk.content };
+  }
+
+  // Choose source file for context padding
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Record index may be undefined at runtime
+  const baseLines = filesBefore[hunk.filePath]?.split('\n');
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Record index may be undefined at runtime
+  const headLines = filesAfter[hunk.filePath]?.split('\n');
+
+  // For added files, context comes from head; for others, from base
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Record index may be undefined at runtime
+  const ctxSource = hunk.fileStatus === 'added' ? headLines : (baseLines ?? headLines);
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Record index may be undefined at runtime
+  if (!ctxSource) {
+    return { expandedHunkHeader: hunk.hunkHeader, expandedContent: hunk.content };
+  }
+
+  // Parse body lines
+  const rawLines = hunk.content.split('\n');
+  const bodyLines: { marker: string; text: string }[] = [];
+  for (const raw of rawLines) {
+    if (raw === '') continue;
+    const marker = raw[0];
+    bodyLines.push({ marker, text: raw.slice(1) });
+  }
+
+  if (bodyLines.length === 0) {
+    return { expandedHunkHeader: hunk.hunkHeader, expandedContent: hunk.content };
+  }
+
+  // Count existing leading/trailing context
+  let leadCtx = 0;
+  for (const bl of bodyLines) {
+    if (bl.marker === ' ') leadCtx++;
+    else break;
+  }
+  let trailCtx = 0;
+  for (let j = bodyLines.length - 1; j >= 0; j--) {
+    if (bodyLines[j].marker === ' ') trailCtx++;
+    else break;
+  }
+
+  // For added files (all + lines), use headStart for positioning
+  const hunkStart0 = hunk.fileStatus === 'added' ? parsed.headStart - 1 : parsed.baseStart - 1;
+
+  // Prepend leading context
+  const extraLead = Math.max(0, targetContext - leadCtx);
+  const prependFrom = Math.max(0, hunkStart0 - extraLead);
+  const prepend = ctxSource.slice(prependFrom, hunkStart0).map((l) => ' ' + l);
+
+  // Calculate where the hunk body ends in the source file
+  // Walk through body lines to find where base pointer ends
+  let basePos = parsed.baseStart - 1;
+  let headPos = parsed.headStart - 1;
+  for (const bl of bodyLines) {
+    if (bl.marker === ' ') {
+      basePos++;
+      headPos++;
+    } else if (bl.marker === '-') {
+      basePos++;
+    } else if (bl.marker === '+') {
+      headPos++;
+    }
+  }
+  const hunkEnd0 = hunk.fileStatus === 'added' ? headPos : basePos;
+
+  // Append trailing context
+  const extraTrail = Math.max(0, targetContext - trailCtx);
+  const appendTo = Math.min(ctxSource.length, hunkEnd0 + extraTrail);
+  const append = ctxSource.slice(hunkEnd0, appendTo).map((l) => ' ' + l);
+
+  // Rebuild hunk header with new counts
+  const allContent = [...prepend, ...rawLines.filter((l) => l !== ''), ...append];
+
+  let newBaseCount = 0;
+  let newHeadCount = 0;
+  for (const l of allContent) {
+    const m = l[0];
+    if (m === ' ') {
+      newBaseCount++;
+      newHeadCount++;
+    } else if (m === '-') {
+      newBaseCount++;
+    } else if (m === '+') {
+      newHeadCount++;
+    }
+  }
+
+  const newBaseStart = Math.max(1, parsed.baseStart - prepend.length);
+  const newHeadStart = Math.max(1, parsed.headStart - prepend.length);
+
+  const expandedHunkHeader = buildHunkHeader(newBaseStart, newBaseCount, newHeadStart, newHeadCount, parsed.suffix);
+  const expandedContent = allContent.join('\n');
+
+  return { expandedHunkHeader, expandedContent };
+}
+
+// ── Full pipeline: parse → expand → index ────────────────────────
+
+export function buildIndexedHunks(
+  diff: string,
+  filesBefore: Record<string, string>,
+  filesAfter: Record<string, string>,
+  targetContext = 15
+): IndexedHunk[] {
+  const parsed = parseUnifiedDiff(diff);
+
+  return parsed.map((hunk) => {
+    const { expandedHunkHeader, expandedContent } = expandHunkContext(hunk, filesBefore, filesAfter, targetContext);
+    const language = inferLanguage(hunk.filePath);
+
+    return {
+      ...hunk,
+      language,
+      expandedHunkHeader,
+      expandedContent,
+    };
+  });
+}
+
+// ── Expand full diff as a single string ──────────────────────────
+// Replaces expandDiffContext from context-builder.ts but also
+// handles added files by using head file contents.
+
+export function expandFullDiff(
+  diff: string,
+  filesBefore: Record<string, string>,
+  filesAfter: Record<string, string>,
+  targetContext = 15
+): string {
+  const result: string[] = [];
+  let currentBasePath: string | null = null;
+  let currentFileStatus: 'added' | 'deleted' | 'modified' = 'modified';
+  const lines = diff.split('\n');
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (line.startsWith('--- /dev/null')) {
+      currentBasePath = null;
+      currentFileStatus = 'added';
+      result.push(line);
+      i++;
+      continue;
+    }
+
+    if (line.startsWith('--- a/')) {
+      currentBasePath = line.slice('--- a/'.length);
+      currentFileStatus = 'modified';
+      result.push(line);
+      i++;
+      continue;
+    }
+
+    if (line.startsWith('+++ /dev/null')) {
+      currentFileStatus = 'deleted';
+      result.push(line);
+      i++;
+      continue;
+    }
+
+    if (line.startsWith('+++ b/')) {
+      const headPath = line.slice('+++ b/'.length);
+      if (currentFileStatus === 'added') {
+        currentBasePath = headPath; // use headPath for context lookup
+      }
+      result.push(line);
+      i++;
+      continue;
+    }
+
+    if (!line.startsWith('@@ ')) {
+      result.push(line);
+      i++;
+      continue;
+    }
+
+    // Hunk header
+    const match = line.match(HUNK_HEADER_RE);
+
+    // Choose file lines for context expansion
+    // For added files, use head file; for others, use base file
+    let fileLines: string[] | undefined;
+    if (currentFileStatus === 'added' && currentBasePath) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Record index may be undefined at runtime
+      fileLines = filesAfter[currentBasePath]?.split('\n');
+    } else if (currentBasePath) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Record index may be undefined at runtime
+      fileLines = filesBefore[currentBasePath]?.split('\n');
+    }
+
+    if (!match || !fileLines) {
+      result.push(line);
+      i++;
+      continue;
+    }
+
+    const baseStart = parseInt(match[1]);
+    const baseCount = parseInt(match[2]) || 1;
+    const headStart = parseInt(match[3]);
+    const headCount = parseInt(match[4]) || 1;
+    const suffix = match[5];
+
+    // Collect hunk body
+    i++;
+    const body: string[] = [];
+    while (i < lines.length && !lines[i].startsWith('@@ ') && !lines[i].startsWith('diff ')) {
+      body.push(lines[i]);
+      i++;
+    }
+    while (body.length > 0 && body[body.length - 1] === '') body.pop();
+
+    // Count existing leading/trailing context
+    let leadCtx = 0;
+    for (const bl of body) {
+      if (bl.startsWith(' ')) leadCtx++;
+      else break;
+    }
+    let trailCtx = 0;
+    for (let j = body.length - 1; j >= 0; j--) {
+      if (body[j].startsWith(' ')) trailCtx++;
+      else break;
+    }
+
+    // For added files, use headStart for positioning
+    const hunkStart0 = currentFileStatus === 'added' ? headStart - 1 : baseStart - 1;
+
+    // Prepend extra leading context
+    const extraLead = Math.max(0, targetContext - leadCtx);
+    const prependFrom = Math.max(0, hunkStart0 - extraLead);
+    const prepend = fileLines.slice(prependFrom, hunkStart0).map((l) => ' ' + l);
+
+    // Append extra trailing context
+    const extraTrail = Math.max(0, targetContext - trailCtx);
+    const hunkEnd0 = currentFileStatus === 'added' ? hunkStart0 + headCount : hunkStart0 + baseCount;
+    const appendTo = Math.min(fileLines.length, hunkEnd0 + extraTrail);
+    const append = fileLines.slice(hunkEnd0, appendTo).map((l) => ' ' + l);
+
+    // Rebuild hunk header
+    const newBaseStart = currentFileStatus === 'added' ? baseStart : Math.max(1, prependFrom + 1);
+    const newBaseCount = currentFileStatus === 'added' ? baseCount : prepend.length + baseCount + append.length;
+    const newHeadStart =
+      currentFileStatus === 'added' ? Math.max(1, headStart - prepend.length) : Math.max(1, headStart - prepend.length);
+    const newHeadCount = prepend.length + headCount + append.length;
+
+    result.push(`@@ -${newBaseStart},${newBaseCount} +${newHeadStart},${newHeadCount} @@${suffix}`);
+    result.push(...prepend, ...body, ...append);
+  }
+
+  return result.join('\n');
+}
+
+// ── Format hunk index as XML for the AI prompt ───────────────────
+
+export function formatHunkIndexForPrompt(hunks: IndexedHunk[]): string {
+  const entries = hunks.map((h) => {
+    const escapedFile = h.filePath.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+    const escapedHeader = h.hunkHeader
+      .replace(/&/g, '&amp;')
+      .replace(/"/g, '&quot;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    return `  <hunk id="${h.id}" file="${escapedFile}" header="${escapedHeader}" additions="${h.additions}" deletions="${h.deletions}" />`;
+  });
+
+  return `<hunk_index>\n${entries.join('\n')}\n</hunk_index>`;
+}
+
+// ── Sort diff hunks by file path then base start line ────────────
+
+export function sortDiffHunks(hunks: DiffHunk[]): DiffHunk[] {
+  return [...hunks].sort((a, b) => {
+    const pathCmp = a.filePath.localeCompare(b.filePath);
+    if (pathCmp !== 0) return pathCmp;
+
+    const aStart = parseHunkHeader(a.hunkHeader)?.baseStart ?? 0;
+    const bStart = parseHunkHeader(b.hunkHeader)?.baseStart ?? 0;
+    return aStart - bStart;
+  });
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -34,6 +34,34 @@ export interface Slide {
   mermaidDiagram?: string | null;
 }
 
+// Intermediate types for raw AI response (before hunk resolution)
+export interface AISlide {
+  id: string;
+  slideNumber: number;
+  title: string;
+  slideType: SlideType;
+  narrative: string;
+  reviewFocus: string | null;
+  diffHunkIds: string[];
+  contextSnippets: string[];
+  affectedFiles: string[];
+  dependsOn: string[];
+  mermaidDiagram?: string | null;
+}
+
+export interface AIReviewGuide {
+  prTitle: string;
+  prDescription: string;
+  prUrl: string;
+  author: string;
+  summary: string;
+  riskLevel: 'low' | 'medium' | 'high';
+  riskRationale: string;
+  totalFilesChanged: number;
+  totalLinesChanged: number;
+  slides: AISlide[];
+}
+
 export interface ReviewGuide {
   prTitle: string;
   prDescription: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,18 +20,21 @@ import type { CiCheck, PrStatus } from '../lib/types';
 import { buildContextPackage } from '../lib/context-builder';
 import { generateReviewGuide } from '../lib/agent';
 import { checkForUpdate } from '../lib/updater';
-import { renderDiffHunk, inferLanguage, reRenderAllHunks } from '../lib/highlight';
+import { renderDiffHunk, reRenderAllHunks } from '../lib/highlight';
 import { parsePatchValidLines } from '../lib/diff-lines';
 import { setBinaryOverride, detectBinaryPath, resolveBinaryPath } from '../lib/providers/shared';
 import { getProvider } from '../lib/provider';
 import { buildSlideChatSystemPrompt, buildSlideChatUserMessage } from '../lib/chat-agent';
+import { buildIndexedHunks, expandFullDiff, formatHunkIndexForPrompt, sortDiffHunks } from '../lib/diff-parse';
 import { writeMcpConfig, cleanupMcpConfig } from '../lib/mcp-config';
 import type {
+  DiffHunk,
   GenerateReviewRequest,
   ModelId,
   Preferences,
   ReviewGuide,
   ReviewHistoryEntry,
+  Slide,
   SendSlideChatRequest,
   SubmitReviewRequest,
   FreshnessResult,
@@ -665,13 +668,19 @@ ipcMain.handle(
       smartImports ? provider : undefined
     );
 
+    // Parse diff into indexed hunks and build expanded diff
+    const indexedHunks = buildIndexedHunks(diff, fileContents, headFileContents);
+    const expandedDiff = expandFullDiff(diff, fileContents, headFileContents);
+    const hunkIndex = formatHunkIndexForPrompt(indexedHunks);
+
     const contextPackage = buildContextPackage(
       prData,
-      diff,
+      expandedDiff,
       changedFiles,
       fileContents,
       headFileContents,
-      neighborFiles
+      neighborFiles,
+      hunkIndex
     );
 
     console.log('[main] Generating review guide...');
@@ -690,9 +699,9 @@ ipcMain.handle(
       }
     }
 
-    let reviewGuide: ReviewGuide;
+    let aiResult;
     try {
-      reviewGuide = await generateReviewGuide(
+      aiResult = await generateReviewGuide(
         contextPackage,
         prUrl,
         provider,
@@ -711,22 +720,93 @@ ipcMain.handle(
 
     const generationDurationMs = Date.now() - generationStart;
 
-    reviewGuide.prTitle = reviewGuide.prTitle || prData.title;
-    reviewGuide.prDescription = reviewGuide.prDescription || prData.description;
-    reviewGuide.author = reviewGuide.author || prData.author;
-    reviewGuide.prUrl = prUrl;
-    reviewGuide.headSha = prData.headSha;
-    reviewGuide.totalFilesChanged = changedFiles.length;
-    reviewGuide.totalLinesChanged = changedFiles.reduce((sum, f) => sum + f.additions + f.deletions, 0);
-    reviewGuide.neighborFileCount = Object.keys(neighborFiles).length;
-    reviewGuide.generationDurationMs = generationDurationMs;
+    // Resolve hunk IDs → real DiffHunk objects
+    const hunkMap = new Map(indexedHunks.map((h) => [h.id, h]));
+    const assignedIds = new Set<string>();
 
+    const resolvedSlides: Slide[] = aiResult.slides.map((aiSlide) => {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- AI response may omit fields
+      const ids = aiSlide.diffHunkIds ?? [];
+      const diffHunks: DiffHunk[] = ids
+        .filter((id: string) => hunkMap.has(id) && !assignedIds.has(id))
+        .map((id: string) => {
+          assignedIds.add(id);
+          // Safe: filter above guarantees hunkMap.has(id)
+          const h = hunkMap.get(id);
+          if (!h) throw new Error(`Hunk ${id} not found in index`);
+          return {
+            filePath: h.filePath,
+            hunkHeader: h.expandedHunkHeader,
+            content: h.expandedContent,
+            language: h.language,
+            renderedHtml: '',
+          };
+        });
+
+      return {
+        id: aiSlide.id,
+        slideNumber: aiSlide.slideNumber,
+        title: aiSlide.title,
+        slideType: aiSlide.slideType,
+        narrative: aiSlide.narrative,
+        reviewFocus: aiSlide.reviewFocus,
+        diffHunks: sortDiffHunks(diffHunks),
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- AI response may omit fields
+        contextSnippets: aiSlide.contextSnippets ?? [],
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- AI response may omit fields
+        affectedFiles: aiSlide.affectedFiles ?? [],
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- AI response may omit fields
+        dependsOn: aiSlide.dependsOn ?? [],
+        mermaidDiagram: aiSlide.mermaidDiagram,
+      };
+    });
+
+    // Catch-all slide for unassigned hunks
+    const unassigned = indexedHunks.filter((h) => !assignedIds.has(h.id));
+    if (unassigned.length > 0) {
+      const otherHunks: DiffHunk[] = unassigned.map((h) => ({
+        filePath: h.filePath,
+        hunkHeader: h.expandedHunkHeader,
+        content: h.expandedContent,
+        language: h.language,
+        renderedHtml: '',
+      }));
+
+      resolvedSlides.push({
+        id: 'other-changes',
+        slideNumber: resolvedSlides.length + 1,
+        title: 'Other changes',
+        slideType: 'refactor',
+        narrative: 'Additional changes not covered in previous slides.',
+        reviewFocus: null,
+        diffHunks: sortDiffHunks(otherHunks),
+        contextSnippets: [],
+        affectedFiles: [...new Set(unassigned.map((h) => h.filePath))],
+        dependsOn: [],
+        mermaidDiagram: null,
+      });
+    }
+
+    const reviewGuide: ReviewGuide = {
+      prTitle: aiResult.prTitle || prData.title,
+      prDescription: aiResult.prDescription || prData.description,
+      prUrl,
+      author: aiResult.author || prData.author,
+      summary: aiResult.summary,
+      riskLevel: aiResult.riskLevel,
+      riskRationale: aiResult.riskRationale,
+      totalFilesChanged: changedFiles.length,
+      totalLinesChanged: changedFiles.reduce((sum, f) => sum + f.additions + f.deletions, 0),
+      neighborFileCount: Object.keys(neighborFiles).length,
+      generationDurationMs,
+      slides: resolvedSlides,
+      headSha: prData.headSha,
+    };
+
+    // Render syntax-highlighted HTML for each hunk
     const codeTheme = loadPreferences().codeTheme;
     for (const slide of reviewGuide.slides) {
       for (const hunk of slide.diffHunks) {
-        if (!hunk.language) {
-          hunk.language = inferLanguage(hunk.filePath);
-        }
         try {
           hunk.renderedHtml = await renderDiffHunk(hunk.content, hunk.language, codeTheme, hunk.hunkHeader);
         } catch (err) {


### PR DESCRIPTION
## Summary

- Replace AI-generated unified diff content with deterministic hunk assignment — the AI now only outputs hunk IDs, and real diff content is resolved from the parsed GitHub diff
- Add `lib/diff-parse.ts` with diff parsing, context expansion, hunk indexing, and prompt formatting
- Add `AISlide`/`AIReviewGuide` intermediate types bridging AI output to resolved `Slide`/`DiffHunk` types
- Remove `lib/diff-postprocess.ts` (text replacement and context padding no longer needed)

## Motivation

The AI was generating full unified-diff `content` for each slide, which caused:
- Hallucinated code, `// ...` abbreviations, wrong line numbers
- Post-processing (`diff-postprocess.ts`) tried to fix this but drifted on position tracking
- Most output tokens were spent reproducing code we already had, slowing generation

## How it works

1. Parse the real GitHub diff into `ParsedHunk[]` with `parseUnifiedDiff`
2. Expand context to 15 lines and assign sequential IDs with `buildIndexedHunks`
3. Include a `<hunk_index>` XML section in the AI prompt listing all hunk IDs
4. AI outputs `diffHunkIds: string[]` per slide instead of `diffHunks`
5. After generation, resolve IDs to real `DiffHunk` objects deterministically
6. Unassigned hunks get a catch-all "Other changes" slide

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] Generate a review for a real PR and verify hunks show real file content
- [ ] Verify context lines are padded to 15 lines
- [ ] Verify added files have proper hunks (all `+` lines)
- [ ] Verify all hunks from the PR appear in some slide
- [ ] Verify hunk rendering (syntax highlighting, +/- markers) works as before
- [ ] Verify old saved reviews still load correctly