### PR TITLE
feat: make file paths in diff headers link to GitHub

### DIFF
--- a/components/DiffHunk.tsx
+++ b/components/DiffHunk.tsx
@@ -1,16 +1,18 @@
+import { FilePathLink } from '@/components/FilePathLink';
 import type { DiffHunk as DiffHunkType } from '@/lib/types';
 
 interface Props {
   hunk: DiffHunkType;
   showFileHeader?: boolean;
+  gitFileUrlBase?: string | null;
 }
 
-export function DiffHunk({ hunk, showFileHeader = true }: Props) {
+export function DiffHunk({ hunk, showFileHeader = true, gitFileUrlBase }: Props) {
   return (
     <div className="rounded-md border overflow-x-auto">
       {showFileHeader && (
         <div className="bg-muted/50 px-3 py-2 font-mono text-xs text-muted-foreground border-b truncate">
-          {hunk.filePath}
+          <FilePathLink filePath={hunk.filePath} gitFileUrlBase={gitFileUrlBase} />
         </div>
       )}
       {hunk.hunkHeader && (
@@ -24,12 +26,15 @@ export function DiffHunk({ hunk, showFileHeader = true }: Props) {
 interface GroupedProps {
   filePath: string;
   hunks: DiffHunkType[];
+  gitFileUrlBase?: string | null;
 }
 
-export function DiffHunkGroup({ filePath, hunks }: GroupedProps) {
+export function DiffHunkGroup({ filePath, hunks, gitFileUrlBase }: GroupedProps) {
   return (
     <div className="rounded-md border overflow-x-auto">
-      <div className="bg-muted/50 px-3 py-2 font-mono text-xs text-muted-foreground border-b truncate">{filePath}</div>
+      <div className="bg-muted/50 px-3 py-2 font-mono text-xs text-muted-foreground border-b truncate">
+        <FilePathLink filePath={filePath} gitFileUrlBase={gitFileUrlBase} />
+      </div>
       {hunks.map((hunk, i) => (
         <div key={i}>
           {i > 0 && <div className="border-t border-dashed border-muted" />}

--- a/components/FilePathLink.tsx
+++ b/components/FilePathLink.tsx
@@ -1,0 +1,22 @@
+interface Props {
+  filePath: string;
+  gitFileUrlBase?: string | null;
+  className?: string;
+}
+
+export function FilePathLink({ filePath, gitFileUrlBase, className }: Props) {
+  if (!gitFileUrlBase) {
+    return <span className={className}>{filePath}</span>;
+  }
+
+  return (
+    <button
+      type="button"
+      className={`hover:underline hover:text-foreground transition-colors text-left ${className ?? ''}`}
+      onClick={() => void window.electronAPI.openExternal(gitFileUrlBase + filePath)}
+      title={`Open on GitHub`}
+    >
+      {filePath}
+    </button>
+  );
+}

--- a/components/InteractiveDiffHunk.tsx
+++ b/components/InteractiveDiffHunk.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react';
 import { MessageSquarePlus } from 'lucide-react';
 import { parseDiffLines, type DiffLineInfo } from '@/lib/diff-lines';
 import type { DiffHunk, PendingReviewComment } from '@/lib/types';
+import { FilePathLink } from '@/components/FilePathLink';
 import {
   type CommentCallbacks,
   parseShikiLines,
@@ -15,6 +16,7 @@ interface InteractiveDiffHunkGroupProps extends CommentCallbacks {
   hunks: DiffHunk[];
   pendingComments: PendingReviewComment[];
   slideIndex: number;
+  gitFileUrlBase?: string | null;
 }
 
 interface ParsedLine {
@@ -187,6 +189,7 @@ export function InteractiveDiffHunkGroup({
   onAddComment,
   onRemoveComment,
   onEditComment,
+  gitFileUrlBase,
 }: InteractiveDiffHunkGroupProps) {
   // Count comments for this file
   const fileCommentCount = pendingComments.filter((c) => c.filePath === filePath).length;
@@ -194,7 +197,7 @@ export function InteractiveDiffHunkGroup({
   return (
     <div className="rounded-md border overflow-x-auto">
       <div className="bg-muted/50 px-3 py-2 font-mono text-xs text-muted-foreground border-b truncate flex items-center justify-between">
-        <span>{filePath}</span>
+        <FilePathLink filePath={filePath} gitFileUrlBase={gitFileUrlBase} />
         {fileCommentCount > 0 && (
           <span className="ml-2 inline-flex items-center gap-1 text-blue-400">
             <MessageSquarePlus className="h-3 w-3" />

--- a/components/SlideView.tsx
+++ b/components/SlideView.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { DiffHunkGroup } from '@/components/DiffHunk';
 import { InteractiveDiffHunkGroup } from '@/components/InteractiveDiffHunk';
 import { SplitDiffHunkGroup } from '@/components/SplitDiffHunk';
+import { FilePathLink } from '@/components/FilePathLink';
 import { Markdown } from '@/components/Markdown';
 import { MermaidDiagram } from '@/components/MermaidDiagram';
 import { slideTypeConfig } from '@/lib/constants';
@@ -21,6 +22,7 @@ interface Props {
   diffLayout: Preferences['diffLayout'];
   onDiffLayoutChange: (layout: Preferences['diffLayout']) => void;
   onAskQuestion?: () => void;
+  gitFileUrlBase?: string | null;
 }
 
 // Group hunks by filePath so we can render them under a single file header
@@ -74,6 +76,7 @@ export function SlideView({
   diffLayout,
   onDiffLayoutChange,
   onAskQuestion,
+  gitFileUrlBase,
 }: Props) {
   const typeConfig = slideTypeConfig[slide.slideType];
   const Icon = typeConfig.icon;
@@ -113,7 +116,7 @@ export function SlideView({
               <ul className="space-y-1">
                 {slide.affectedFiles.map((f) => (
                   <li key={f} className="font-mono text-xs text-muted-foreground truncate">
-                    {f}
+                    <FilePathLink filePath={f} gitFileUrlBase={gitFileUrlBase} />
                   </li>
                 ))}
               </ul>
@@ -175,6 +178,7 @@ export function SlideView({
                   pendingComments={pendingComments}
                   slideIndex={slideNumber}
                   commentCallbacks={commentCallbacks}
+                  gitFileUrlBase={gitFileUrlBase}
                 />
               );
             }
@@ -188,9 +192,10 @@ export function SlideView({
                 onAddComment={commentCallbacks.onAddComment}
                 onRemoveComment={commentCallbacks.onRemoveComment}
                 onEditComment={commentCallbacks.onEditComment}
+                gitFileUrlBase={gitFileUrlBase}
               />
             ) : (
-              <DiffHunkGroup key={filePath} filePath={filePath} hunks={hunks} />
+              <DiffHunkGroup key={filePath} filePath={filePath} hunks={hunks} gitFileUrlBase={gitFileUrlBase} />
             );
           })}
         </div>

--- a/components/SplitDiffHunk.tsx
+++ b/components/SplitDiffHunk.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react';
 import { MessageSquarePlus } from 'lucide-react';
 import { parseDiffLines, buildSplitRows, type DiffLineInfo, type SplitRow } from '@/lib/diff-lines';
 import type { DiffHunk, PendingReviewComment } from '@/lib/types';
+import { FilePathLink } from '@/components/FilePathLink';
 import {
   type CommentCallbacks,
   parseShikiLines,
@@ -16,6 +17,7 @@ interface SplitDiffHunkGroupProps {
   pendingComments?: PendingReviewComment[];
   slideIndex?: number;
   commentCallbacks?: CommentCallbacks;
+  gitFileUrlBase?: string | null;
 }
 
 function SplitDiffCell({
@@ -292,13 +294,14 @@ export function SplitDiffHunkGroup({
   pendingComments = [],
   slideIndex = 0,
   commentCallbacks,
+  gitFileUrlBase,
 }: SplitDiffHunkGroupProps) {
   const fileCommentCount = pendingComments.filter((c) => c.filePath === filePath).length;
 
   return (
     <div className="rounded-md border overflow-x-auto">
       <div className="bg-muted/50 px-3 py-2 font-mono text-xs text-muted-foreground border-b truncate flex items-center justify-between">
-        <span>{filePath}</span>
+        <FilePathLink filePath={filePath} gitFileUrlBase={gitFileUrlBase} />
         {commentCallbacks && fileCommentCount > 0 && (
           <span className="ml-2 inline-flex items-center gap-1 text-blue-400">
             <MessageSquarePlus className="h-3 w-3" />

--- a/lib/github-url.ts
+++ b/lib/github-url.ts
@@ -1,0 +1,10 @@
+/**
+ * Build a base URL for linking to files on GitHub at a specific commit.
+ * Returns null when headSha is missing (e.g. loaded reviews without SHA).
+ */
+export function buildFileUrlBase(prUrl: string, headSha?: string): string | null {
+  if (!headSha) return null;
+  const match = prUrl.match(/^(https:\/\/github\.com\/[^/]+\/[^/]+)\//);
+  if (!match) return null;
+  return `${match[1]}/blob/${headSha}/`;
+}

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -10,6 +10,7 @@ import { SubmitReviewDialog } from '../../components/SubmitReviewDialog';
 import { SettingsDialog } from '../../components/SettingsDialog';
 import { useReviewComments } from '../../lib/use-review-comments';
 import { useSlideChat } from '../../lib/use-slide-chat';
+import { buildFileUrlBase } from '../../lib/github-url';
 import type {
   ReviewGuide,
   ReviewEvent,
@@ -41,6 +42,7 @@ export function ReviewPage({ review: initialReview, onBack, onReReview }: Props)
   const [prefs, setPrefs] = useState<Preferences | null>(null);
   const { comments, addComment, removeComment, editComment, clearAll } = useReviewComments();
   const slideChat = useSlideChat(review, chatProvider, chatModel);
+  const gitFileUrlBase = useMemo(() => buildFileUrlBase(review.prUrl, review.headSha), [review.prUrl, review.headSha]);
 
   useEffect(() => {
     void window.electronAPI.loadPreferences().then((p) => {
@@ -165,6 +167,7 @@ export function ReviewPage({ review: initialReview, onBack, onReReview }: Props)
               diffLayout={diffLayout}
               onDiffLayoutChange={handleDiffLayoutChange}
               onAskQuestion={() => setChatOpen(true)}
+              gitFileUrlBase={gitFileUrlBase}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- File paths in diff headers and affected files list are now clickable links that open the file on GitHub at the reviewed commit
- Adds `buildFileUrlBase` utility that constructs `https://github.com/owner/repo/blob/<sha>/` from the PR URL and head SHA
- Adds `FilePathLink` component that calls `window.electronAPI.openExternal()` on click, falls back to plain text when SHA is unavailable

## Test plan
- [ ] Open a review — file paths in diff headers (unified, split, interactive) are clickable and open GitHub in browser
- [ ] Affected files list in left panel — clickable and opens GitHub
- [ ] When `headSha` is missing (loaded reviews) — paths render as plain text, no crash
- [ ] Hover shows underline/color change indicating clickability