### PR TITLE
feat: show active tool calls on loading screen

### DIFF
--- a/components/LoadingScreen.tsx
+++ b/components/LoadingScreen.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
-import { Brain, GitPullRequest, FileCode, Loader } from 'lucide-react';
+import { Brain, GitPullRequest, FileCode, Loader, Globe } from 'lucide-react';
 
 interface Props {
   message: string;
   streamingText?: string;
+  activeToolCall?: string | null;
 }
 
 const phases = [
@@ -13,7 +14,7 @@ const phases = [
   { icon: Loader, text: 'Generating review…' },
 ];
 
-export function LoadingScreen({ message, streamingText }: Props) {
+export function LoadingScreen({ message, streamingText, activeToolCall }: Props) {
   const preRef = useRef<HTMLPreElement>(null);
   const [phaseIndex, setPhaseIndex] = useState(0);
 
@@ -76,6 +77,13 @@ export function LoadingScreen({ message, streamingText }: Props) {
             />
           ))}
         </div>
+
+        {activeToolCall && (
+          <div className="flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs text-primary animate-pulse">
+            <Globe className="h-3 w-3" />
+            <span>{activeToolCall}</span>
+          </div>
+        )}
 
         <p className="text-xs text-muted-foreground/60">{message}</p>
 

--- a/components/OverviewSlide.tsx
+++ b/components/OverviewSlide.tsx
@@ -17,6 +17,7 @@ import {
   Users,
   Zap,
   Milestone,
+  Globe,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
@@ -216,6 +217,7 @@ function StatusBar({ status }: { status: PrStatus | null }) {
 export function OverviewSlide({ review, prStatus, onNavigate }: Props) {
   const risk = riskConfig[review.riskLevel];
   const [descOpen, setDescOpen] = useState(false);
+  const [sourcesOpen, setSourcesOpen] = useState(false);
 
   return (
     <div className="flex-1 overflow-y-auto p-8">
@@ -264,6 +266,35 @@ export function OverviewSlide({ review, prStatus, onNavigate }: Props) {
                 <div className="text-sm text-muted-foreground leading-relaxed max-h-48 overflow-y-auto rounded-md border bg-muted/20 px-4 py-3">
                   <Markdown>{review.prDescription}</Markdown>
                 </div>
+              )}
+            </section>
+          )}
+
+          {/* Web Sources — collapsible */}
+          {review.webSources && review.webSources.length > 0 && (
+            <section className="animate-fade-in-up flex flex-col gap-2" style={{ animationDelay: '180ms' }}>
+              <button
+                onClick={() => setSourcesOpen((v) => !v)}
+                className="text-xs uppercase tracking-wider text-muted-foreground flex items-center gap-1.5 hover:text-foreground transition-colors"
+              >
+                <Globe className="h-3 w-3" />
+                Web Sources ({review.webSources.length})
+                {sourcesOpen ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+              </button>
+              {sourcesOpen && (
+                <ul className="flex flex-col gap-1.5 rounded-md border bg-muted/20 px-4 py-3">
+                  {review.webSources.map((source, i) => (
+                    <li key={i}>
+                      <button
+                        onClick={() => window.electronAPI.openExternal(source.url)}
+                        className="text-sm text-primary hover:underline truncate max-w-full text-left"
+                        title={source.url}
+                      >
+                        {source.title || source.url}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
               )}
             </section>
           )}

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -106,6 +106,17 @@ const CONCISE_SUFFIX = `
 
 IMPORTANT: Be concise. Keep narrative and reviewFocus under 2 sentences each. Omit contextSnippets entirely (use empty arrays). Limit diffHunkIds to the 5 most important hunk IDs per slide. Return only raw JSON starting with { and ending with }.`;
 
+const WEB_RESEARCH_DIRECTIVE = `
+WEB RESEARCH MODE — ACTIVE
+You have access to web search and fetch tools. Before producing the review guide:
+1. Identify frameworks, libraries, and APIs referenced in the code
+2. Search for their official documentation, migration guides, or changelogs when relevant
+3. Look up best practices or known issues for patterns used in the PR
+4. Use this research to enrich your narratives with accurate technical context
+
+Include every URL you consulted in the "webSources" array. Each entry needs "url" and "title".
+`;
+
 const SIGNAL_BOOST_DIRECTIVE = `
 SIGNAL BOOST MODE — ACTIVE
 You must apply these rules on top of all other guidelines:
@@ -150,26 +161,31 @@ export async function generateReviewGuide(
   signalBoost: boolean = false,
   mcpConfigPath?: string,
   allowedTools?: string[],
-  reviewSuggestions: boolean = true
+  reviewSuggestions: boolean = true,
+  webResearch: boolean = false,
+  onToolUse?: (toolName: string) => void
 ): Promise<AIReviewGuide> {
   const provider = getProvider(providerName);
 
   async function attempt(extraInstruction: string = ''): Promise<AIReviewGuide> {
     const customInstructions = instructions?.trim();
+    const webSourcesSchema = webResearch ? `,\n  "webSources": [{ "url": string, "title": string }, ...]` : '';
     const userMessage = customInstructions
       ? contextPackage +
-        USER_SUFFIX +
+        USER_SUFFIX.replace('\n}', `${webSourcesSchema}\n}`) +
         extraInstruction +
         `\n\n<reviewer_instructions>\nThe reviewer has provided custom instructions that MUST take priority over default style guidelines.\n${customInstructions}\n</reviewer_instructions>`
-      : contextPackage + USER_SUFFIX + extraInstruction;
+      : contextPackage + USER_SUFFIX.replace('\n}', `${webSourcesSchema}\n}`) + extraInstruction;
 
     const reviewSuggestionsDirective = reviewSuggestions
       ? ''
       : `\nREVIEW SUGGESTIONS DISABLED: The reviewer has turned off review suggestions. Set "reviewFocus" to null for every slide. Do not generate any review focus content.\n`;
 
+    const webResearchDirective = webResearch ? WEB_RESEARCH_DIRECTIVE : '';
+
     const baseSystem = signalBoost
-      ? `${SIGNAL_BOOST_DIRECTIVE}\n${SYSTEM_PROMPT}${reviewSuggestionsDirective}`
-      : `${SYSTEM_PROMPT}${reviewSuggestionsDirective}`;
+      ? `${SIGNAL_BOOST_DIRECTIVE}\n${webResearchDirective}${SYSTEM_PROMPT}${reviewSuggestionsDirective}`
+      : `${webResearchDirective}${SYSTEM_PROMPT}${reviewSuggestionsDirective}`;
 
     const system = customInstructions
       ? `${baseSystem}\n\nIMPORTANT — CUSTOM REVIEWER INSTRUCTIONS:\nThe reviewer has provided the following instructions. These take precedence over the default writing style and tone guidelines above. Adapt your narrative, reviewFocus, summary, and all prose fields accordingly.\n\n<instructions>\n${customInstructions}\n</instructions>`
@@ -188,6 +204,7 @@ export async function generateReviewGuide(
       model,
       thinking,
       onChunk,
+      onToolUse,
       mcpConfigPath,
       allowedTools,
     });

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -8,6 +8,7 @@ export interface GenerateOptions {
   model: ModelId;
   thinking: boolean;
   onChunk?: (chunk: string, isThinking: boolean) => void;
+  onToolUse?: (toolName: string) => void;
   mcpConfigPath?: string;
   allowedTools?: string[];
 }

--- a/lib/providers/claude.ts
+++ b/lib/providers/claude.ts
@@ -23,7 +23,7 @@ export const claudeProvider: LLMProvider = {
     { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', quick: true },
   ],
 
-  async generate({ content, systemPrompt, model, thinking, onChunk, mcpConfigPath, allowedTools }) {
+  async generate({ content, systemPrompt, model, thinking, onChunk, onToolUse, mcpConfigPath, allowedTools }) {
     const claudePath = resolveClaudePath();
     let fullText = '';
 
@@ -44,7 +44,15 @@ export const claudeProvider: LLMProvider = {
         }
         if (outer.type !== 'stream_event') return;
         const inner = outer.event as Record<string, unknown> | undefined;
-        if (!inner || inner.type !== 'content_block_delta') return;
+        if (!inner) return;
+        if (inner.type === 'content_block_start') {
+          const block = inner.content_block as Record<string, unknown> | undefined;
+          if (block?.type === 'tool_use' && typeof block.name === 'string') {
+            onToolUse?.(block.name);
+          }
+          return;
+        }
+        if (inner.type !== 'content_block_delta') return;
         const delta = inner.delta as Record<string, unknown> | undefined;
         if (!delta) return;
         if (delta.type === 'thinking_delta' && typeof delta.thinking === 'string') {
@@ -61,10 +69,10 @@ export const claudeProvider: LLMProvider = {
     const toolArgs: string[] = [];
     if (mcpConfigPath) {
       toolArgs.push('--mcp-config', mcpConfigPath, '--strict-mcp-config');
-      if (allowedTools && allowedTools.length > 0) {
-        toolArgs.push('--allowedTools', allowedTools.join(','));
-      }
-    } else {
+    }
+    if (allowedTools && allowedTools.length > 0) {
+      toolArgs.push('--allowedTools', allowedTools.join(','));
+    } else if (!mcpConfigPath) {
       toolArgs.push('--tools', '');
     }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -49,6 +49,11 @@ export interface AISlide {
   mermaidDiagram?: string | null;
 }
 
+export interface WebSource {
+  url: string;
+  title: string;
+}
+
 export interface AIReviewGuide {
   prTitle: string;
   prDescription: string;
@@ -60,6 +65,7 @@ export interface AIReviewGuide {
   totalFilesChanged: number;
   totalLinesChanged: number;
   slides: AISlide[];
+  webSources?: WebSource[];
 }
 
 export interface ReviewGuide {
@@ -76,6 +82,7 @@ export interface ReviewGuide {
   generationDurationMs?: number;
   slides: Slide[];
   headSha?: string;
+  webSources?: WebSource[];
 }
 
 export interface PrStatus {
@@ -149,6 +156,7 @@ export interface Preferences {
   smartImports: boolean;
   reviewSuggestions: boolean;
   enableTools: boolean;
+  enableWebResearch: boolean;
   codeTheme: string;
   codeFont: string;
   claudePath: string;
@@ -180,6 +188,7 @@ export interface GenerateReviewRequest {
   signalBoost?: boolean;
   smartImports?: boolean;
   reviewSuggestions?: boolean;
+  webResearch?: boolean;
 }
 
 export interface GenerateReviewResponse {

--- a/src/main.ts
+++ b/src/main.ts
@@ -361,6 +361,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   smartImports: true,
   reviewSuggestions: true,
   enableTools: false,
+  enableWebResearch: false,
   codeTheme: 'aurora-x',
   codeFont: 'jetbrains-mono',
   claudePath: '',
@@ -617,6 +618,7 @@ ipcMain.handle(
       signalBoost,
       smartImports,
       reviewSuggestions,
+      webResearch,
     }: GenerateReviewRequest
   ) => {
     const token = getResolvedToken();
@@ -698,6 +700,8 @@ ipcMain.handle(
       } else {
         allowedTools = WEB_ONLY_TOOLS;
       }
+    } else if (webResearch && provider === 'claude') {
+      allowedTools = WEB_ONLY_TOOLS;
     }
 
     let aiResult;
@@ -713,7 +717,9 @@ ipcMain.handle(
         signalBoost ?? false,
         mcpConfigPath,
         allowedTools,
-        reviewSuggestions ?? true
+        reviewSuggestions ?? true,
+        webResearch ?? false,
+        (toolName) => _event.sender.send('review-tool-use', { toolName })
       );
     } finally {
       if (mcpConfigPath) cleanupMcpConfig(mcpConfigPath);
@@ -802,6 +808,7 @@ ipcMain.handle(
       generationDurationMs,
       slides: resolvedSlides,
       headSha: prData.headSha,
+      webSources: aiResult.webSources,
     };
 
     // Render syntax-highlighted HTML for each hunk
@@ -839,6 +846,8 @@ ipcMain.handle('send-slide-chat', async (_event, req: SendSlideChatRequest) => {
     } else {
       allowedTools = WEB_ONLY_TOOLS;
     }
+  } else if (prefs.enableWebResearch && req.provider === 'claude') {
+    allowedTools = WEB_ONLY_TOOLS;
   }
 
   try {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -115,6 +115,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [signalBoost, setSignalBoost] = useState(true);
   const [smartImports, setSmartImports] = useState(true);
   const [reviewSuggestions, setReviewSuggestions] = useState(true);
+  const [webResearch, setWebResearch] = useState(false);
   const [instructions, setInstructions] = useState('');
   const [prefsLoaded, setPrefsLoaded] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -127,6 +128,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [cliNotFound, setCliNotFound] = useState<{ provider: string } | null>(null);
   const [expandedPRs, setExpandedPRs] = useState<Set<string>>(new Set());
+  const [activeToolCall, setActiveToolCall] = useState<string | null>(null);
 
   const prGroups = useMemo(() => groupReviewsByPR(history), [history]);
 
@@ -143,6 +145,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       setSignalBoost(prefs.signalBoost);
       setSmartImports(prefs.smartImports);
       setReviewSuggestions(prefs.reviewSuggestions);
+      setWebResearch(prefs.enableWebResearch);
       setPrefsLoaded(true);
     });
   }, []);
@@ -159,17 +162,18 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
           signalBoost,
           smartImports,
           reviewSuggestions,
+          enableWebResearch: webResearch,
           ...overrides,
         });
       });
     },
-    [instructions, provider, model, thinking, signalBoost, smartImports, reviewSuggestions]
+    [instructions, provider, model, thinking, signalBoost, smartImports, reviewSuggestions, webResearch]
   );
 
   // Auto-save when toggles or model/provider change (skip initial load)
   useEffect(() => {
     if (prefsLoaded) savePrefs();
-  }, [prefsLoaded, provider, model, thinking, signalBoost, smartImports, reviewSuggestions, savePrefs]);
+  }, [prefsLoaded, provider, model, thinking, signalBoost, smartImports, reviewSuggestions, webResearch, savePrefs]);
 
   async function handleSignIn() {
     setAuthError(null);
@@ -204,16 +208,22 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
 
     setStreamingText('');
     setIsThinkingPhase(false);
+    setActiveToolCall(null);
     setLoading(true);
 
     window.electronAPI.offReviewProgress();
+    window.electronAPI.offReviewToolUse();
     window.electronAPI.onReviewProgress((chunk, isThinking) => {
       if (isThinking) {
         setIsThinkingPhase(true);
       } else {
         setIsThinkingPhase(false);
+        setActiveToolCall(null);
         setStreamingText((prev) => prev + chunk);
       }
+    });
+    window.electronAPI.onReviewToolUse((toolName) => {
+      setActiveToolCall(toolName);
     });
 
     try {
@@ -226,6 +236,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
         signalBoost,
         smartImports,
         reviewSuggestions,
+        webResearch,
       });
       void window.electronAPI.listReviews().then(setHistory);
       onReviewReady(review);
@@ -234,6 +245,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       setLoading(false);
     } finally {
       window.electronAPI.offReviewProgress();
+      window.electronAPI.offReviewToolUse();
     }
   }
 
@@ -271,6 +283,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       <LoadingScreen
         message={isThinkingPhase ? 'Thinking...' : 'Generating review guide...'}
         streamingText={streamingText}
+        activeToolCall={activeToolCall}
       />
     );
   }
@@ -498,6 +511,16 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                     checked={reviewSuggestions}
                     onToggle={() => setReviewSuggestions((r) => !r)}
                   />
+
+                  {provider === 'claude' && (
+                    <ToggleSwitch
+                      id="web-research"
+                      label="Web research"
+                      description="Search for framework docs and best practices (slower)"
+                      checked={webResearch}
+                      onToggle={() => setWebResearch((w) => !w)}
+                    />
+                  )}
 
                   {error && (
                     <Alert variant="destructive">

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -30,6 +30,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   offReviewProgress: (): void => {
     ipcRenderer.removeAllListeners('review-progress');
   },
+  onReviewToolUse: (callback: (toolName: string) => void): void => {
+    ipcRenderer.on('review-tool-use', (_event, { toolName }: { toolName: string }) => callback(toolName));
+  },
+  offReviewToolUse: (): void => {
+    ipcRenderer.removeAllListeners('review-tool-use');
+  },
   sendSlideChat: (req: SendSlideChatRequest): Promise<string> => ipcRenderer.invoke('send-slide-chat', req),
   onChatProgress: (callback: (chunk: string) => void): void => {
     ipcRenderer.on('chat-progress', (_event, { chunk }: { chunk: string }) => callback(chunk));

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -25,6 +25,8 @@ declare global {
       deleteAllReviews: () => Promise<void>;
       onReviewProgress: (callback: (chunk: string, isThinking: boolean) => void) => void;
       offReviewProgress: () => void;
+      onReviewToolUse: (callback: (toolName: string) => void) => void;
+      offReviewToolUse: () => void;
       sendSlideChat: (req: SendSlideChatRequest) => Promise<string>;
       onChatProgress: (callback: (chunk: string) => void) => void;
       offChatProgress: () => void;


### PR DESCRIPTION
## Summary
- Parse `content_block_start` tool_use events from the Claude CLI stream to detect when tools like WebSearch/WebFetch are invoked
- Thread a new `onToolUse` callback through the provider → agent → main → renderer pipeline, mirroring the existing `onChunk` pattern
- Display the active tool name as an animated pill on the loading screen; auto-clears when text generation resumes
- Add web research toggle, `WebSource` types, web sources collapsible section in overview, and supporting IPC/preferences wiring

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Generate a review with web research enabled — loading screen shows tool names (e.g. "WebSearch") during tool calls
- [ ] Tool indicator disappears when text streaming resumes
- [ ] Generate a review without web research — no tool indicators shown
- [ ] No regressions in thinking phase display or streaming text