### PR TITLE
feat: show tool call pills inline in slide chat

### DIFF
--- a/components/SlideChatSheet.tsx
+++ b/components/SlideChatSheet.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { Send, Loader2, MessageSquare } from 'lucide-react';
+import { Send, Loader2, MessageSquare, Globe } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Markdown } from '@/components/Markdown';
 import type { ChatMessage } from '@/lib/use-slide-chat';
@@ -76,6 +76,19 @@ function MessageBubble({ message }: { message: ChatMessage }) {
   return (
     <div className="flex justify-start">
       <div className="bg-muted rounded-lg px-3 py-2 max-w-[85%] text-sm">
+        {message.toolCalls && message.toolCalls.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            {message.toolCalls.map((tool) => (
+              <span
+                key={tool}
+                className={`inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 text-primary px-2 py-0.5 text-xs ${message.isStreaming ? 'animate-pulse' : ''}`}
+              >
+                <Globe className="h-3 w-3" />
+                {tool}
+              </span>
+            ))}
+          </div>
+        )}
         {message.content ? (
           <Markdown className="chat-response">{message.content}</Markdown>
         ) : message.isStreaming ? (

--- a/lib/use-slide-chat.ts
+++ b/lib/use-slide-chat.ts
@@ -6,6 +6,7 @@ export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
   isStreaming?: boolean;
+  toolCalls?: string[];
 }
 
 type MessagesMap = Map<number, ChatMessage[]>;
@@ -13,6 +14,7 @@ type MessagesMap = Map<number, ChatMessage[]>;
 type Action =
   | { type: 'SEND'; slideIndex: number; userMessage: ChatMessage; assistantMessage: ChatMessage }
   | { type: 'APPEND_CHUNK'; slideIndex: number; assistantId: string; chunk: string }
+  | { type: 'TOOL_USE'; slideIndex: number; assistantId: string; toolName: string }
   | { type: 'FINALIZE'; slideIndex: number; assistantId: string }
   | { type: 'ERROR'; slideIndex: number; assistantId: string; error: string }
   | { type: 'CLEAR'; slideIndex: number };
@@ -32,6 +34,20 @@ function reducer(state: MessagesMap, action: Action): MessagesMap {
       next.set(
         action.slideIndex,
         msgs.map((m) => (m.id === action.assistantId ? { ...m, content: m.content + action.chunk } : m))
+      );
+      return next;
+    }
+    case 'TOOL_USE': {
+      const msgs = next.get(action.slideIndex);
+      if (!msgs) return state;
+      next.set(
+        action.slideIndex,
+        msgs.map((m) => {
+          if (m.id !== action.assistantId) return m;
+          const existing = m.toolCalls ?? [];
+          if (existing.includes(action.toolName)) return m;
+          return { ...m, toolCalls: [...existing, action.toolName] };
+        })
       );
       return next;
     }
@@ -74,9 +90,17 @@ export function useSlideChat(review: ReviewGuide, provider: Provider, model: Mod
       dispatch({ type: 'APPEND_CHUNK', slideIndex: current.slideIndex, assistantId: current.assistantId, chunk });
     };
 
+    const toolHandler = (toolName: string) => {
+      const current = streamingRef.current;
+      if (!current) return;
+      dispatch({ type: 'TOOL_USE', slideIndex: current.slideIndex, assistantId: current.assistantId, toolName });
+    };
+
     window.electronAPI.onChatProgress(handler);
+    window.electronAPI.onChatToolUse(toolHandler);
     return () => {
       window.electronAPI.offChatProgress();
+      window.electronAPI.offChatToolUse();
     };
   }, []);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -861,6 +861,7 @@ ipcMain.handle('send-slide-chat', async (_event, req: SendSlideChatRequest) => {
           _event.sender.send('chat-progress', { chunk });
         }
       },
+      onToolUse: (toolName) => _event.sender.send('chat-tool-use', { toolName }),
       mcpConfigPath,
       allowedTools,
     });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -43,6 +43,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   offChatProgress: (): void => {
     ipcRenderer.removeAllListeners('chat-progress');
   },
+  onChatToolUse: (callback: (toolName: string) => void): void => {
+    ipcRenderer.on('chat-tool-use', (_event, { toolName }: { toolName: string }) => callback(toolName));
+  },
+  offChatToolUse: (): void => {
+    ipcRenderer.removeAllListeners('chat-tool-use');
+  },
   submitReview: (req: SubmitReviewRequest): Promise<{ reviewUrl: string; droppedCommentCount: number }> =>
     ipcRenderer.invoke('submit-review', req),
   checkPrFreshness: (prUrl: string, headSha: string | undefined): Promise<FreshnessResult> =>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -30,6 +30,8 @@ declare global {
       sendSlideChat: (req: SendSlideChatRequest) => Promise<string>;
       onChatProgress: (callback: (chunk: string) => void) => void;
       offChatProgress: () => void;
+      onChatToolUse: (callback: (toolName: string) => void) => void;
+      offChatToolUse: () => void;
       submitReview: (req: SubmitReviewRequest) => Promise<{ reviewUrl: string; droppedCommentCount: number }>;
       checkPrFreshness: (prUrl: string, headSha: string | undefined) => Promise<FreshnessResult>;
       loadPreferences: () => Promise<Preferences>;


### PR DESCRIPTION
## Summary
- Surface tool calls (WebSearch, WebFetch, etc.) as inline pill indicators within assistant chat messages
- Pills appear during streaming with a pulse animation and persist after completion
- Wires up `onToolUse` callback through IPC (`chat-tool-use`) from main → preload → renderer

## Test plan
- [ ] Open slide chat with web research enabled, ask a question — tool names appear as pills during streaming
- [ ] After response completes, pills remain visible without animation
- [ ] Without web research enabled, no tool pills shown
- [ ] Multiple tool calls accumulate (e.g. WebSearch + WebFetch both shown)
- [ ] No regressions in existing chat streaming or markdown rendering