### PR TITLE
fix: exclude large files from LLM prompt

### DIFF
--- a/components/SlideView.tsx
+++ b/components/SlideView.tsx
@@ -23,6 +23,7 @@ interface Props {
   onDiffLayoutChange: (layout: Preferences['diffLayout']) => void;
   onAskQuestion?: () => void;
   gitFileUrlBase?: string | null;
+  excludedFiles?: Set<string>;
 }
 
 // Group hunks by filePath so we can render them under a single file header
@@ -77,6 +78,7 @@ export function SlideView({
   onDiffLayoutChange,
   onAskQuestion,
   gitFileUrlBase,
+  excludedFiles,
 }: Props) {
   const typeConfig = slideTypeConfig[slide.slideType];
   const Icon = typeConfig.icon;
@@ -116,7 +118,11 @@ export function SlideView({
               <ul className="space-y-1">
                 {slide.affectedFiles.map((f) => (
                   <li key={f} className="font-mono text-xs text-muted-foreground truncate">
-                    <FilePathLink filePath={f} gitFileUrlBase={gitFileUrlBase} />
+                    {excludedFiles?.has(f) ? (
+                      <span className="italic">{f} (excluded)</span>
+                    ) : (
+                      <FilePathLink filePath={f} gitFileUrlBase={gitFileUrlBase} />
+                    )}
                   </li>
                 ))}
               </ul>

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -58,6 +58,7 @@ You are given:
 - <file_contents_before>: full file contents at base ref (before the PR)
 - <file_contents_after>: full file contents at head ref (after the PR)
 - <neighbor_files>: files imported by the changed files
+- <excluded_files> (if present): files that were changed but excluded from the diff because they are generated or low-value (e.g. lock files, minified assets). Mention these in the relevant slide's narrative — for example, if a lock file was excluded, note it alongside the dependency manifest changes. Include excluded files in the "affectedFiles" array of the relevant slide. Do NOT create a separate slide just for excluded files.
 
 Use file_contents_before and file_contents_after to understand the full shape of each changed file, not just the lines in the diff. Reference surrounding functions, types, and patterns when writing narratives to give the reviewer genuine codebase context.
 

--- a/lib/context-builder.ts
+++ b/lib/context-builder.ts
@@ -18,7 +18,8 @@ export function buildContextPackage(
   fileContents: Record<string, string>,
   headFileContents: Record<string, string>,
   neighborFiles: Record<string, string>,
-  hunkIndex: string
+  hunkIndex: string,
+  excludedFilesSummary?: string
 ): string {
   const totalAdditions = changedFiles.reduce((s, f) => s + f.additions, 0);
   const totalDeletions = changedFiles.reduce((s, f) => s + f.deletions, 0);
@@ -63,9 +64,12 @@ ${expandedDiff}
   let headContentsStr = headContentsSection;
   let neighborStr = neighborSection;
 
+  const excludedStr = excludedFilesSummary ?? '';
+
   function totalSize(): number {
     return (
       metaSection.length +
+      excludedStr.length +
       4 +
       diffStr.length +
       4 +
@@ -154,6 +158,7 @@ ${expandedDiff}
 
   const finalPackage =
     metaSection +
+    (excludedStr ? '\n\n' + excludedStr : '') +
     '\n\n' +
     diffStr +
     '\n\n' +

--- a/lib/file-filter.ts
+++ b/lib/file-filter.ts
@@ -1,0 +1,190 @@
+import type { ChangedFile } from './types';
+
+/**
+ * Built-in patterns for generated / low-value files.
+ * Supports: exact basename match, *.ext suffix, *.mid.* middle wildcard.
+ */
+const DEFAULT_GENERATED_PATTERNS: string[] = [
+  // Lock files
+  'poetry.lock',
+  'Pipfile.lock',
+  'package-lock.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+  'Gemfile.lock',
+  'Cargo.lock',
+  'go.sum',
+  'composer.lock',
+  'flake.lock',
+  'pdm.lock',
+  'uv.lock',
+  'bun.lockb',
+  'packages.lock.json',
+  'Podfile.lock',
+  'pubspec.lock',
+
+  // Minified assets
+  '*.min.js',
+  '*.min.css',
+
+  // Generated code
+  '*.generated.*',
+  '*.g.dart',
+  '*.freezed.dart',
+  '*.pb.go',
+  '*.pb.ts',
+
+  // Snapshots
+  '*.snap',
+];
+
+/**
+ * Files exceeding this many changed lines (additions + deletions) are
+ * auto-classified as generated, unless they have a recognized source extension.
+ */
+const LARGE_FILE_THRESHOLD = 2000;
+
+const SOURCE_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.py',
+  '.rb',
+  '.rs',
+  '.go',
+  '.java',
+  '.kt',
+  '.swift',
+  '.c',
+  '.cpp',
+  '.h',
+  '.hpp',
+  '.cs',
+  '.dart',
+  '.vue',
+  '.svelte',
+  '.astro',
+  '.php',
+  '.scala',
+  '.ex',
+  '.exs',
+  '.clj',
+  '.hs',
+  '.ml',
+  '.fs',
+  '.lua',
+  '.zig',
+  '.nim',
+  '.md',
+  '.mdx',
+  '.txt',
+  '.yml',
+  '.yaml',
+  '.toml',
+  '.json',
+  '.xml',
+  '.html',
+  '.css',
+  '.scss',
+  '.less',
+  '.sql',
+]);
+
+export interface FileClassification {
+  filename: string;
+  classification: 'generated' | 'normal';
+  reason?: string;
+}
+
+export interface FilterResult {
+  normalFiles: ChangedFile[];
+  generatedFiles: FileClassification[];
+}
+
+function matchesPattern(filename: string, pattern: string): boolean {
+  const basename = filename.split('/').pop() ?? filename;
+
+  // *.mid.* (middle wildcard like *.generated.*)
+  if (pattern.startsWith('*.') && pattern.lastIndexOf('*') > 0) {
+    const inner = pattern.slice(1, pattern.lastIndexOf('*'));
+    return basename.includes(inner);
+  }
+
+  // *.ext (suffix match)
+  if (pattern.startsWith('*')) {
+    return basename.endsWith(pattern.slice(1));
+  }
+
+  // Exact basename match
+  return basename === pattern;
+}
+
+export function classifyFiles(changedFiles: ChangedFile[], extraPatterns: string[] = []): FilterResult {
+  const patterns = [...DEFAULT_GENERATED_PATTERNS, ...extraPatterns];
+  const normalFiles: ChangedFile[] = [];
+  const generatedFiles: FileClassification[] = [];
+
+  for (const file of changedFiles) {
+    const matchedPattern = patterns.find((p) => matchesPattern(file.filename, p));
+    if (matchedPattern) {
+      generatedFiles.push({
+        filename: file.filename,
+        classification: 'generated',
+        reason: `matches pattern: ${matchedPattern}`,
+      });
+      continue;
+    }
+
+    // Size threshold for non-source files
+    const ext = '.' + (file.filename.split('.').pop() ?? '');
+    const totalChanged = file.additions + file.deletions;
+    if (totalChanged > LARGE_FILE_THRESHOLD && !SOURCE_EXTENSIONS.has(ext)) {
+      generatedFiles.push({
+        filename: file.filename,
+        classification: 'generated',
+        reason: `exceeds ${LARGE_FILE_THRESHOLD} changed lines (${totalChanged})`,
+      });
+      continue;
+    }
+
+    normalFiles.push(file);
+  }
+
+  return { normalFiles, generatedFiles };
+}
+
+export function filterDiff(rawDiff: string, generatedFilenames: Set<string>): string {
+  if (generatedFilenames.size === 0) return rawDiff;
+
+  const lines = rawDiff.split('\n');
+  const result: string[] = [];
+  let skipping = false;
+
+  for (const line of lines) {
+    if (line.startsWith('diff --git')) {
+      const match = line.match(/diff --git a\/(.*) b\/(.*)/);
+      const filePath = match?.[2] ?? match?.[1];
+      skipping = filePath ? generatedFilenames.has(filePath) : false;
+    }
+
+    if (!skipping) {
+      result.push(line);
+    }
+  }
+
+  return result.join('\n');
+}
+
+export function buildExcludedFilesSummary(generatedFiles: FileClassification[]): string {
+  if (generatedFiles.length === 0) return '';
+
+  const lines = generatedFiles.map((f) => `  - ${f.filename} (${f.reason})`);
+
+  return `<excluded_files count="${generatedFiles.length}">
+The following files were changed in this PR but excluded from the diff and file contents because they are generated or low-value for review purposes:
+${lines.join('\n')}
+</excluded_files>`;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -79,6 +79,7 @@ export interface ReviewGuide {
   totalFilesChanged: number;
   totalLinesChanged: number;
   neighborFileCount?: number;
+  excludedFiles?: string[];
   generationDurationMs?: number;
   slides: Slide[];
   headSha?: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import { setBinaryOverride, detectBinaryPath, resolveBinaryPath } from '../lib/p
 import { getProvider } from '../lib/provider';
 import { buildSlideChatSystemPrompt, buildSlideChatUserMessage } from '../lib/chat-agent';
 import { buildIndexedHunks, expandFullDiff, formatHunkIndexForPrompt, sortDiffHunks } from '../lib/diff-parse';
+import { classifyFiles, filterDiff, buildExcludedFilesSummary } from '../lib/file-filter';
 import { writeMcpConfig, cleanupMcpConfig } from '../lib/mcp-config';
 import type {
   DiffHunk,
@@ -636,14 +637,27 @@ ipcMain.handle(
       throw new Error('PR has no changed files');
     }
 
+    // Filter out generated/lock files early to avoid token budget blowup
+    const { normalFiles, generatedFiles } = classifyFiles(changedFiles);
+    const generatedFilenames = new Set(generatedFiles.map((f) => f.filename));
+    const filteredDiff = filterDiff(diff, generatedFilenames);
+    const excludedFilesSummary = buildExcludedFilesSummary(generatedFiles);
+
+    if (generatedFiles.length > 0) {
+      console.log(
+        `[main] Filtered ${generatedFiles.length} generated file(s):`,
+        generatedFiles.map((f) => f.filename)
+      );
+    }
+
     const baseRef = prData.baseBranch;
     const headRef = prData.headSha;
 
     const fileContents: Record<string, string> = {};
     const headFileContents: Record<string, string> = {};
     const concurrency = 5;
-    const filesToFetch = changedFiles.filter((f) => f.status !== 'deleted');
-    const filesToFetchBase = changedFiles.filter((f) => f.status !== 'added');
+    const filesToFetch = normalFiles.filter((f) => f.status !== 'deleted');
+    const filesToFetchBase = normalFiles.filter((f) => f.status !== 'added');
 
     for (let i = 0; i < Math.max(filesToFetch.length, filesToFetchBase.length); i += concurrency) {
       const headBatch = filesToFetch.slice(i, i + concurrency);
@@ -665,15 +679,15 @@ ipcMain.handle(
       octokit,
       owner,
       repo,
-      changedFiles.map((f) => f.filename),
+      normalFiles.map((f) => f.filename),
       allFileContents,
       baseRef,
       smartImports ? provider : undefined
     );
 
-    // Parse diff into indexed hunks and build expanded diff
-    const indexedHunks = buildIndexedHunks(diff, fileContents, headFileContents);
-    const expandedDiff = expandFullDiff(diff, fileContents, headFileContents);
+    // Parse diff into indexed hunks and build expanded diff (using filtered diff)
+    const indexedHunks = buildIndexedHunks(filteredDiff, fileContents, headFileContents);
+    const expandedDiff = expandFullDiff(filteredDiff, fileContents, headFileContents);
     const hunkIndex = formatHunkIndexForPrompt(indexedHunks);
 
     const contextPackage = buildContextPackage(
@@ -683,7 +697,8 @@ ipcMain.handle(
       fileContents,
       headFileContents,
       neighborFiles,
-      hunkIndex
+      hunkIndex,
+      excludedFilesSummary
     );
 
     console.log('[main] Generating review guide...');
@@ -805,6 +820,7 @@ ipcMain.handle(
       totalFilesChanged: changedFiles.length,
       totalLinesChanged: changedFiles.reduce((sum, f) => sum + f.additions + f.deletions, 0),
       neighborFileCount: Object.keys(neighborFiles).length,
+      excludedFiles: generatedFiles.length > 0 ? generatedFiles.map((f) => f.filename) : undefined,
       generationDurationMs,
       slides: resolvedSlides,
       headSha: prData.headSha,

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -43,6 +43,7 @@ export function ReviewPage({ review: initialReview, onBack, onReReview }: Props)
   const { comments, addComment, removeComment, editComment, clearAll } = useReviewComments();
   const slideChat = useSlideChat(review, chatProvider, chatModel);
   const gitFileUrlBase = useMemo(() => buildFileUrlBase(review.prUrl, review.headSha), [review.prUrl, review.headSha]);
+  const excludedFilesSet = useMemo(() => new Set(review.excludedFiles ?? []), [review.excludedFiles]);
 
   useEffect(() => {
     void window.electronAPI.loadPreferences().then((p) => {
@@ -168,6 +169,7 @@ export function ReviewPage({ review: initialReview, onBack, onReReview }: Props)
               onDiffLayoutChange={handleDiffLayoutChange}
               onAskQuestion={() => setChatOpen(true)}
               gitFileUrlBase={gitFileUrlBase}
+              excludedFiles={excludedFilesSet}
             />
           )}
         </div>


### PR DESCRIPTION
Testing the new "web search" feature with a PR that contained a poetry lockfile ran me into a "prompt too long" generation error. This is perhaps a wider issue: in some projects, commiting large files (such as lockfile) to version control is standard practice, yet these eat up tokens or render the prompt too large if they are naively handled.

## Summary of changes

- Filter out generated and lock files early in the review pipeline to prevent "prompt too long" errors on PRs with large files like `poetry.lock` or `package-lock.json`
- Excluded files are still acknowledged in the review narrative and shown in the affected files list
- No user configuration needed — ships with smart defaults for common lock files, minified assets, and generated code

## Problem

When a PR contains a large generated file (e.g. `poetry.lock` with thousands of changed lines), the full diff and file contents consume most of the 150K token budget. The existing truncation cascade degrades review quality by crudely slicing the diff, and in extreme cases the prompt still exceeds the limit.

## How it works

A new `lib/file-filter.ts` module classifies changed files as "generated" or "normal" using:

- **Pattern matching** against a built-in list (16 lock file types, minified assets like `*.min.js`, generated code like `*.pb.go`, snapshots)
- **Size threshold** — files with 2000+ changed lines are auto-excluded unless they have a recognized source extension

Filtering runs immediately after fetching the PR file list, **before** file content fetching and diff expansion. This avoids wasted GitHub API calls and keeps the token budget available for actual source code.

The LLM receives an `<excluded_files>` section listing what was filtered and why, with a prompt directive to mention these files in the relevant slide's narrative. Excluded files also appear in the "Affected files" list on slides, rendered as non-clickable italic text with "(excluded)".

## Risks

Careful review of [lib/file-filter.ts](https://github.com/oddur/gnosis/compare/main...reniervr:fix/filter-large-files?expand=1#diff-400a0f52b24f0eb6673ad174e506ab90983458652423190bbd37f749cc67aab0) is necessary to esnure it's not too strict.