### PR TITLE
feat: background review generation with phase indicators

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -138,9 +138,18 @@ export interface ReviewHistoryEntry {
   prUrl: string;
   author: string;
   riskLevel: 'low' | 'medium' | 'high';
+  status?: 'generating' | 'completed' | 'failed'; // undefined defaults to 'completed' (backward compat)
+  error?: string;
   model?: ModelId;
   generationDurationMs?: number;
   savedAt: string; // ISO date string
+}
+
+export interface StartReviewResult {
+  reviewId: string;
+  prTitle: string;
+  prUrl: string;
+  author: string;
 }
 
 export type Provider = 'claude' | 'gemini';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { TooltipProvider } from '../components/ui/tooltip';
 import { HomePage } from './pages/HomePage';
 import { ReviewPage } from './pages/ReviewPage';
@@ -19,11 +19,11 @@ export function App() {
   const [review, setReview] = useState<ReviewGuide | null>(null);
   const [prefillPrUrl, setPrefillPrUrl] = useState<string | undefined>();
 
-  function handleReviewReady(r: ReviewGuide) {
+  const handleReviewReady = useCallback((r: ReviewGuide) => {
     setPrefillPrUrl(undefined);
     setReview(r);
     setPage('review');
-  }
+  }, []);
 
   function handleBack() {
     setReview(null);
@@ -35,6 +35,18 @@ export function App() {
     setReview(null);
     setPage('home');
   }
+
+  // Navigate to a completed review when notification is clicked
+  useEffect(() => {
+    window.electronAPI.onReviewNavigate((reviewId) => {
+      void window.electronAPI.loadReview(reviewId).then((r) => {
+        handleReviewReady(r);
+      });
+    });
+    return () => {
+      window.electronAPI.offReviewNavigate();
+    };
+  }, [handleReviewReady]);
 
   return (
     <>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, safeStorage, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, Notification, safeStorage, shell } from 'electron';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
@@ -37,6 +37,7 @@ import type {
   ReviewHistoryEntry,
   Slide,
   SendSlideChatRequest,
+  StartReviewResult,
   SubmitReviewRequest,
   FreshnessResult,
 } from '../lib/types';
@@ -283,6 +284,9 @@ function startUpdateChecks() {
 }
 
 void app.whenReady().then(() => {
+  // Mark any stale "generating" entries from a previous crash as failed
+  cleanupStaleGeneratingEntries();
+
   applyBinaryOverrides(loadPreferences());
   createWindow();
   startUpdateChecks();
@@ -291,6 +295,14 @@ void app.whenReady().then(() => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
     if (!updateInterval) startUpdateChecks();
   });
+});
+
+app.on('before-quit', () => {
+  // Mark any in-flight generations as failed
+  for (const [id] of activeGenerations) {
+    updateHistoryEntry(id, { status: 'failed', error: 'App quit during generation' });
+  }
+  activeGenerations.clear();
 });
 
 app.on('window-all-closed', () => {
@@ -318,33 +330,62 @@ function ensureReviewsDir() {
 
 function readReviewsIndex(): ReviewHistoryEntry[] {
   try {
-    return JSON.parse(fs.readFileSync(getReviewsIndexPath(), 'utf-8')) as ReviewHistoryEntry[];
+    const entries = JSON.parse(fs.readFileSync(getReviewsIndexPath(), 'utf-8')) as ReviewHistoryEntry[];
+    // Backward compat: entries without status are completed
+    return entries.map((e) => ({ ...e, status: e.status ?? 'completed' }));
   } catch {
     return [];
   }
 }
 
-function saveReviewToHistory(review: ReviewGuide, model?: ModelId): void {
+// ── Background generation tracking ──────────────────────────────
+
+const activeGenerations = new Map<string, { abortController?: AbortController }>();
+
+function createPendingHistoryEntry(id: string, prTitle: string, prUrl: string, author: string, model?: ModelId): void {
   ensureReviewsDir();
-  const id = Date.now().toString();
-  const savedAt = new Date().toISOString();
-
-  fs.writeFileSync(path.join(getReviewsDir(), `${id}.json`), JSON.stringify(review));
-
   const entry: ReviewHistoryEntry = {
     id,
-    prTitle: review.prTitle,
-    prUrl: review.prUrl,
-    author: review.author,
-    riskLevel: review.riskLevel,
+    prTitle,
+    prUrl,
+    author,
+    riskLevel: 'low', // placeholder until generation completes
+    status: 'generating',
     model,
-    generationDurationMs: review.generationDurationMs,
-    savedAt,
+    savedAt: new Date().toISOString(),
   };
-
   const index = readReviewsIndex();
-  index.unshift(entry); // newest first
+  index.unshift(entry);
   fs.writeFileSync(getReviewsIndexPath(), JSON.stringify(index, null, 2));
+}
+
+function updateHistoryEntry(id: string, updates: Partial<ReviewHistoryEntry>): void {
+  const index = readReviewsIndex();
+  const idx = index.findIndex((e) => e.id === id);
+  if (idx === -1) return;
+  index[idx] = { ...index[idx], ...updates };
+  fs.writeFileSync(getReviewsIndexPath(), JSON.stringify(index, null, 2));
+}
+
+function broadcastToAllWindows(channel: string, ...args: unknown[]): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send(channel, ...args);
+  }
+}
+
+function cleanupStaleGeneratingEntries(): void {
+  const index = readReviewsIndex();
+  let changed = false;
+  for (const entry of index) {
+    if (entry.status === 'generating') {
+      entry.status = 'failed';
+      entry.error = 'Generation was interrupted';
+      changed = true;
+    }
+  }
+  if (changed) {
+    fs.writeFileSync(getReviewsIndexPath(), JSON.stringify(index, null, 2));
+  }
 }
 
 // ── Preferences helpers ─────────────────────────────────────────
@@ -606,29 +647,24 @@ ipcMain.handle('get-pr-status', async (_event, prUrl: string): Promise<PrStatus>
   };
 });
 
-ipcMain.handle(
-  'generate-review',
-  async (
-    _event,
-    {
-      prUrl,
-      provider,
-      model,
-      instructions,
-      thinking,
-      signalBoost,
-      smartImports,
-      reviewSuggestions,
-      webResearch,
-    }: GenerateReviewRequest
-  ) => {
+// ── Background review generation ────────────────────────────────
+
+async function runBackgroundGeneration(
+  reviewId: string,
+  request: GenerateReviewRequest,
+  prData: Awaited<ReturnType<typeof getPrMetadata>>
+): Promise<void> {
+  const { prUrl, provider, model, instructions, thinking, signalBoost, smartImports, reviewSuggestions, webResearch } =
+    request;
+
+  try {
     const token = getResolvedToken();
     const octokit = new Octokit({ auth: token ?? undefined });
-
     const { owner, repo, pullNumber } = parsePrUrl(prUrl);
 
-    const [prData, diff, changedFiles] = await Promise.all([
-      getPrMetadata(octokit, owner, repo, pullNumber),
+    broadcastToAllWindows('review-phase', { reviewId, phase: 'Fetching PR data' });
+
+    const [diff, changedFiles] = await Promise.all([
       getPrDiff(octokit, owner, repo, pullNumber),
       getChangedFiles(octokit, owner, repo, pullNumber),
     ]);
@@ -653,6 +689,8 @@ ipcMain.handle(
     const baseRef = prData.baseBranch;
     const headRef = prData.headSha;
 
+    broadcastToAllWindows('review-phase', { reviewId, phase: 'Fetching file contents' });
+
     const fileContents: Record<string, string> = {};
     const headFileContents: Record<string, string> = {};
     const concurrency = 5;
@@ -674,6 +712,8 @@ ipcMain.handle(
       ]);
     }
 
+    broadcastToAllWindows('review-phase', { reviewId, phase: 'Resolving imports' });
+
     const allFileContents = { ...fileContents, ...headFileContents };
     const neighborFiles = await getNeighborFiles(
       octokit,
@@ -684,6 +724,8 @@ ipcMain.handle(
       baseRef,
       smartImports ? provider : undefined
     );
+
+    broadcastToAllWindows('review-phase', { reviewId, phase: 'Building context' });
 
     // Parse diff into indexed hunks and build expanded diff (using filtered diff)
     const indexedHunks = buildIndexedHunks(filteredDiff, fileContents, headFileContents);
@@ -701,7 +743,9 @@ ipcMain.handle(
       excludedFilesSummary
     );
 
-    console.log('[main] Generating review guide...');
+    broadcastToAllWindows('review-phase', { reviewId, phase: 'Generating review' });
+
+    console.log(`[main] Generating review guide (${reviewId})...`);
     const generationStart = Date.now();
 
     const prefs = loadPreferences();
@@ -720,6 +764,7 @@ ipcMain.handle(
     }
 
     let aiResult;
+    let lastStreamPhase: string | null = null;
     try {
       aiResult = await generateReviewGuide(
         contextPackage,
@@ -727,14 +772,21 @@ ipcMain.handle(
         provider,
         model,
         instructions,
-        (chunk, isThinking) => _event.sender.send('review-progress', { chunk, isThinking }),
+        (chunk, isThinking) => {
+          const phase = isThinking ? 'Thinking' : 'Generating review';
+          if (phase !== lastStreamPhase) {
+            lastStreamPhase = phase;
+            broadcastToAllWindows('review-phase', { reviewId, phase });
+          }
+          broadcastToAllWindows('review-progress', { reviewId, chunk, isThinking });
+        },
         thinking ?? false,
         signalBoost ?? false,
         mcpConfigPath,
         allowedTools,
         reviewSuggestions ?? true,
         webResearch ?? false,
-        (toolName) => _event.sender.send('review-tool-use', { toolName })
+        (toolName) => broadcastToAllWindows('review-tool-use', { reviewId, toolName })
       );
     } finally {
       if (mcpConfigPath) cleanupMcpConfig(mcpConfigPath);
@@ -753,7 +805,6 @@ ipcMain.handle(
         .filter((id: string) => hunkMap.has(id) && !assignedIds.has(id))
         .map((id: string) => {
           assignedIds.add(id);
-          // Safe: filter above guarantees hunkMap.has(id)
           const h = hunkMap.get(id);
           if (!h) throw new Error(`Hunk ${id} not found in index`);
           return {
@@ -857,6 +908,8 @@ ipcMain.handle(
       webSources: aiResult.webSources,
     };
 
+    broadcastToAllWindows('review-phase', { reviewId, phase: 'Rendering' });
+
     // Render syntax-highlighted HTML for each hunk
     const codeTheme = loadPreferences().codeTheme;
     for (const slide of reviewGuide.slides) {
@@ -870,10 +923,77 @@ ipcMain.handle(
       }
     }
 
-    saveReviewToHistory(reviewGuide, model);
-    return reviewGuide;
+    // Save review JSON and update history entry to completed
+    fs.writeFileSync(path.join(getReviewsDir(), `${reviewId}.json`), JSON.stringify(reviewGuide));
+    updateHistoryEntry(reviewId, {
+      status: 'completed',
+      riskLevel: reviewGuide.riskLevel,
+      generationDurationMs,
+    });
+
+    broadcastToAllWindows('review-completed', { reviewId });
+
+    // Desktop notification
+    const notif = new Notification({
+      title: 'Review ready',
+      body: prData.title,
+    });
+    notif.on('click', () => {
+      broadcastToAllWindows('review-navigate', { reviewId });
+      const windows = BrowserWindow.getAllWindows();
+      if (windows.length > 0) {
+        const win = windows[0];
+        if (win.isMinimized()) win.restore();
+        win.focus();
+      }
+    });
+    notif.show();
+
+    console.log(`[main] Review ${reviewId} completed in ${formatMs(generationDurationMs)}`);
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+    console.error(`[main] Review ${reviewId} failed:`, errorMessage);
+
+    updateHistoryEntry(reviewId, {
+      status: 'failed',
+      error: errorMessage,
+    });
+
+    broadcastToAllWindows('review-failed', { reviewId, error: errorMessage });
+  } finally {
+    activeGenerations.delete(reviewId);
   }
-);
+}
+
+function formatMs(ms: number): string {
+  const s = Math.round(ms / 1000);
+  return s >= 60 ? `${Math.floor(s / 60)}m ${s % 60}s` : `${s}s`;
+}
+
+ipcMain.handle('start-review', async (_event, request: GenerateReviewRequest): Promise<StartReviewResult> => {
+  const token = getResolvedToken();
+  const octokit = new Octokit({ auth: token ?? undefined });
+  const { owner, repo, pullNumber } = parsePrUrl(request.prUrl);
+
+  // Fetch PR metadata (fast, single API call)
+  const prData = await getPrMetadata(octokit, owner, repo, pullNumber);
+
+  const reviewId = crypto.randomUUID();
+
+  // Create pending history entry
+  createPendingHistoryEntry(reviewId, prData.title, request.prUrl, prData.author, request.model);
+
+  // Track and fire off background generation (no await)
+  activeGenerations.set(reviewId, {});
+  void runBackgroundGeneration(reviewId, request, prData);
+
+  return {
+    reviewId,
+    prTitle: prData.title,
+    prUrl: request.prUrl,
+    author: prData.author,
+  };
+});
 
 ipcMain.handle('send-slide-chat', async (_event, req: SendSlideChatRequest) => {
   const chatProvider = getProvider(req.provider);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -10,13 +10,14 @@ import {
   Settings,
   ChevronDown,
   ChevronRight,
+  Loader2,
+  CircleX,
 } from 'lucide-react';
 import { GitHubIcon } from '../../lib/constants';
 import { Button } from '../../components/ui/button';
 import { Card, CardContent } from '../../components/ui/card';
 import { Alert, AlertDescription } from '../../components/ui/alert';
 import { Badge } from '../../components/ui/badge';
-import { LoadingScreen } from '../../components/LoadingScreen';
 import { PRPickerDialog } from '../../components/PRPickerDialog';
 import { SettingsDialog } from '../../components/SettingsDialog';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../components/ui/dialog';
@@ -55,6 +56,10 @@ const PROVIDERS = {
 const MODEL_LABELS: Record<string, string> = Object.fromEntries(
   Object.values(PROVIDERS).flatMap((p) => p.models.map((m) => [m.id, `${p.label} ${m.label}`]))
 );
+
+function getEntryStatus(entry: ReviewHistoryEntry): 'generating' | 'completed' | 'failed' {
+  return entry.status ?? 'completed';
+}
 
 // ── Reusable toggle switch ──────────────────────────────────────
 
@@ -118,9 +123,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [webResearch, setWebResearch] = useState(false);
   const [instructions, setInstructions] = useState('');
   const [prefsLoaded, setPrefsLoaded] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [streamingText, setStreamingText] = useState('');
-  const [isThinkingPhase, setIsThinkingPhase] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [authError, setAuthError] = useState<string | null>(null);
   const [history, setHistory] = useState<ReviewHistoryEntry[]>([]);
@@ -128,7 +131,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [cliNotFound, setCliNotFound] = useState<{ provider: string } | null>(null);
   const [expandedPRs, setExpandedPRs] = useState<Set<string>>(new Set());
-  const [activeToolCall, setActiveToolCall] = useState<string | null>(null);
+  const [reviewPhases, setReviewPhases] = useState<Map<string, string>>(new Map());
 
   const prGroups = useMemo(() => groupReviewsByPR(history), [history]);
 
@@ -148,6 +151,34 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       setWebResearch(prefs.enableWebResearch);
       setPrefsLoaded(true);
     });
+  }, []);
+
+  // Listen for background review phase changes, completion, and failure
+  useEffect(() => {
+    window.electronAPI.onReviewPhase((reviewId, phase) => {
+      setReviewPhases((prev) => new Map(prev).set(reviewId, phase));
+    });
+    window.electronAPI.onReviewCompleted((reviewId) => {
+      setReviewPhases((prev) => {
+        const next = new Map(prev);
+        next.delete(reviewId);
+        return next;
+      });
+      void window.electronAPI.listReviews().then(setHistory);
+    });
+    window.electronAPI.onReviewFailed((reviewId) => {
+      setReviewPhases((prev) => {
+        const next = new Map(prev);
+        next.delete(reviewId);
+        return next;
+      });
+      void window.electronAPI.listReviews().then(setHistory);
+    });
+    return () => {
+      window.electronAPI.offReviewPhase();
+      window.electronAPI.offReviewCompleted();
+      window.electronAPI.offReviewFailed();
+    };
   }, []);
 
   const savePrefs = useCallback(
@@ -195,7 +226,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
 
   async function handleSubmit(e: React.SyntheticEvent) {
     e.preventDefault();
-    if (!prUrl.trim()) return;
+    if (!prUrl.trim() || submitting) return;
 
     savePrefs();
     setError(null);
@@ -206,28 +237,10 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       return;
     }
 
-    setStreamingText('');
-    setIsThinkingPhase(false);
-    setActiveToolCall(null);
-    setLoading(true);
-
-    window.electronAPI.offReviewProgress();
-    window.electronAPI.offReviewToolUse();
-    window.electronAPI.onReviewProgress((chunk, isThinking) => {
-      if (isThinking) {
-        setIsThinkingPhase(true);
-      } else {
-        setIsThinkingPhase(false);
-        setActiveToolCall(null);
-        setStreamingText((prev) => prev + chunk);
-      }
-    });
-    window.electronAPI.onReviewToolUse((toolName) => {
-      setActiveToolCall(toolName);
-    });
+    setSubmitting(true);
 
     try {
-      const review = await window.electronAPI.generateReview({
+      await window.electronAPI.startReview({
         prUrl: prUrl.trim(),
         provider,
         model,
@@ -238,25 +251,23 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
         reviewSuggestions,
         webResearch,
       });
-      void window.electronAPI.listReviews().then(setHistory);
-      onReviewReady(review);
+      // Refresh history to show the new "generating" entry
+      const updated = await window.electronAPI.listReviews();
+      setHistory(updated);
+      setPrUrl('');
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An unexpected error occurred.');
-      setLoading(false);
+      setError(err instanceof Error ? err.message : 'Failed to start review.');
     } finally {
-      window.electronAPI.offReviewProgress();
-      window.electronAPI.offReviewToolUse();
+      setSubmitting(false);
     }
   }
 
   async function handleLoadFromHistory(id: string) {
-    setLoading(true);
     try {
       const review = await window.electronAPI.loadReview(id);
       onReviewReady(review);
     } catch {
       setError('Failed to load saved review.');
-      setLoading(false);
     }
   }
 
@@ -276,16 +287,6 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
     setProvider(p);
     setModel(PROVIDERS[p].models[0].id);
     if (p === 'gemini') setThinking(false);
-  }
-
-  if (loading) {
-    return (
-      <LoadingScreen
-        message={isThinkingPhase ? 'Thinking...' : 'Generating review guide...'}
-        streamingText={streamingText}
-        activeToolCall={activeToolCall}
-      />
-    );
   }
 
   const isAuthenticated = typeof authStatus === 'object';
@@ -528,9 +529,18 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                     </Alert>
                   )}
 
-                  <Button type="submit" className="w-full gap-2">
-                    <Play className="h-4 w-4" />
-                    Generate Review
+                  <Button type="submit" className="w-full gap-2" disabled={submitting}>
+                    {submitting ? (
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Starting…
+                      </>
+                    ) : (
+                      <>
+                        <Play className="h-4 w-4" />
+                        Generate Review
+                      </>
+                    )}
                   </Button>
                 </form>
               </CardContent>
@@ -555,9 +565,11 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                 <CardContent className="p-0 flex-1 overflow-y-auto min-h-0">
                   <ul className="divide-y">
                     {prGroups.map((group) => {
+                      const latestStatus = getEntryStatus(group.latestReview);
                       const risk = riskConfig[group.latestReview.riskLevel];
                       const hasMultiple = group.reviews.length > 1;
                       const isExpanded = expandedPRs.has(group.prUrl);
+                      const isClickable = latestStatus === 'completed';
 
                       return (
                         <li key={group.prUrl}>
@@ -585,8 +597,9 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                               )}
                             </div>
                             <button
-                              onClick={() => handleLoadFromHistory(group.latestReview.id)}
-                              className="flex-1 min-w-0 flex items-center gap-3 text-left"
+                              onClick={() => isClickable && handleLoadFromHistory(group.latestReview.id)}
+                              className={`flex-1 min-w-0 flex items-center gap-3 text-left ${!isClickable ? 'cursor-default' : ''}`}
+                              disabled={!isClickable}
                             >
                               <div className="flex-1 min-w-0 flex flex-col gap-0.5">
                                 <span className="text-sm font-medium truncate">{group.prTitle}</span>
@@ -596,11 +609,25 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                                 </span>
                               </div>
                             </button>
-                            <Badge variant="outline" className={`shrink-0 text-xs ${risk.badgeClassName}`}>
-                              {risk.label}
-                            </Badge>
+                            {latestStatus === 'generating' && (
+                              <Badge variant="outline" className="shrink-0 text-xs border-blue-500/30 text-blue-400">
+                                <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                                {reviewPhases.get(group.latestReview.id) ?? 'Starting'}
+                              </Badge>
+                            )}
+                            {latestStatus === 'failed' && (
+                              <Badge variant="outline" className="shrink-0 text-xs border-red-500/30 text-red-400">
+                                <CircleX className="h-3 w-3 mr-1" />
+                                Failed
+                              </Badge>
+                            )}
+                            {latestStatus === 'completed' && (
+                              <Badge variant="outline" className={`shrink-0 text-xs ${risk.badgeClassName}`}>
+                                {risk.label}
+                              </Badge>
+                            )}
                             <div className="shrink-0 w-7 flex items-center justify-center">
-                              {!hasMultiple && (
+                              {!hasMultiple && latestStatus !== 'generating' && (
                                 <button
                                   onClick={(e) => handleDeleteFromHistory(e, group.latestReview.id)}
                                   className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive transition-opacity px-1"
@@ -615,12 +642,15 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                           {hasMultiple && isExpanded && (
                             <ul className="border-t border-border/50">
                               {group.reviews.map((review) => {
+                                const reviewStatus = getEntryStatus(review);
                                 const reviewRisk = riskConfig[review.riskLevel];
+                                const reviewClickable = reviewStatus === 'completed';
                                 return (
                                   <li key={review.id}>
                                     <button
-                                      onClick={() => handleLoadFromHistory(review.id)}
-                                      className="w-full flex items-center gap-3 pl-10 pr-4 py-2 text-left hover:bg-muted/30 transition-colors group/review"
+                                      onClick={() => reviewClickable && handleLoadFromHistory(review.id)}
+                                      className={`w-full flex items-center gap-3 pl-10 pr-4 py-2 text-left hover:bg-muted/30 transition-colors group/review ${!reviewClickable ? 'cursor-default' : ''}`}
+                                      disabled={!reviewClickable}
                                     >
                                       <div className="flex-1 min-w-0 flex flex-col gap-0.5">
                                         <span className="text-xs text-muted-foreground truncate">
@@ -631,19 +661,40 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                                           {timeAgo(review.savedAt)}
                                         </span>
                                       </div>
-                                      <Badge
-                                        variant="outline"
-                                        className={`shrink-0 text-xs ${reviewRisk.badgeClassName}`}
-                                      >
-                                        {reviewRisk.label}
-                                      </Badge>
-                                      <button
-                                        onClick={(e) => handleDeleteFromHistory(e, review.id)}
-                                        className="shrink-0 opacity-0 group-hover/review:opacity-100 text-muted-foreground hover:text-destructive transition-opacity px-1"
-                                        aria-label="Delete"
-                                      >
-                                        <Trash2 className="h-3.5 w-3.5" />
-                                      </button>
+                                      {reviewStatus === 'generating' && (
+                                        <Badge
+                                          variant="outline"
+                                          className="shrink-0 text-xs border-blue-500/30 text-blue-400"
+                                        >
+                                          <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                                          {reviewPhases.get(review.id) ?? 'Starting'}
+                                        </Badge>
+                                      )}
+                                      {reviewStatus === 'failed' && (
+                                        <Badge
+                                          variant="outline"
+                                          className="shrink-0 text-xs border-red-500/30 text-red-400"
+                                        >
+                                          Failed
+                                        </Badge>
+                                      )}
+                                      {reviewStatus === 'completed' && (
+                                        <Badge
+                                          variant="outline"
+                                          className={`shrink-0 text-xs ${reviewRisk.badgeClassName}`}
+                                        >
+                                          {reviewRisk.label}
+                                        </Badge>
+                                      )}
+                                      {reviewStatus !== 'generating' && (
+                                        <button
+                                          onClick={(e) => handleDeleteFromHistory(e, review.id)}
+                                          className="shrink-0 opacity-0 group-hover/review:opacity-100 text-muted-foreground hover:text-destructive transition-opacity px-1"
+                                          aria-label="Delete"
+                                        >
+                                          <Trash2 className="h-3.5 w-3.5" />
+                                        </button>
+                                      )}
                                     </button>
                                   </li>
                                 );

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -7,13 +7,14 @@ import type {
   ReviewGuide,
   ReviewHistoryEntry,
   SendSlideChatRequest,
+  StartReviewResult,
   SubmitReviewRequest,
   FreshnessResult,
   UpdateInfo,
 } from '../lib/types';
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  generateReview: (req: GenerateReviewRequest): Promise<ReviewGuide> => ipcRenderer.invoke('generate-review', req),
+  startReview: (req: GenerateReviewRequest): Promise<StartReviewResult> => ipcRenderer.invoke('start-review', req),
   getConfig: (): Promise<{ githubToken: string | null }> => ipcRenderer.invoke('get-config'),
   startOAuth: (): Promise<void> => ipcRenderer.invoke('start-oauth'),
   getAuthState: (): Promise<{ authenticated: boolean; login: string | null }> => ipcRenderer.invoke('get-auth-state'),
@@ -22,19 +23,51 @@ contextBridge.exposeInMainWorld('electronAPI', {
   loadReview: (id: string): Promise<ReviewGuide> => ipcRenderer.invoke('load-review', id),
   deleteReview: (id: string): Promise<void> => ipcRenderer.invoke('delete-review', id),
   deleteAllReviews: (): Promise<void> => ipcRenderer.invoke('delete-all-reviews'),
-  onReviewProgress: (callback: (chunk: string, isThinking: boolean) => void): void => {
-    ipcRenderer.on('review-progress', (_event, { chunk, isThinking }: { chunk: string; isThinking: boolean }) =>
-      callback(chunk, isThinking)
+  onReviewProgress: (callback: (reviewId: string, chunk: string, isThinking: boolean) => void): void => {
+    ipcRenderer.on(
+      'review-progress',
+      (_event, { reviewId, chunk, isThinking }: { reviewId: string; chunk: string; isThinking: boolean }) =>
+        callback(reviewId, chunk, isThinking)
     );
   },
   offReviewProgress: (): void => {
     ipcRenderer.removeAllListeners('review-progress');
   },
-  onReviewToolUse: (callback: (toolName: string) => void): void => {
-    ipcRenderer.on('review-tool-use', (_event, { toolName }: { toolName: string }) => callback(toolName));
+  onReviewToolUse: (callback: (reviewId: string, toolName: string) => void): void => {
+    ipcRenderer.on('review-tool-use', (_event, { reviewId, toolName }: { reviewId: string; toolName: string }) =>
+      callback(reviewId, toolName)
+    );
   },
   offReviewToolUse: (): void => {
     ipcRenderer.removeAllListeners('review-tool-use');
+  },
+  onReviewPhase: (callback: (reviewId: string, phase: string) => void): void => {
+    ipcRenderer.on('review-phase', (_event, { reviewId, phase }: { reviewId: string; phase: string }) =>
+      callback(reviewId, phase)
+    );
+  },
+  offReviewPhase: (): void => {
+    ipcRenderer.removeAllListeners('review-phase');
+  },
+  onReviewCompleted: (callback: (reviewId: string) => void): void => {
+    ipcRenderer.on('review-completed', (_event, { reviewId }: { reviewId: string }) => callback(reviewId));
+  },
+  offReviewCompleted: (): void => {
+    ipcRenderer.removeAllListeners('review-completed');
+  },
+  onReviewFailed: (callback: (reviewId: string, error: string) => void): void => {
+    ipcRenderer.on('review-failed', (_event, { reviewId, error }: { reviewId: string; error: string }) =>
+      callback(reviewId, error)
+    );
+  },
+  offReviewFailed: (): void => {
+    ipcRenderer.removeAllListeners('review-failed');
+  },
+  onReviewNavigate: (callback: (reviewId: string) => void): void => {
+    ipcRenderer.on('review-navigate', (_event, { reviewId }: { reviewId: string }) => callback(reviewId));
+  },
+  offReviewNavigate: (): void => {
+    ipcRenderer.removeAllListeners('review-navigate');
   },
   sendSlideChat: (req: SendSlideChatRequest): Promise<string> => ipcRenderer.invoke('send-slide-chat', req),
   onChatProgress: (callback: (chunk: string) => void): void => {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,6 +6,7 @@ import type {
   ReviewGuide,
   ReviewHistoryEntry,
   SendSlideChatRequest,
+  StartReviewResult,
   SubmitReviewRequest,
   FreshnessResult,
   UpdateInfo,
@@ -14,7 +15,7 @@ import type {
 declare global {
   interface Window {
     electronAPI: {
-      generateReview: (req: GenerateReviewRequest) => Promise<ReviewGuide>;
+      startReview: (req: GenerateReviewRequest) => Promise<StartReviewResult>;
       getConfig: () => Promise<{ githubToken: string | null }>;
       startOAuth: () => Promise<void>;
       getAuthState: () => Promise<{ authenticated: boolean; login: string | null }>;
@@ -23,10 +24,18 @@ declare global {
       loadReview: (id: string) => Promise<ReviewGuide>;
       deleteReview: (id: string) => Promise<void>;
       deleteAllReviews: () => Promise<void>;
-      onReviewProgress: (callback: (chunk: string, isThinking: boolean) => void) => void;
+      onReviewProgress: (callback: (reviewId: string, chunk: string, isThinking: boolean) => void) => void;
       offReviewProgress: () => void;
-      onReviewToolUse: (callback: (toolName: string) => void) => void;
+      onReviewToolUse: (callback: (reviewId: string, toolName: string) => void) => void;
       offReviewToolUse: () => void;
+      onReviewPhase: (callback: (reviewId: string, phase: string) => void) => void;
+      offReviewPhase: () => void;
+      onReviewCompleted: (callback: (reviewId: string) => void) => void;
+      offReviewCompleted: () => void;
+      onReviewFailed: (callback: (reviewId: string, error: string) => void) => void;
+      offReviewFailed: () => void;
+      onReviewNavigate: (callback: (reviewId: string) => void) => void;
+      offReviewNavigate: () => void;
       sendSlideChat: (req: SendSlideChatRequest) => Promise<string>;
       onChatProgress: (callback: (chunk: string) => void) => void;
       offChatProgress: () => void;


### PR DESCRIPTION
## Summary
- Replace blocking `generate-review` IPC with fire-and-forget `start-review` that returns immediately after creating a placeholder history entry
- Review generation runs in a background async function — the UI stays interactive (form usable, history browsable, concurrent reviews supported)
- History sidebar shows spinner badge with live phase name (Fetching PR data → Fetching file contents → Resolving imports → Building context → Thinking → Generating review → Rendering)
- Desktop notification on completion; clicking it navigates to the finished review
- Stale "generating" entries cleaned up on startup and before-quit

## File changes
- `lib/types.ts` — Add `status`, `error` to `ReviewHistoryEntry`; add `StartReviewResult` type
- `src/main.ts` — Replace `generate-review` handler with `start-review` + `runBackgroundGeneration()`; add phase broadcasts, `activeGenerations` tracking, cleanup logic
- `src/preload.ts` / `src/types.d.ts` — Replace `generateReview` with `startReview`; add `onReviewPhase`, `onReviewCompleted`, `onReviewFailed`, `onReviewNavigate` events
- `src/pages/HomePage.tsx` — Remove blocking `LoadingScreen` pattern; show phase-aware spinner badges in history; form stays interactive
- `src/App.tsx` — Add `review-navigate` listener for notification click → load review

## Backward compatibility
- Existing `reviews-index.json` entries without `status` default to `'completed'`
- No data migration needed

## Test plan
- [ ] Submit a PR URL → form stays interactive, history shows spinner with phase name
- [ ] Submit a second PR while first generates → both show in history
- [ ] First review completes → notification appears, history entry gets risk badge, clickable
- [ ] Click completed review → navigates to ReviewPage
- [ ] Force-quit during generation → restart → stale entry shows as "Failed"
- [ ] Click notification → app focuses and navigates to review