### PR TITLE
fix: handle nullable reviewFocus in SlideView

### DIFF
--- a/components/SlideView.tsx
+++ b/components/SlideView.tsx
@@ -140,7 +140,7 @@ export function SlideView({
                 })}
               </ul>
             ) : (
-              <Markdown className="text-sm review-focus-content">{slide.reviewFocus}</Markdown>
+              <Markdown className="text-sm review-focus-content">{slide.reviewFocus ?? ''}</Markdown>
             )}
           </div>
 


### PR DESCRIPTION
## Summary
- Add nullish coalescing fallback for `slide.reviewFocus` when passed to `<Markdown>` component
- Fixes `TS2745` compilation error introduced in #47

## Test plan
- [ ] `npx tsc --noEmit` passes