### PR TITLE
feat: open logs and view prompt on failed reviews

### DIFF
--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react';
+import { FolderOpen } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
 import { CODE_THEMES, CODE_FONTS } from '@/lib/constants';
 import type { CodeTheme, CodeFont } from '@/lib/constants';
 
@@ -158,6 +160,18 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange }: Props) {
               className="rounded-md border border-input bg-transparent px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
             />
             <p className="text-xs text-muted-foreground">Leave empty to auto-detect</p>
+          </div>
+
+          <div className="border-t border-border pt-4">
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              onClick={() => void window.electronAPI.openLogsDirectory()}
+            >
+              <FolderOpen className="h-3.5 w-3.5" />
+              Open logs
+            </Button>
           </div>
         </div>
       </DialogContent>

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -177,7 +177,8 @@ export async function generateReviewGuide(
   allowedTools?: string[],
   reviewSuggestions: boolean = true,
   webResearch: boolean = false,
-  onToolUse?: (toolName: string) => void
+  onToolUse?: (toolName: string) => void,
+  onPromptReady?: (system: string, userMessage: string) => void
 ): Promise<AIReviewGuide> {
   const provider = getProvider(providerName);
 
@@ -212,6 +213,7 @@ export async function generateReviewGuide(
       `[agent] Input size: system=${system.length} + user=${userMessage.length} = ${totalInputChars} chars (~${estimatedTokens.toLocaleString()} tokens)`
     );
     console.log(`[agent] Calling ${providerName} (${model})...`);
+    onPromptReady?.(system, userMessage);
     const fullText = await provider.generate({
       content: userMessage,
       systemPrompt: system,

--- a/src/main.ts
+++ b/src/main.ts
@@ -233,6 +233,53 @@ function runOAuthFlow(): Promise<void> {
   });
 }
 
+// ── Persistent logging ───────────────────────────────────────────
+
+function getLogsDir() {
+  return path.join(app.getPath('userData'), 'logs');
+}
+
+function setupLogging() {
+  const logsDir = getLogsDir();
+  if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true });
+
+  const logPath = path.join(logsDir, 'main.log');
+  const prevPath = path.join(logsDir, 'main.log.1');
+
+  // Rotate previous log
+  if (fs.existsSync(logPath)) {
+    try {
+      fs.renameSync(logPath, prevPath);
+    } catch {
+      // Best-effort rotation
+    }
+  }
+
+  const stream = fs.createWriteStream(logPath, { flags: 'a' });
+  const origLog = console.log.bind(console);
+  const origWarn = console.warn.bind(console);
+  const origError = console.error.bind(console);
+
+  function write(level: string, args: unknown[]) {
+    const ts = new Date().toISOString();
+    const msg = args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+    stream.write(`${ts} [${level}] ${msg}\n`);
+  }
+
+  console.log = (...args: unknown[]) => {
+    origLog(...args);
+    write('info', args);
+  };
+  console.warn = (...args: unknown[]) => {
+    origWarn(...args);
+    write('warn', args);
+  };
+  console.error = (...args: unknown[]) => {
+    origError(...args);
+    write('error', args);
+  };
+}
+
 // ── Window ───────────────────────────────────────────────────────
 
 function createWindow() {
@@ -309,6 +356,8 @@ function setupAutoUpdater() {
 }
 
 void app.whenReady().then(() => {
+  setupLogging();
+
   // Expose packaged state to preload via env var (before creating windows)
   process.env.APP_IS_PACKAGED = app.isPackaged ? '1' : '0';
 
@@ -500,6 +549,19 @@ ipcMain.handle('open-external', (_event, url: string) => {
   }
 });
 
+ipcMain.handle('open-logs-directory', () => {
+  const logsDir = getLogsDir();
+  if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true });
+  void shell.openPath(logsDir);
+});
+
+ipcMain.handle('open-review-prompt', (_event, id: string) => {
+  const promptPath = path.join(getReviewsDir(), `${id}-prompt.md`);
+  if (fs.existsSync(promptPath)) {
+    void shell.openPath(promptPath);
+  }
+});
+
 // Backward-compat shim — renderer still calls getConfig to check if signed in
 ipcMain.handle('get-config', () => {
   const token = getResolvedToken();
@@ -579,8 +641,10 @@ ipcMain.handle('re-render-hunks', async (_event, review: ReviewGuide) => {
 });
 
 ipcMain.handle('delete-review', (_event, id: string) => {
-  const filePath = path.join(getReviewsDir(), `${id}.json`);
-  if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+  const reviewPath = path.join(getReviewsDir(), `${id}.json`);
+  const promptPath = path.join(getReviewsDir(), `${id}-prompt.md`);
+  if (fs.existsSync(reviewPath)) fs.unlinkSync(reviewPath);
+  if (fs.existsSync(promptPath)) fs.unlinkSync(promptPath);
   const index = readReviewsIndex().filter((e) => e.id !== id);
   fs.writeFileSync(getReviewsIndexPath(), JSON.stringify(index, null, 2));
 });
@@ -589,7 +653,7 @@ ipcMain.handle('delete-all-reviews', () => {
   const dir = getReviewsDir();
   if (fs.existsSync(dir)) {
     for (const file of fs.readdirSync(dir)) {
-      if (file.endsWith('.json')) fs.unlinkSync(path.join(dir, file));
+      if (file.endsWith('.json') || file.endsWith('-prompt.md')) fs.unlinkSync(path.join(dir, file));
     }
   }
   fs.writeFileSync(getReviewsIndexPath(), JSON.stringify([], null, 2));
@@ -822,7 +886,18 @@ async function runBackgroundGeneration(
         allowedTools,
         reviewSuggestions ?? true,
         webResearch ?? false,
-        (toolName) => broadcastToAllWindows('review-tool-use', { reviewId, toolName })
+        (toolName) => broadcastToAllWindows('review-tool-use', { reviewId, toolName }),
+        (system, userMessage) => {
+          try {
+            ensureReviewsDir();
+            fs.writeFileSync(
+              path.join(getReviewsDir(), `${reviewId}-prompt.md`),
+              `# System Prompt\n\n${system}\n\n# User Message\n\n${userMessage}\n`
+            );
+          } catch {
+            // Best-effort — don't fail the review if prompt save fails
+          }
+        }
       );
     } finally {
       if (mcpConfigPath) cleanupMcpConfig(mcpConfigPath);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -12,6 +12,7 @@ import {
   ChevronRight,
   Loader2,
   CircleX,
+  FileText,
 } from 'lucide-react';
 import { GitHubIcon } from '../../lib/constants';
 import { Button } from '../../components/ui/button';
@@ -630,7 +631,20 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                                 {risk.label}
                               </Badge>
                             )}
-                            <div className="shrink-0 w-7 flex items-center justify-center">
+                            <div className="shrink-0 flex items-center gap-0.5">
+                              {!hasMultiple && latestStatus === 'failed' && (
+                                <button
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    void window.electronAPI.openReviewPrompt(group.latestReview.id);
+                                  }}
+                                  className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground transition-opacity px-1"
+                                  aria-label="View prompt"
+                                  title="Open the prompt sent to the AI"
+                                >
+                                  <FileText className="h-3.5 w-3.5" />
+                                </button>
+                              )}
                               {!hasMultiple && latestStatus !== 'generating' && (
                                 <button
                                   onClick={(e) => handleDeleteFromHistory(e, group.latestReview.id)}
@@ -691,6 +705,19 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                                         >
                                           {reviewRisk.label}
                                         </Badge>
+                                      )}
+                                      {reviewStatus === 'failed' && (
+                                        <button
+                                          onClick={(e) => {
+                                            e.stopPropagation();
+                                            void window.electronAPI.openReviewPrompt(review.id);
+                                          }}
+                                          className="shrink-0 opacity-0 group-hover/review:opacity-100 text-muted-foreground hover:text-foreground transition-opacity px-1"
+                                          aria-label="View prompt"
+                                          title="Open the prompt sent to the AI"
+                                        >
+                                          <FileText className="h-3.5 w-3.5" />
+                                        </button>
                                       )}
                                       {reviewStatus !== 'generating' && (
                                         <button

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -99,6 +99,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   dismissUpdate: (version: string): Promise<void> => ipcRenderer.invoke('dismiss-update', version),
   openExternal: (url: string): Promise<void> => ipcRenderer.invoke('open-external', url),
+  openLogsDirectory: (): Promise<void> => ipcRenderer.invoke('open-logs-directory'),
+  openReviewPrompt: (id: string): Promise<void> => ipcRenderer.invoke('open-review-prompt', id),
   detectBinaryPath: (name: string): Promise<string> => ipcRenderer.invoke('detect-binary-path', name),
   checkCliInstalled: (provider: string): Promise<{ installed: boolean; resolvedPath: string }> =>
     ipcRenderer.invoke('check-cli-installed', provider),

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -52,6 +52,8 @@ declare global {
       offUpdateAvailable: () => void;
       dismissUpdate: (version: string) => Promise<void>;
       openExternal: (url: string) => Promise<void>;
+      openLogsDirectory: () => Promise<void>;
+      openReviewPrompt: (id: string) => Promise<void>;
       detectBinaryPath: (name: string) => Promise<string>;
       checkCliInstalled: (provider: string) => Promise<{ installed: boolean; resolvedPath: string }>;
       applyUpdate: () => Promise<void>;


### PR DESCRIPTION
## Summary
- **Persistent logging**: Main process console output is tee'd to `logs/main.log` in the app data directory, with simple rotation (keeps 1 previous log)
- **Open logs**: Settings dialog has an "Open logs" button that opens the logs directory in Finder/Explorer
- **Prompt saving**: The full system prompt + user message sent to the AI is saved as `{reviewId}-prompt.md` alongside the review JSON
- **View prompt on failure**: Failed review entries show a file icon button (on hover) that opens the saved prompt in the default text editor
- Prompt files are cleaned up when reviews are deleted

## Test plan
- [ ] Generate a review, check `~/Library/Application Support/Gnosis/logs/main.log` has timestamped output
- [x] Quit and relaunch — `main.log.1` exists with previous session's logs
- [ ] Settings → "Open logs" → opens logs directory
- [ ] Trigger a failed review → hover over entry → click file icon → opens prompt file
- [ ] Delete a review → prompt file is also deleted