### PR TITLE
fix: handle EPIPE crash when CLI exits early

### DIFF
--- a/lib/providers/claude.ts
+++ b/lib/providers/claude.ts
@@ -98,8 +98,12 @@ export const claudeProvider: LLMProvider = {
       env: makeClaudeEnv(thinking),
       installHint: INSTALL_HINT,
       handleExitError: (stderr: string) => {
+        const stderrTrimmed = stderr.trim();
+        if (streamError && stderrTrimmed && !stderrTrimmed.includes(streamError)) {
+          return new Error(`${streamError} — ${stderrTrimmed.slice(0, 200)}`);
+        }
         if (streamError) return new Error(streamError);
-        if (stderr) return new Error(stderr.slice(0, 300));
+        if (stderrTrimmed) return new Error(stderrTrimmed.slice(0, 300));
         return undefined;
       },
     });

--- a/lib/providers/shared.ts
+++ b/lib/providers/shared.ts
@@ -158,6 +158,9 @@ export function spawnCliStreaming(opts: StreamingCliOptions): Promise<void> {
       stderr += chunk.toString();
     });
 
+    proc.stdin.on('error', () => {
+      // Ignore EPIPE — the process may exit before stdin write completes
+    });
     proc.stdin.write(opts.stdinContent);
     proc.stdin.end();
 
@@ -214,6 +217,9 @@ export function spawnCliQuick(opts: QuickCliOptions): Promise<string> {
       stderr += chunk.toString();
     });
 
+    proc.stdin.on('error', () => {
+      // Ignore EPIPE — the process may exit before stdin write completes
+    });
     proc.stdin.write(opts.stdinContent);
     proc.stdin.end();
 


### PR DESCRIPTION
## Summary
- Handle `EPIPE` error on `proc.stdin` in both `spawnCliStreaming` and `spawnCliQuick` — prevents app crash when the CLI process exits before stdin write completes (e.g. rate limit rejection)
- Improve Claude provider error messages: when both `streamError` and `stderr` have different useful content, combine them

## Root cause
When the Claude CLI rejects a request immediately (rate limit, auth error), the process exits before `proc.stdin.write()` finishes. The unhandled `EPIPE` error on stdin bubbles up as an uncaught exception, showing a "JavaScript error occurred in the main process" dialog and crashing the app — instead of showing the actual error in the UI.

## Test plan
- [ ] Trigger a rate limit error → app should show the error in the failed badge instead of crashing
- [ ] Normal review generation still works