### PR TITLE
feat: silent auto-update with native notification

### DIFF
--- a/components/UpdateBanner.tsx
+++ b/components/UpdateBanner.tsx
@@ -1,33 +1,20 @@
 import { useState, useEffect } from 'react';
-import { ArrowUpCircle, X, Download, RotateCw, Loader2 } from 'lucide-react';
+import { ArrowUpCircle, X, Download } from 'lucide-react';
 import type { UpdateInfo } from '../lib/types';
-
-type UpdateState = 'available' | 'downloading' | 'ready' | 'error';
 
 const supportsAutoUpdate = window.electronAPI.platform !== 'linux' && window.electronAPI.isPackaged;
 
 export function UpdateBanner() {
   const [update, setUpdate] = useState<UpdateInfo | null>(null);
-  const [state, setState] = useState<UpdateState>('available');
 
   useEffect(() => {
-    window.electronAPI.onUpdateAvailable((info) => {
-      setUpdate(info);
-      setState('available');
-    });
+    window.electronAPI.onUpdateAvailable((info) => setUpdate(info));
     return () => window.electronAPI.offUpdateAvailable();
   }, []);
 
-  useEffect(() => {
-    window.electronAPI.onUpdateDownloaded(() => setState('ready'));
-    window.electronAPI.onUpdateError(() => setState('error'));
-    return () => {
-      window.electronAPI.offUpdateDownloaded();
-      window.electronAPI.offUpdateError();
-    };
-  }, []);
-
-  if (!update) return null;
+  // On platforms with auto-update, the update is handled silently via
+  // native notification + install-on-exit. No in-app banner needed.
+  if (!update || supportsAutoUpdate) return null;
 
   const { version, releaseUrl } = update;
 
@@ -36,60 +23,20 @@ export function UpdateBanner() {
     setUpdate(null);
   }
 
-  function handleUpdate() {
-    setState('downloading');
-    void window.electronAPI.applyUpdate();
-  }
-
-  function handleRestart() {
-    void window.electronAPI.restartToUpdate();
-  }
-
   return (
     <div className="flex items-center justify-between gap-3 px-4 py-2 text-sm updateBanner">
       <div className="flex items-center gap-2">
         <ArrowUpCircle className="h-4 w-4 shrink-0" />
-
-        {state === 'downloading' ? (
-          <span className="flex items-center gap-2">
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            Downloading update...
-          </span>
-        ) : state === 'ready' ? (
-          <span className="flex items-center gap-2">
-            Update ready &mdash;
-            <button
-              onClick={handleRestart}
-              className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-0.5 text-xs font-medium transition-colors updateBanner-btn"
-            >
-              <RotateCw className="h-3 w-3" />
-              Restart
-            </button>
-          </span>
-        ) : (
-          <>
-            <span>
-              Gnosis <strong>v{version}</strong> is available
-            </span>
-            {supportsAutoUpdate && state === 'available' ? (
-              <button
-                onClick={handleUpdate}
-                className="ml-1 inline-flex items-center gap-1.5 rounded-md px-2.5 py-0.5 text-xs font-medium transition-colors updateBanner-btn"
-              >
-                <Download className="h-3 w-3" />
-                Update
-              </button>
-            ) : (
-              <button
-                onClick={() => void window.electronAPI.openExternal(releaseUrl)}
-                className="ml-1 inline-flex items-center gap-1.5 rounded-md px-2.5 py-0.5 text-xs font-medium transition-colors updateBanner-btn"
-              >
-                <Download className="h-3 w-3" />
-                Download
-              </button>
-            )}
-          </>
-        )}
+        <span>
+          Gnosis <strong>v{version}</strong> is available
+        </span>
+        <button
+          onClick={() => void window.electronAPI.openExternal(releaseUrl)}
+          className="ml-1 inline-flex items-center gap-1.5 rounded-md px-2.5 py-0.5 text-xs font-medium transition-colors updateBanner-btn"
+        >
+          <Download className="h-3 w-3" />
+          Download
+        </button>
       </div>
       <button onClick={handleDismiss} className="shrink-0 transition-opacity hover:opacity-80">
         <X className="h-3.5 w-3.5" />

--- a/src/main.ts
+++ b/src/main.ts
@@ -340,19 +340,26 @@ function setupAutoUpdater() {
     autoUpdater.setFeedURL({ url: feedURL });
   } catch (err) {
     console.warn('[main] Failed to set autoUpdater feed URL:', err);
+    return;
   }
 
-  autoUpdater.on('update-downloaded', () => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('auto-update-downloaded');
-    }
+  autoUpdater.on('update-downloaded', (_event, _releaseNotes, releaseName) => {
+    const version = releaseName ? ` ${releaseName}` : '';
+    console.log(`[main] Update${version} downloaded, will install on exit`);
+    const notif = new Notification({
+      title: 'A new update is ready to install',
+      body: `Gnosis${version} has been downloaded and will be automatically installed on exit`,
+    });
+    notif.show();
   });
 
   autoUpdater.on('error', (err: Error) => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('auto-update-error', err.message);
-    }
+    console.warn('[main] Auto-updater error:', err.message);
   });
+
+  // Check for updates automatically — download happens silently
+  autoUpdater.checkForUpdates();
+  setInterval(() => autoUpdater.checkForUpdates(), 4 * 60 * 60 * 1_000);
 }
 
 void app.whenReady().then(() => {
@@ -365,12 +372,16 @@ void app.whenReady().then(() => {
   cleanupStaleGeneratingEntries();
   applyBinaryOverrides(loadPreferences());
   createWindow();
-  startUpdateChecks();
   setupAutoUpdater();
+
+  // GitHub release polling only needed on platforms without native auto-update (Linux, dev)
+  if (process.platform === 'linux' || !app.isPackaged) {
+    startUpdateChecks();
+  }
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
-    if (!updateInterval) startUpdateChecks();
+    if (!updateInterval && (process.platform === 'linux' || !app.isPackaged)) startUpdateChecks();
   });
 });
 
@@ -529,14 +540,6 @@ const WEB_ONLY_TOOLS = ['WebFetch', 'WebSearch'];
 
 ipcMain.handle('dismiss-update', (_event, version: string) => {
   dismissedUpdateVersion = version;
-});
-
-ipcMain.handle('apply-update', () => {
-  autoUpdater.checkForUpdates();
-});
-
-ipcMain.handle('restart-to-update', () => {
-  autoUpdater.quitAndInstall();
 });
 
 ipcMain.handle('open-external', (_event, url: string) => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -104,20 +104,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   detectBinaryPath: (name: string): Promise<string> => ipcRenderer.invoke('detect-binary-path', name),
   checkCliInstalled: (provider: string): Promise<{ installed: boolean; resolvedPath: string }> =>
     ipcRenderer.invoke('check-cli-installed', provider),
-  applyUpdate: (): Promise<void> => ipcRenderer.invoke('apply-update'),
-  restartToUpdate: (): Promise<void> => ipcRenderer.invoke('restart-to-update'),
-  onUpdateDownloaded: (callback: () => void): void => {
-    ipcRenderer.on('auto-update-downloaded', () => callback());
-  },
-  offUpdateDownloaded: (): void => {
-    ipcRenderer.removeAllListeners('auto-update-downloaded');
-  },
-  onUpdateError: (callback: (message: string) => void): void => {
-    ipcRenderer.on('auto-update-error', (_event, message: string) => callback(message));
-  },
-  offUpdateError: (): void => {
-    ipcRenderer.removeAllListeners('auto-update-error');
-  },
   platform: process.platform,
   isPackaged: process.env.APP_IS_PACKAGED === '1',
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -56,12 +56,6 @@ declare global {
       openReviewPrompt: (id: string) => Promise<void>;
       detectBinaryPath: (name: string) => Promise<string>;
       checkCliInstalled: (provider: string) => Promise<{ installed: boolean; resolvedPath: string }>;
-      applyUpdate: () => Promise<void>;
-      restartToUpdate: () => Promise<void>;
-      onUpdateDownloaded: (callback: () => void) => void;
-      offUpdateDownloaded: () => void;
-      onUpdateError: (callback: (message: string) => void) => void;
-      offUpdateError: () => void;
       platform: NodeJS.Platform;
       isPackaged: boolean;
     };


### PR DESCRIPTION
## Summary
- Auto-updater now checks and downloads updates automatically on startup
- Shows a native OS notification when the update is ready: "A new update is ready to install — will be automatically installed on exit"
- Update installs silently on app exit, no user interaction needed
- In-app update banner kept only for Linux (no auto-update support)
- Removed unused IPC handlers: `apply-update`, `restart-to-update`, `onUpdateDownloaded`, `onUpdateError`

## Test plan
- [ ] On macOS: launch app → if update available, native notification appears after download
- [ ] Quit app → update installs automatically
- [ ] On Linux: in-app banner still shows with "Download" link