### PR TITLE
feat: native desktop UI polish

### DIFF
--- a/src/globals.css
+++ b/src/globals.css
@@ -129,10 +129,79 @@
   * {
     @apply border-border outline-ring/50;
     scrollbar-color: oklch(0.35 0 0) transparent;
+    -webkit-tap-highlight-color: transparent;
+    -webkit-touch-callout: none;
   }
+
+  html,
+  body {
+    overscroll-behavior: none;
+    overflow: hidden;
+  }
+
   body {
     @apply bg-background text-foreground;
     font-family: var(--font-sans);
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  input,
+  textarea,
+  [contenteditable],
+  .selectable {
+    -webkit-user-select: text;
+    user-select: text;
+  }
+
+  label,
+  button,
+  [role='button'],
+  span,
+  p,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  .ui-label {
+    cursor: default;
+  }
+
+  input,
+  textarea,
+  [contenteditable] {
+    cursor: text;
+  }
+
+  a,
+  button,
+  summary,
+  [role='button'],
+  .clickable {
+    cursor: pointer;
+  }
+
+  img,
+  a,
+  svg {
+    -webkit-user-drag: none;
+  }
+
+  button:focus:not(:focus-visible),
+  [role='button']:focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  button:focus-visible,
+  [role='button']:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
   }
 }
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -574,7 +574,9 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
 
                       return (
                         <li key={group.prUrl}>
-                          <div className="flex items-center gap-1 px-4 py-3 hover:bg-muted/50 transition-colors group">
+                          <div
+                            className={`flex items-center gap-1 px-4 py-3 hover:bg-muted/50 transition-colors group ${isClickable ? 'cursor-pointer' : ''}`}
+                          >
                             <div className="shrink-0 w-5 flex items-center justify-center">
                               {hasMultiple && (
                                 <button

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -5,6 +5,20 @@ import './globals.css';
 // Apply dark mode at the HTML level so body/scrollbars also get dark variables
 document.documentElement.classList.add('dark');
 
+// ─── Native UI: disable web-like behaviors ─────────────────────
+window.addEventListener('contextmenu', (e) => e.preventDefault());
+document.addEventListener('dragover', (e) => e.preventDefault());
+document.addEventListener('drop', (e) => e.preventDefault());
+
+if (window.electronAPI.isPackaged) {
+  window.addEventListener('keydown', (e) => {
+    if (!(e.ctrlKey || e.metaKey)) return;
+    if (e.key === 'r' || e.key === 'u' || e.key === 'p') {
+      e.preventDefault();
+    }
+  });
+}
+
 const container = document.getElementById('root');
 if (!container) throw new Error('No #root element found');
 


### PR DESCRIPTION
## Summary
- Add global CSS rules to make the app feel native: disable text selection on UI chrome, set proper cursor types, prevent drag/overscroll/tap highlights, add font rendering optimizations, and custom focus-visible styles
- Disable context menu, drag-and-drop navigation, and browser shortcuts (Ctrl+R/U/P) in production builds via JS in renderer entry point
- Add cursor-pointer to full review history rows so the entire clickable area shows the pointer

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Hover over buttons, links, summaries → pointer cursor
- [ ] Hover over labels, paragraphs, headings → default cursor
- [ ] Hover over inputs/textareas → text cursor
- [ ] Text in UI chrome is not selectable; text in inputs is
- [ ] Right-click does not open browser context menu
- [ ] Dragging images/links does not start a browser drag
- [ ] No rubber-band overscroll effect
- [ ] Review history rows show pointer cursor across the full row
- [ ] In dev: Ctrl+R still refreshes (shortcut blocking only in packaged builds)