### PR TITLE
feat: silent notifications with on/off setting

### DIFF
--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -22,6 +22,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange }: Props) {
   const [codeTheme, setCodeTheme] = useState<CodeTheme>('aurora-x');
   const [codeFont, setCodeFont] = useState<CodeFont>('jetbrains-mono');
   const [enableTools, setEnableTools] = useState(false);
+  const [notifications, setNotifications] = useState(true);
   const [claudePath, setClaudePath] = useState('');
   const [geminiPath, setGeminiPath] = useState('');
   const [claudeDetected, setClaudeDetected] = useState('');
@@ -33,6 +34,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange }: Props) {
       if (prefs.codeTheme) setCodeTheme(prefs.codeTheme as CodeTheme);
       if (prefs.codeFont) setCodeFont(prefs.codeFont as CodeFont);
       setEnableTools(prefs.enableTools);
+      setNotifications(prefs.notifications);
       setClaudePath(prefs.claudePath || '');
       setGeminiPath(prefs.geminiPath || '');
     });
@@ -131,6 +133,32 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange }: Props) {
               <span
                 className={`pointer-events-none block h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
                   enableTools ? 'translate-x-4' : 'translate-x-0'
+                }`}
+              />
+            </button>
+          </div>
+
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex flex-col gap-0.5">
+              <label className="text-sm font-medium">Desktop notifications</label>
+              <p className="text-xs text-muted-foreground">Notify when a review completes</p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={notifications}
+              onClick={() => {
+                const next = !notifications;
+                setNotifications(next);
+                saveField({ notifications: next });
+              }}
+              className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+                notifications ? 'bg-primary' : 'bg-muted'
+              }`}
+            >
+              <span
+                className={`pointer-events-none block h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
+                  notifications ? 'translate-x-4' : 'translate-x-0'
                 }`}
               />
             </button>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -179,6 +179,7 @@ export interface Preferences {
   codeFont: string;
   claudePath: string;
   geminiPath: string;
+  notifications: boolean;
   diffLayout: 'unified' | 'split';
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -346,11 +346,14 @@ function setupAutoUpdater() {
   autoUpdater.on('update-downloaded', (_event, _releaseNotes, releaseName) => {
     const version = releaseName ? ` ${releaseName}` : '';
     console.log(`[main] Update${version} downloaded, will install on exit`);
-    const notif = new Notification({
-      title: 'A new update is ready to install',
-      body: `Gnosis${version} has been downloaded and will be automatically installed on exit`,
-    });
-    notif.show();
+    if (loadPreferences().notifications) {
+      const notif = new Notification({
+        title: 'A new update is ready to install',
+        body: `Gnosis${version} has been downloaded and will be automatically installed on exit`,
+        silent: true,
+      });
+      notif.show();
+    }
   });
 
   autoUpdater.on('error', (err: Error) => {
@@ -496,6 +499,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   codeFont: 'jetbrains-mono',
   claudePath: '',
   geminiPath: '',
+  notifications: true,
   diffLayout: 'unified',
 };
 
@@ -1048,20 +1052,23 @@ async function runBackgroundGeneration(
     broadcastToAllWindows('review-completed', { reviewId });
 
     // Desktop notification
-    const notif = new Notification({
-      title: 'Review ready',
-      body: prData.title,
-    });
-    notif.on('click', () => {
-      broadcastToAllWindows('review-navigate', { reviewId });
-      const windows = BrowserWindow.getAllWindows();
-      if (windows.length > 0) {
-        const win = windows[0];
-        if (win.isMinimized()) win.restore();
-        win.focus();
-      }
-    });
-    notif.show();
+    if (loadPreferences().notifications) {
+      const notif = new Notification({
+        title: 'Review ready',
+        body: prData.title,
+        silent: true,
+      });
+      notif.on('click', () => {
+        broadcastToAllWindows('review-navigate', { reviewId });
+        const windows = BrowserWindow.getAllWindows();
+        if (windows.length > 0) {
+          const win = windows[0];
+          if (win.isMinimized()) win.restore();
+          win.focus();
+        }
+      });
+      notif.show();
+    }
 
     console.log(`[main] Review ${reviewId} completed in ${formatMs(generationDurationMs)}`);
   } catch (err) {


### PR DESCRIPTION
## Summary
- Add `silent: true` to all `new Notification()` calls to prevent macOS "Apple Music media library" permission prompt
- Gate both notification sites (auto-updater + review-complete) behind a user preference
- Add "Desktop notifications" toggle in Settings (default: on)

## Test plan
- [ ] Toggle off → complete a review → no notification
- [ ] Toggle on → complete a review → silent notification (no Apple Music prompt)
- [ ] Fresh install → notifications default to on
- [ ] `npx tsc --noEmit` passes