### PR TITLE
fix: detect claude binary in ~/.local/bin

### DIFF
--- a/lib/providers/shared.ts
+++ b/lib/providers/shared.ts
@@ -50,6 +50,7 @@ export function detectBinaryPath(name: string, extraCandidates: string[] = []): 
   const candidates = [
     `/usr/local/bin/${name}`,
     `/opt/homebrew/bin/${name}`,
+    `${home}/.local/bin/${name}`,
     `${home}/.npm-global/bin/${name}`,
     `${home}/.nvm/current/bin/${name}`,
     ...extraCandidates,

--- a/src/main.ts
+++ b/src/main.ts
@@ -672,12 +672,12 @@ ipcMain.handle('save-preferences', (_event, prefs: Preferences) => {
 });
 
 ipcMain.handle('detect-binary-path', (_event, name: string) => {
-  const extra = name === 'claude' ? [`${os.homedir()}/.volta/bin/claude`] : [];
+  const extra = name === 'claude' ? [`${os.homedir()}/.volta/bin/claude`, `${os.homedir()}/.local/bin/claude`] : [];
   return detectBinaryPath(name, extra);
 });
 
 ipcMain.handle('check-cli-installed', (_event, provider: string) => {
-  const extra = provider === 'claude' ? [`${os.homedir()}/.volta/bin/claude`] : [];
+  const extra = provider === 'claude' ? [`${os.homedir()}/.volta/bin/claude`, `${os.homedir()}/.local/bin/claude`] : [];
   const resolved = resolveBinaryPath(provider, extra);
   const installed = path.isAbsolute(resolved) && fs.existsSync(resolved);
   return { installed, resolvedPath: resolved };


### PR DESCRIPTION
## Summary
- Add `~/.local/bin` to the static fallback candidates in `detectBinaryPath` (covers all binaries)
- Add `~/.local/bin/claude` to the explicit extra-candidates for claude in `detect-binary-path` and `check-cli-installed` IPC handlers

Fixes auto-detection when Claude CLI is installed at `~/.local/bin/claude`, which is common for users who install via pipx or similar tools.