### PR TITLE
feat: make review content text selectable

### DIFF
--- a/components/DiffHunk.tsx
+++ b/components/DiffHunk.tsx
@@ -18,7 +18,7 @@ export function DiffHunk({ hunk, showFileHeader = true, gitFileUrlBase }: Props)
       {hunk.hunkHeader && (
         <div className="bg-muted/30 px-3 py-1 font-mono text-xs text-muted-foreground border-b">{hunk.hunkHeader}</div>
       )}
-      <div dangerouslySetInnerHTML={{ __html: hunk.renderedHtml }} />
+      <div className="select-text" dangerouslySetInnerHTML={{ __html: hunk.renderedHtml }} />
     </div>
   );
 }
@@ -43,7 +43,7 @@ export function DiffHunkGroup({ filePath, hunks, gitFileUrlBase }: GroupedProps)
               {hunk.hunkHeader}
             </div>
           )}
-          <div dangerouslySetInnerHTML={{ __html: hunk.renderedHtml }} />
+          <div className="select-text" dangerouslySetInnerHTML={{ __html: hunk.renderedHtml }} />
         </div>
       ))}
     </div>

--- a/components/InteractiveDiffHunk.tsx
+++ b/components/InteractiveDiffHunk.tsx
@@ -54,7 +54,7 @@ function InteractiveHunk({
           `parsed=${lineInfos.length} html=${lineHtmls.length}, falling back to non-interactive`
       );
     }
-    return <div dangerouslySetInnerHTML={{ __html: hunk.renderedHtml }} />;
+    return <div className="select-text" dangerouslySetInnerHTML={{ __html: hunk.renderedHtml }} />;
   }
 
   const lines: ParsedLine[] = lineInfos.map((info, i) => ({
@@ -82,7 +82,7 @@ function InteractiveHunk({
   const hasDiff = lineInfos.some((l) => l.type !== 'context');
 
   return (
-    <pre className={shikiStyles.preClass} style={shikiStyles.preStyle}>
+    <pre className={`${shikiStyles.preClass} select-text`} style={shikiStyles.preStyle}>
       <code style={{ display: 'block', fontSize: 0, minWidth: '100%', width: 'max-content' }}>
         {lines.map((line, idx) => {
           const lineComments = pendingComments.filter(

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -1,6 +1,7 @@
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { Components } from 'react-markdown';
+import { cn } from '@/lib/utils';
 
 interface Props {
   children: string;
@@ -58,7 +59,7 @@ const components: Components = {
 
 export function Markdown({ children, className }: Props) {
   return (
-    <div className={className}>
+    <div className={cn('select-text', className)}>
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
         {children}
       </ReactMarkdown>

--- a/components/SlideView.tsx
+++ b/components/SlideView.tsx
@@ -114,7 +114,7 @@ export function SlideView({
             </Badge>
           </div>
 
-          <h2 className="text-lg font-semibold leading-tight font-display">{slide.title}</h2>
+          <h2 className="text-lg font-semibold leading-tight font-display select-text">{slide.title}</h2>
 
           <Markdown className="text-sm text-muted-foreground leading-relaxed">{slide.narrative}</Markdown>
 

--- a/components/SplitDiffHunk.tsx
+++ b/components/SplitDiffHunk.tsx
@@ -72,7 +72,7 @@ function SplitDiffCell({
         {lineNum ?? ''}
       </span>
       <span
-        className={`split-diff-code ${cellClass}`}
+        className={`split-diff-code select-text ${cellClass}`}
         style={{ paddingLeft: '0.5ch', paddingRight: '1ch', whiteSpace: 'pre' }}
       >
         {html ? <span dangerouslySetInnerHTML={{ __html: html }} /> : null}
@@ -106,7 +106,7 @@ function SplitHunk({
   }, [lineInfos, lineHtmls]);
 
   if (!splitRows) {
-    return <div dangerouslySetInnerHTML={{ __html: hunk.renderedHtml }} />;
+    return <div className="select-text" dangerouslySetInnerHTML={{ __html: hunk.renderedHtml }} />;
   }
 
   const isInteractive = !!commentCallbacks;


### PR DESCRIPTION
## Summary
- Narrative, review focus, context snippets, PR description, risk rationale, and chat responses are now selectable (via `select-text` on the `Markdown` wrapper)
- Diff code content is selectable in all three diff views (unified, interactive, split)
- Slide titles are selectable

UI elements (buttons, badges, labels, navigation) remain non-selectable from the global `body { user-select: none }`. Line number gutters and diff gutter symbols keep their existing `userSelect: 'none'` inline overrides.