### PR TITLE
feat: add review signature to posted reviews

### DIFF
--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -23,6 +23,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange }: Props) {
   const [codeFont, setCodeFont] = useState<CodeFont>('jetbrains-mono');
   const [enableTools, setEnableTools] = useState(false);
   const [notifications, setNotifications] = useState(true);
+  const [reviewSignature, setReviewSignature] = useState(true);
   const [claudePath, setClaudePath] = useState('');
   const [geminiPath, setGeminiPath] = useState('');
   const [claudeDetected, setClaudeDetected] = useState('');
@@ -35,6 +36,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange }: Props) {
       if (prefs.codeFont) setCodeFont(prefs.codeFont as CodeFont);
       setEnableTools(prefs.enableTools);
       setNotifications(prefs.notifications);
+      setReviewSignature(prefs.reviewSignature);
       setClaudePath(prefs.claudePath || '');
       setGeminiPath(prefs.geminiPath || '');
     });
@@ -159,6 +161,34 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange }: Props) {
               <span
                 className={`pointer-events-none block h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
                   notifications ? 'translate-x-4' : 'translate-x-0'
+                }`}
+              />
+            </button>
+          </div>
+
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex flex-col gap-0.5">
+              <label className="text-sm font-medium">Review signature</label>
+              <p className="text-xs text-muted-foreground">
+                Append a &ldquo;Reviewed using gnosis.to&rdquo; link to posted reviews
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={reviewSignature}
+              onClick={() => {
+                const next = !reviewSignature;
+                setReviewSignature(next);
+                saveField({ reviewSignature: next });
+              }}
+              className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
+                reviewSignature ? 'bg-primary' : 'bg-muted'
+              }`}
+            >
+              <span
+                className={`pointer-events-none block h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
+                  reviewSignature ? 'translate-x-4' : 'translate-x-0'
                 }`}
               />
             </button>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -184,6 +184,7 @@ export interface Preferences {
   notifications: boolean;
   diffLayout: 'unified' | 'split';
   includeAllFiles: boolean;
+  reviewSignature: boolean;
 }
 
 export interface SendSlideChatRequest {

--- a/src/main.ts
+++ b/src/main.ts
@@ -555,6 +555,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   notifications: true,
   diffLayout: 'unified',
   includeAllFiles: true,
+  reviewSignature: true,
 };
 
 function applyBinaryOverrides(prefs: Preferences): void {
@@ -1317,6 +1318,11 @@ ipcMain.handle('submit-review', async (_event, req: SubmitReviewRequest) => {
     const droppedText = droppedComments.map((c) => `**${c.path}:${c.line}** — ${c.body}`).join('\n\n');
     const suffix = `\n\n---\n_${droppedComments.length} comment(s) could not be posted inline (lines outside the diff range):_\n\n${droppedText}`;
     reviewBody = (reviewBody || '') + suffix;
+  }
+
+  const prefs = loadPreferences();
+  if (prefs.reviewSignature) {
+    reviewBody = (reviewBody || '') + '\n\n---\n_Reviewed using [gnosis.to](https://gnosis.to)_';
   }
 
   const { data } = await octokit.pulls.createReview({


### PR DESCRIPTION
## Summary

- Appends `---\n_Reviewed using [gnosis.to](https://gnosis.to)_` to the body of submitted GitHub reviews
- Adds a **Review signature** toggle in Settings (on by default)
- New `reviewSignature` boolean preference, defaults to `true`