### PR TITLE
feat: add Personal Access Token auth support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -137,6 +137,16 @@ async function fetchGitHubLogin(token: string): Promise<string> {
   return data.login ?? 'unknown';
 }
 
+async function validateAndFetchLogin(token: string): Promise<string> {
+  const res = await fetch('https://api.github.com/user', {
+    headers: { Authorization: `token ${token}`, 'User-Agent': 'Gnosis-App' },
+  });
+  if (!res.ok) throw new Error(`Invalid token (GitHub returned ${res.status})`);
+  const data = (await res.json()) as { login?: string };
+  if (!data.login) throw new Error('Token validated but could not retrieve GitHub username');
+  return data.login;
+}
+
 function generatePkce(): { verifier: string; challenge: string } {
   const verifier = crypto.randomBytes(32).toString('base64url');
   const challenge = crypto.createHash('sha256').update(verifier).digest('base64url');
@@ -632,6 +642,16 @@ ipcMain.handle('get-config', () => {
 
 ipcMain.handle('start-oauth', async () => {
   await runOAuthFlow();
+});
+
+ipcMain.handle('save-pat', async (_event, token: string) => {
+  const trimmed = token.trim();
+  if (!trimmed) throw new Error('Token must not be empty');
+  const login = await validateAndFetchLogin(trimmed);
+  persistToken(trimmed);
+  cachedToken = trimmed;
+  cachedLogin = login;
+  return login;
 });
 
 ipcMain.handle('get-auth-state', async () => {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -152,6 +152,10 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [livePrStates, setLivePrStates] = useState<
     Map<string, { prState: 'open' | 'merged' | 'closed'; headSha: string }>
   >(new Map());
+  const [patExpanded, setPatExpanded] = useState(false);
+  const [patToken, setPatToken] = useState('');
+  const [patError, setPatError] = useState<string | null>(null);
+  const [patConnecting, setPatConnecting] = useState(false);
 
   const prGroups = useMemo(() => groupReviewsByPR(history), [history]);
 
@@ -335,6 +339,23 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
     }
   }
 
+  async function handleConnectPat() {
+    const trimmed = patToken.trim();
+    if (!trimmed || patConnecting) return;
+    setPatError(null);
+    setPatConnecting(true);
+    try {
+      const login = await window.electronAPI.savePat(trimmed);
+      setAuthStatus({ login });
+      setPatToken('');
+      setPatExpanded(false);
+    } catch (err) {
+      setPatError(err instanceof Error ? err.message : 'Failed to connect token.');
+    } finally {
+      setPatConnecting(false);
+    }
+  }
+
   async function handleSignOut() {
     await window.electronAPI.signOut();
     setAuthStatus('unauthenticated');
@@ -457,6 +478,60 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                   <GitHubIcon className="h-4 w-4" />
                   Sign in with GitHub
                 </Button>
+                <div className="w-full border-t" />
+                <button
+                  type="button"
+                  className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  onClick={() => {
+                    setPatExpanded((v) => !v);
+                    setPatError(null);
+                  }}
+                >
+                  {patExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+                  Use a Personal Access Token
+                </button>
+                {patExpanded && (
+                  <div className="w-full flex flex-col gap-2 text-left">
+                    <p className="text-xs text-muted-foreground">
+                      Create a token with <code className="font-mono">repo</code> scope at{' '}
+                      <button
+                        type="button"
+                        className="underline hover:text-foreground"
+                        onClick={() =>
+                          void window.electronAPI.openExternal(
+                            'https://github.com/settings/tokens/new?scopes=repo&description=Gnosis'
+                          )
+                        }
+                      >
+                        github.com/settings/tokens
+                      </button>
+                      , then paste it below.
+                    </p>
+                    <input
+                      type="password"
+                      placeholder="ghp_…"
+                      value={patToken}
+                      onChange={(e) => setPatToken(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') void handleConnectPat();
+                      }}
+                      className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    />
+                    {patError && (
+                      <Alert variant="destructive">
+                        <AlertDescription>{patError}</AlertDescription>
+                      </Alert>
+                    )}
+                    <Button
+                      onClick={() => void handleConnectPat()}
+                      disabled={!patToken.trim() || patConnecting}
+                      className="w-full"
+                      size="sm"
+                    >
+                      {patConnecting ? 'Connecting…' : 'Connect'}
+                    </Button>
+                  </div>
+                )}
               </CardContent>
             </Card>
           </>

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -21,6 +21,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   startOAuth: (): Promise<void> => ipcRenderer.invoke('start-oauth'),
   getAuthState: (): Promise<{ authenticated: boolean; login: string | null }> => ipcRenderer.invoke('get-auth-state'),
   signOut: (): Promise<void> => ipcRenderer.invoke('sign-out'),
+  savePat: (token: string): Promise<string> => ipcRenderer.invoke('save-pat', token),
   listReviews: (): Promise<ReviewHistoryEntry[]> => ipcRenderer.invoke('list-reviews'),
   loadReview: (id: string): Promise<ReviewGuide> => ipcRenderer.invoke('load-review', id),
   deleteReview: (id: string): Promise<void> => ipcRenderer.invoke('delete-review', id),

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -22,6 +22,7 @@ declare global {
       startOAuth: () => Promise<void>;
       getAuthState: () => Promise<{ authenticated: boolean; login: string | null }>;
       signOut: () => Promise<void>;
+      savePat: (token: string) => Promise<string>;
       listReviews: () => Promise<ReviewHistoryEntry[]>;
       loadReview: (id: string) => Promise<ReviewGuide>;
       deleteReview: (id: string) => Promise<void>;


### PR DESCRIPTION
## Summary

- Adds a collapsible PAT section below the OAuth button on the sign-in screen
- New `save-pat` IPC handler validates the token against the GitHub API and stores it via `safeStorage` (same path as OAuth tokens)
- Sign-out and token loading are unchanged — PATs go through the same `persistToken`/`loadStoredToken`/`deleteStoredToken` helpers

## Test plan

- [ ] No token stored: sign-in screen shows OAuth button + "Use a Personal Access Token" disclosure
- [ ] Expand PAT section → paste a valid `ghp_…` token → Connect → transitions to authenticated state with correct GitHub login
- [ ] Paste an invalid token → inline error message shown
- [ ] Sign out → token deleted, back to unauthenticated card
- [ ] Restart app with a stored PAT → loads as authenticated