### PR TITLE
fix: update banner improvements

### DIFF
--- a/components/UpdateBanner.tsx
+++ b/components/UpdateBanner.tsx
@@ -6,13 +6,44 @@ const supportsAutoUpdate = window.electronAPI.platform !== 'linux' && window.ele
 
 export function UpdateBanner() {
   const [update, setUpdate] = useState<UpdateInfo | null>(null);
+  const [readyVersion, setReadyVersion] = useState<string | null>(null);
 
   useEffect(() => {
     window.electronAPI.onUpdateAvailable((info) => setUpdate(info));
-    return () => window.electronAPI.offUpdateAvailable();
+    window.electronAPI.onUpdateReady((version) => setReadyVersion(version));
+    return () => {
+      window.electronAPI.offUpdateAvailable();
+      window.electronAPI.offUpdateReady();
+    };
   }, []);
 
-  // Banner is only for Linux — macOS/Windows use native Squirrel auto-update.
+  // macOS/Windows: show banner when update has been downloaded and is ready to install
+  if (supportsAutoUpdate && readyVersion !== null) {
+    return (
+      <div className="flex items-center justify-between gap-3 px-4 py-2 text-sm updateBanner">
+        <div className="flex items-center gap-2">
+          <ArrowUpCircle className="h-4 w-4 shrink-0" />
+          <span>
+            Gnosis
+            {readyVersion ? (
+              <>
+                {' '}
+                <strong>v{readyVersion}</strong>
+              </>
+            ) : (
+              ''
+            )}{' '}
+            will install on next restart
+          </span>
+        </div>
+        <button onClick={() => setReadyVersion(null)} className="shrink-0 transition-opacity hover:opacity-80">
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    );
+  }
+
+  // Linux: show banner when a new version is available for manual download
   if (!update || supportsAutoUpdate) return null;
 
   const { version, releaseUrl } = update;

--- a/src/main.ts
+++ b/src/main.ts
@@ -369,15 +369,19 @@ function setupAutoUpdater() {
   }
 
   autoUpdater.on('update-downloaded', (_event, _releaseNotes, releaseName) => {
-    const version = releaseName ? ` ${releaseName}` : '';
-    console.log(`[main] Update${version} downloaded, will install on exit`);
+    const version = releaseName.replace(/^v/, '');
+    const label = version ? ` ${version}` : '';
+    console.log(`[main] Update${label} downloaded, will install on exit`);
     if (loadPreferences().notifications) {
       const notif = new Notification({
         title: 'A new update is ready to install',
-        body: `Gnosis${version} has been downloaded and will be automatically installed on exit`,
+        body: `Gnosis${label} has been downloaded and will be automatically installed on exit`,
         silent: true,
       });
       notif.show();
+    }
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('update-ready', version);
     }
   });
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -107,6 +107,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   offUpdateAvailable: (): void => {
     ipcRenderer.removeAllListeners('update-available');
   },
+  onUpdateReady: (callback: (version: string) => void): void => {
+    ipcRenderer.on('update-ready', (_event, version: string) => callback(version));
+  },
+  offUpdateReady: (): void => {
+    ipcRenderer.removeAllListeners('update-ready');
+  },
   dismissUpdate: (version: string): Promise<void> => ipcRenderer.invoke('dismiss-update', version),
   openExternal: (url: string): Promise<void> => ipcRenderer.invoke('open-external', url),
   openLogsDirectory: (): Promise<void> => ipcRenderer.invoke('open-logs-directory'),

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -54,6 +54,8 @@ declare global {
       getPrStatus: (prUrl: string) => Promise<PrStatus>;
       onUpdateAvailable: (callback: (info: UpdateInfo) => void) => void;
       offUpdateAvailable: () => void;
+      onUpdateReady: (callback: (version: string) => void) => void;
+      offUpdateReady: () => void;
       dismissUpdate: (version: string) => Promise<void>;
       openExternal: (url: string) => Promise<void>;
       openLogsDirectory: () => Promise<void>;


### PR DESCRIPTION
## Summary

- GitHub release polling was running in dev mode (\`npm start\`), causing the update banner to appear on Mac during development — now gated on \`process.platform === 'linux'\` only
- macOS/Windows: when Squirrel finishes downloading an update, an in-app banner now appears: "Gnosis **vX.X.X** will install on next restart" (dismissible), alongside the existing OS notification

## Test plan

- [ ] \`npm start\` on Mac — update banner no longer appears
- [ ] Linux packaged build — update banner appears when a new release is available with Download button
- [ ] macOS packaged build — after Squirrel downloads an update, in-app banner appears with restart message