### PR TITLE
feat: move review signature toggle to submit dialog

### DIFF
--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -23,7 +23,6 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange }: Props) {
   const [codeFont, setCodeFont] = useState<CodeFont>('jetbrains-mono');
   const [enableTools, setEnableTools] = useState(false);
   const [notifications, setNotifications] = useState(true);
-  const [reviewSignature, setReviewSignature] = useState(true);
   const [claudePath, setClaudePath] = useState('');
   const [geminiPath, setGeminiPath] = useState('');
   const [claudeDetected, setClaudeDetected] = useState('');
@@ -36,7 +35,6 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange }: Props) {
       if (prefs.codeFont) setCodeFont(prefs.codeFont as CodeFont);
       setEnableTools(prefs.enableTools);
       setNotifications(prefs.notifications);
-      setReviewSignature(prefs.reviewSignature);
       setClaudePath(prefs.claudePath || '');
       setGeminiPath(prefs.geminiPath || '');
     });
@@ -161,34 +159,6 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange }: Props) {
               <span
                 className={`pointer-events-none block h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
                   notifications ? 'translate-x-4' : 'translate-x-0'
-                }`}
-              />
-            </button>
-          </div>
-
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex flex-col gap-0.5">
-              <label className="text-sm font-medium">Review signature</label>
-              <p className="text-xs text-muted-foreground">
-                Append a &ldquo;Reviewed using gnosis.to&rdquo; link to posted reviews
-              </p>
-            </div>
-            <button
-              type="button"
-              role="switch"
-              aria-checked={reviewSignature}
-              onClick={() => {
-                const next = !reviewSignature;
-                setReviewSignature(next);
-                saveField({ reviewSignature: next });
-              }}
-              className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${
-                reviewSignature ? 'bg-primary' : 'bg-muted'
-              }`}
-            >
-              <span
-                className={`pointer-events-none block h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
-                  reviewSignature ? 'translate-x-4' : 'translate-x-0'
                 }`}
               />
             </button>

--- a/components/SubmitReviewDialog.tsx
+++ b/components/SubmitReviewDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { AlertTriangle, Check, ExternalLink, MessageSquare, ShieldCheck, ShieldX } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -28,6 +28,14 @@ export function SubmitReviewDialog({ open, onOpenChange, comments, headSha, isOw
   const [successUrl, setSuccessUrl] = useState<string | null>(null);
   const [droppedCount, setDroppedCount] = useState(0);
   const [submittedCount, setSubmittedCount] = useState(0);
+  const [reviewSignature, setReviewSignature] = useState(true);
+
+  useEffect(() => {
+    if (!open) return;
+    void window.electronAPI.loadPreferences().then((prefs) => {
+      setReviewSignature(prefs.reviewSignature);
+    });
+  }, [open]);
 
   // Group comments by file for the summary
   const fileGroups = new Map<string, PendingReviewComment[]>();
@@ -154,14 +162,30 @@ export function SubmitReviewDialog({ open, onOpenChange, comments, headSha, isOw
         )}
 
         {/* Review body */}
-        <div>
-          <label className="text-xs text-muted-foreground mb-1 block">Review summary (optional)</label>
-          <textarea
-            value={body}
-            onChange={(e) => setBody(e.target.value)}
-            placeholder="Overall feedback..."
-            className="w-full min-h-[80px] bg-transparent text-sm resize-y border rounded p-2 focus:outline-none focus:ring-1 focus:ring-ring"
-          />
+        <div className="flex flex-col gap-2">
+          <div>
+            <label className="text-xs text-muted-foreground mb-1 block">Review summary (optional)</label>
+            <textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="Overall feedback..."
+              className="w-full min-h-[80px] bg-transparent text-sm resize-y border rounded p-2 focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+          </div>
+          <label className="flex items-center gap-2 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={reviewSignature}
+              onChange={(e) => {
+                setReviewSignature(e.target.checked);
+                void window.electronAPI
+                  .loadPreferences()
+                  .then((prefs) => window.electronAPI.savePreferences({ ...prefs, reviewSignature: e.target.checked }));
+              }}
+              className="rounded border"
+            />
+            <span className="text-xs text-muted-foreground">Add &ldquo;Reviewed using gnosis.to&rdquo; signature</span>
+          </label>
         </div>
 
         {error && <p className="text-sm text-destructive">{error}</p>}


### PR DESCRIPTION
## Summary

- Removes the "Review signature" toggle from Settings
- Adds a checkbox directly on the Submit Review dialog below the summary textarea
- Defaults to `true`, persists the preference (same storage key) so it's remembered across submits

## Test plan

- [ ] Submit dialog shows "Add 'Reviewed using gnosis.to' signature" checkbox, checked by default
- [ ] Unchecking and submitting — no signature appended to review
- [ ] Preference is remembered on next open
- [ ] Settings dialog no longer shows the toggle