### PR TITLE
feat: newspaper-style homepage experiment

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -169,6 +169,8 @@ export interface ReviewHistoryEntry {
   unread?: boolean;
   prState?: 'open' | 'merged' | 'closed';
   prHeadSha?: string;
+  /** First ~200 chars of the AI summary, used as article lede on the homepage. */
+  summary?: string;
 }
 
 export interface StartReviewResult {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,9 @@ export function App() {
       >
         Skip to content
       </a>
-      <UpdateBanner />
+      {/* Update banner shows on the review page. On the home page,
+          the newspaper "Extra" notice handles it instead. */}
+      {page !== 'home' && <UpdateBanner />}
       <div id="main-content">
         {page === 'home' && <HomePage onReviewReady={handleReviewReady} prefillPrUrl={prefillPrUrl} />}
         {page === 'review' && review && (

--- a/src/globals.css
+++ b/src/globals.css
@@ -1269,11 +1269,6 @@ ul.review-focus-content > li::before {
   cursor: pointer;
 }
 
-.newspaper-article *,
-.newspaper-article--featured * {
-  cursor: pointer;
-}
-
 /* Remove right border on last column items */
 .newspaper-grid > .newspaper-article:nth-child(3n) {
   border-right: none;

--- a/src/globals.css
+++ b/src/globals.css
@@ -1290,22 +1290,33 @@ ul.review-focus-content > li::before {
 }
 
 /* First article spans full width as a secondary lead.
-   Uses a two-column layout where the headline spans both columns
-   and the lede + meta sit side by side beneath it. */
+   Two-column layout: headline + meta on the left, lede on the right.
+   The grid creates a proper broadsheet feature-story feel. */
 .newspaper-article--featured {
   grid-column: 1 / -1;
   border-right: none;
   border-bottom: 1px solid oklch(0.5 0.012 65 / 14%);
   padding: 1.5rem 1.5rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem 2.5rem;
 }
 
-.newspaper-article--featured > * {
-  max-width: 50ch;
+/* Headline column spans left; lede column sits right */
+.newspaper-article--featured .newspaper-featured-left,
+.newspaper-article--featured .newspaper-featured-right {
+  min-width: 0;
 }
 
-@media (max-width: 640px) {
-  .newspaper-article--featured > * {
-    max-width: none;
+/* Anything not in the two columns spans full width below */
+.newspaper-article--featured .newspaper-featured-footer {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 768px) {
+  .newspaper-article--featured {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
   }
 }
 
@@ -1361,9 +1372,8 @@ ul.review-focus-content > li::before {
   letter-spacing: 0.01em;
 }
 
-/* Article lede — the AI summary excerpt. Full text in featured
-   articles, clamped to 3 lines in the regular grid to keep
-   column heights even. */
+/* Article lede — the AI summary excerpt. No truncation — like a
+   real newspaper, show the full summary text. */
 .newspaper-article-lede {
   font-family: var(--font-serif);
   font-size: 0.9375rem;
@@ -1372,17 +1382,6 @@ ul.review-focus-content > li::before {
   color: var(--muted-foreground);
   font-variation-settings: 'opsz' 14;
   margin-top: 0.5rem;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-/* Featured articles show the full summary */
-.newspaper-article--featured .newspaper-article-lede {
-  display: block;
-  -webkit-line-clamp: unset;
-  overflow: visible;
 }
 
 /* ─ Newsroom section (compose) ─ Rule-above separates it from

--- a/src/globals.css
+++ b/src/globals.css
@@ -958,6 +958,438 @@ ul.review-focus-content > li::before {
   transition: width 600ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+/* ─── Newspaper layout ───────────────────────────────────────
+   Broadsheet-inspired layout for the homepage. Classic newspaper
+   typography: centered masthead, Oxford rules, column dividers,
+   headline hierarchy, and multi-column archives grid. Built on
+   the existing editorial palette (warm paper, Fraunces serif,
+   claret accent). */
+
+/* Vertical rhythm scale for the newspaper page:
+   Sections are separated by generous space (2-3rem).
+   Sub-sections within a zone get tighter space (1-1.5rem).
+   Content inside an article gets the tightest (0.375-0.75rem). */
+.newspaper {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 2rem 2.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* ─ Masthead ─ */
+.newspaper-masthead {
+  text-align: center;
+  padding: 1.5rem 0 0;
+  margin-bottom: 2rem;
+}
+
+.newspaper-masthead h1 {
+  font-family: var(--font-serif);
+  font-size: clamp(2.25rem, 1.5rem + 3.5vw, 3.75rem);
+  font-weight: 300;
+  letter-spacing: 0.22em;
+  line-height: 1;
+  font-variation-settings: 'opsz' 96;
+  color: var(--foreground);
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.newspaper-tagline {
+  font-family: var(--font-serif);
+  font-size: 0.9375rem;
+  font-weight: 300;
+  font-style: italic;
+  letter-spacing: 0.04em;
+  color: var(--muted-foreground);
+  font-variation-settings: 'opsz' 12;
+  margin-top: 0.25rem;
+}
+
+.newspaper-dateline {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  line-height: 1.5;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+  margin-top: 0.5rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.newspaper-dateline a,
+.newspaper-dateline button {
+  color: var(--muted-foreground);
+  text-decoration: none;
+  transition: color 150ms;
+}
+
+.newspaper-dateline a:hover,
+.newspaper-dateline button:hover {
+  color: var(--foreground);
+}
+
+/* ─ Oxford rules ─ Thin-thick-thin lines used in broadsheet headers */
+.newspaper-rule {
+  border: none;
+  height: 1px;
+  background: var(--border);
+  margin: 0;
+}
+
+.newspaper-rule--double {
+  height: 0;
+  border-top: 2px solid var(--foreground);
+  border-bottom: 1px solid var(--foreground);
+  padding-top: 3px;
+  background: none;
+}
+
+.newspaper-rule--thin {
+  height: 0;
+  border-top: 1px solid var(--border);
+  background: none;
+}
+
+/* ─ Section headers ─ Small-caps section labels like in broadsheets */
+.newspaper-section {
+  font-family: var(--font-sans);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  line-height: 1.5;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--foreground);
+  display: block;
+  margin-bottom: 0.75rem;
+}
+
+/* ─ Above the fold ─ Lead story + dispatches sidebar */
+.newspaper-above-fold {
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 0;
+}
+
+@media (max-width: 768px) {
+  .newspaper-above-fold {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ─ Lead story ─ */
+.newspaper-lead {
+  padding-right: 2rem;
+  border-right: 1px solid var(--border);
+}
+
+@media (max-width: 768px) {
+  .newspaper-lead {
+    padding-right: 0;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 1.5rem;
+  }
+}
+
+.newspaper-headline--lead {
+  font-family: var(--font-serif);
+  font-size: clamp(1.75rem, 1rem + 3vw, 3rem);
+  font-weight: 500;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  font-variation-settings: 'opsz' 72;
+  color: var(--foreground);
+  text-wrap: balance;
+  margin: 0.25rem 0 0.75rem;
+}
+
+.newspaper-headline--lead:hover {
+  color: var(--ring);
+}
+
+/* Secondary headline — used for the "All caught up" state and
+   other moments that need a headline but not the full lead weight. */
+.newspaper-headline--secondary {
+  font-family: var(--font-serif);
+  font-size: clamp(1.25rem, 0.8rem + 1.5vw, 1.75rem);
+  font-weight: 440;
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  font-variation-settings: 'opsz' 36;
+  color: var(--foreground);
+  text-wrap: balance;
+  margin: 0.25rem 0 0.75rem;
+}
+
+.newspaper-byline {
+  font-family: var(--font-sans);
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+  line-height: 1.4;
+}
+
+.newspaper-lede {
+  font-family: var(--font-serif);
+  font-size: 1.0625rem;
+  font-weight: 340;
+  line-height: 1.55;
+  color: var(--foreground);
+  font-variation-settings: 'opsz' 14;
+  margin-top: 0.75rem;
+  max-width: 56ch;
+}
+
+/* ─ Sidebar (dispatches) ─ */
+.newspaper-sidebar {
+  padding-left: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  .newspaper-sidebar {
+    padding-left: 0;
+    padding-top: 1.5rem;
+  }
+}
+
+.newspaper-sidebar-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding: 0.625rem 0.5rem;
+  margin: 0 -0.5rem;
+  border-bottom: 1px solid oklch(0.5 0.012 65 / 12%);
+  border-radius: 2px;
+  transition: background 150ms;
+}
+
+.newspaper-sidebar-item:last-child {
+  border-bottom: none;
+}
+
+.newspaper-sidebar-item:hover {
+  background: oklch(0.5 0.012 65 / 4%);
+}
+
+.newspaper-sidebar-headline {
+  font-family: var(--font-serif);
+  font-size: 0.9375rem;
+  font-weight: 460;
+  line-height: 1.25;
+  letter-spacing: -0.005em;
+  font-variation-settings: 'opsz' 14;
+  color: var(--foreground);
+}
+
+/* ─ Archives grid ─ Multi-column newspaper layout */
+.newspaper-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+}
+
+@media (max-width: 1024px) {
+  .newspaper-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .newspaper-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Column rules — vertical dividers between newspaper columns.
+   Uses the right border on non-last-column items. The CSS calc
+   accounts for the gap (none here) so they butt up. */
+.newspaper-article {
+  padding: 1rem 1.5rem;
+  border-right: 1px solid oklch(0.5 0.012 65 / 14%);
+  border-bottom: 1px solid oklch(0.5 0.012 65 / 14%);
+  transition: background 150ms;
+}
+
+.newspaper-article:hover,
+.newspaper-article--featured:hover {
+  background: oklch(0.5 0.012 65 / 4%);
+}
+
+.newspaper-article,
+.newspaper-article--featured {
+  cursor: pointer;
+}
+
+.newspaper-article *,
+.newspaper-article--featured * {
+  cursor: pointer;
+}
+
+/* Remove right border on last column items */
+.newspaper-grid > .newspaper-article:nth-child(3n) {
+  border-right: none;
+}
+
+@media (max-width: 1024px) {
+  .newspaper-grid > .newspaper-article:nth-child(3n) {
+    border-right: 1px solid oklch(0.5 0.012 65 / 14%);
+  }
+  .newspaper-grid > .newspaper-article:nth-child(2n) {
+    border-right: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .newspaper-grid > .newspaper-article {
+    border-right: none;
+  }
+}
+
+/* First article spans full width as a secondary lead.
+   Uses a two-column layout where the headline spans both columns
+   and the lede + meta sit side by side beneath it. */
+.newspaper-article--featured {
+  grid-column: 1 / -1;
+  border-right: none;
+  border-bottom: 1px solid oklch(0.5 0.012 65 / 14%);
+  padding: 1.5rem 1.5rem;
+}
+
+.newspaper-article--featured > * {
+  max-width: 50ch;
+}
+
+@media (max-width: 640px) {
+  .newspaper-article--featured > * {
+    max-width: none;
+  }
+}
+
+/* Headline scale: featured 1.375rem (22px) > unread 1.25rem (20px)
+   > regular 1.125rem (18px) > lede 0.9375rem (15px).
+   Each step is ~1.12-1.2x, enough to read as different at a glance. */
+.newspaper-article-headline {
+  font-family: var(--font-serif);
+  font-size: 1.125rem;
+  font-weight: 460;
+  line-height: 1.22;
+  letter-spacing: -0.005em;
+  font-variation-settings: 'opsz' 20;
+  color: var(--foreground);
+  text-wrap: balance;
+  transition: color 150ms;
+}
+
+.newspaper-article-headline:hover {
+  color: var(--ring);
+}
+
+.newspaper-article-headline--unread {
+  font-weight: 540;
+  font-size: 1.25rem;
+  font-variation-settings: 'opsz' 24;
+}
+
+/* Featured article headline — intermediate tier between the lead
+   and regular article headlines. Used on the first archive item. */
+.newspaper-article-headline--featured {
+  font-family: var(--font-serif);
+  font-size: 1.375rem;
+  font-weight: 500;
+  line-height: 1.18;
+  letter-spacing: -0.01em;
+  font-variation-settings: 'opsz' 28;
+  color: var(--foreground);
+  text-wrap: balance;
+  transition: color 150ms;
+}
+
+.newspaper-article-headline--featured:hover {
+  color: var(--ring);
+}
+
+.newspaper-article-meta {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--muted-foreground);
+  margin-top: 0.375rem;
+  line-height: 1.5;
+  letter-spacing: 0.01em;
+}
+
+/* Article lede — the AI summary excerpt. Full text in featured
+   articles, clamped to 3 lines in the regular grid to keep
+   column heights even. */
+.newspaper-article-lede {
+  font-family: var(--font-serif);
+  font-size: 0.9375rem;
+  font-weight: 340;
+  line-height: 1.5;
+  color: var(--muted-foreground);
+  font-variation-settings: 'opsz' 14;
+  margin-top: 0.5rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* Featured articles show the full summary */
+.newspaper-article--featured .newspaper-article-lede {
+  display: block;
+  -webkit-line-clamp: unset;
+  overflow: visible;
+}
+
+/* ─ Newsroom section (compose) ─ Rule-above separates it from
+   the above-the-fold zone. The generous top padding creates a
+   clear "new section" beat. */
+.newspaper-newsroom {
+  margin: 0;
+  padding: 1.5rem 0 2rem;
+}
+
+/* ─ Footer strip ─ */
+.newspaper-footer {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  padding: 1.5rem 0 0;
+}
+
+.newspaper-footer button {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+  color: var(--muted-foreground);
+  text-transform: uppercase;
+  transition: color 150ms;
+}
+
+.newspaper-footer button:hover {
+  color: var(--foreground);
+}
+
+/* ─ Dark mode overrides ─ */
+.dark .newspaper-article {
+  border-right-color: oklch(0.65 0.012 65 / 10%);
+  border-bottom-color: oklch(0.65 0.012 65 / 10%);
+}
+
+.dark .newspaper-article:hover {
+  background: oklch(0.65 0.012 65 / 5%);
+}
+
+.dark .newspaper-sidebar-item {
+  border-bottom-color: oklch(0.65 0.012 65 / 10%);
+}
+
+.dark .newspaper-sidebar-item:hover {
+  background: oklch(0.65 0.012 65 / 5%);
+}
+
 /* ─── Reduced motion ─────────────────────────────────────────
    Honor the OS preference. Every transition and animation in
    the app collapses to instantaneous changes for users who

--- a/src/globals.css
+++ b/src/globals.css
@@ -1031,6 +1031,53 @@ ul.review-focus-content > li::before {
   color: var(--foreground);
 }
 
+/* ─ Extra notice ─ Newspaper "Extra" strip for update announcements.
+   Sits between the masthead and content, styled like the strip a
+   newsboy would shout about on the street corner. Centered, compact,
+   with the "EXTRA" label in the brand's section-header voice. */
+.newspaper-extra {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.625rem 1rem;
+  margin: -0.75rem 0 1.25rem;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  text-align: center;
+}
+
+.newspaper-extra-label {
+  font-family: var(--font-sans);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ring);
+  line-height: 1;
+}
+
+.newspaper-extra-text {
+  font-family: var(--font-serif);
+  font-size: 0.875rem;
+  font-weight: 340;
+  font-variation-settings: 'opsz' 12;
+  color: var(--foreground);
+}
+
+.newspaper-extra-text strong {
+  font-weight: 600;
+}
+
+.newspaper-extra-dismiss {
+  color: var(--muted-foreground);
+  transition: color 150ms;
+}
+
+.newspaper-extra-dismiss:hover {
+  color: var(--foreground);
+}
+
 /* ─ Oxford rules ─ Thin-thick-thin lines used in broadsheet headers */
 .newspaper-rule {
   border: none;

--- a/src/main.ts
+++ b/src/main.ts
@@ -604,7 +604,29 @@ function readReviewsIndex(): ReviewHistoryEntry[] {
   try {
     const entries = JSON.parse(fs.readFileSync(getReviewsIndexPath(), 'utf-8')) as ReviewHistoryEntry[];
     // Backward compat: entries without status are completed
-    return entries.map((e) => ({ ...e, status: e.status ?? 'completed' }));
+    let dirty = false;
+    const result = entries.map((e) => {
+      const patched = { ...e, status: e.status ?? ('completed' as const) };
+      // Backfill summary from the full review JSON if missing
+      if (!patched.summary && patched.status === 'completed') {
+        try {
+          const reviewPath = path.join(getReviewsDir(), `${patched.id}.json`);
+          const review = JSON.parse(fs.readFileSync(reviewPath, 'utf-8')) as ReviewGuide;
+          if (review.summary) {
+            patched.summary = review.summary;
+            dirty = true;
+          }
+        } catch {
+          // Review file missing or unreadable — skip
+        }
+      }
+      return patched;
+    });
+    // Persist backfilled summaries so we only do this once
+    if (dirty) {
+      fs.writeFileSync(getReviewsIndexPath(), JSON.stringify(result, null, 2));
+    }
+    return result;
   } catch {
     return [];
   }
@@ -1327,6 +1349,7 @@ async function runBackgroundGeneration(
       status: 'completed',
       riskLevel: reviewGuide.riskLevel,
       generationDurationMs,
+      summary: reviewGuide.summary,
     });
 
     broadcastToAllWindows('review-completed', { reviewId });

--- a/src/main.ts
+++ b/src/main.ts
@@ -532,6 +532,8 @@ void app.whenReady().then(() => {
 
   // Mark any stale "generating" entries from a previous crash as failed
   cleanupStaleGeneratingEntries();
+  // Backfill summaries for reviews that predate the summary field
+  backfillSummaries();
   applyBinaryOverrides(loadPreferences());
   createWindow();
   setupAutoUpdater();
@@ -604,31 +606,34 @@ function readReviewsIndex(): ReviewHistoryEntry[] {
   try {
     const entries = JSON.parse(fs.readFileSync(getReviewsIndexPath(), 'utf-8')) as ReviewHistoryEntry[];
     // Backward compat: entries without status are completed
-    let dirty = false;
-    const result = entries.map((e) => {
-      const patched = { ...e, status: e.status ?? ('completed' as const) };
-      // Backfill summary from the full review JSON if missing
-      if (!patched.summary && patched.status === 'completed') {
-        try {
-          const reviewPath = path.join(getReviewsDir(), `${patched.id}.json`);
-          const review = JSON.parse(fs.readFileSync(reviewPath, 'utf-8')) as ReviewGuide;
-          if (review.summary) {
-            patched.summary = review.summary;
-            dirty = true;
-          }
-        } catch {
-          // Review file missing or unreadable — skip
-        }
-      }
-      return patched;
-    });
-    // Persist backfilled summaries so we only do this once
-    if (dirty) {
-      fs.writeFileSync(getReviewsIndexPath(), JSON.stringify(result, null, 2));
-    }
-    return result;
+    return entries.map((e) => ({ ...e, status: e.status ?? 'completed' }));
   } catch {
     return [];
+  }
+}
+
+/** One-time migration: backfill summary from full review JSON into
+ *  the index for entries that predate the summary field. Runs once
+ *  at startup and persists results so subsequent reads are fast. */
+function backfillSummaries(): void {
+  const index = readReviewsIndex();
+  let dirty = false;
+  for (const entry of index) {
+    if (!entry.summary && entry.status === 'completed') {
+      try {
+        const reviewPath = path.join(getReviewsDir(), `${entry.id}.json`);
+        const review = JSON.parse(fs.readFileSync(reviewPath, 'utf-8')) as ReviewGuide;
+        if (review.summary) {
+          entry.summary = review.summary;
+          dirty = true;
+        }
+      } catch {
+        // Review file missing or unreadable — skip
+      }
+    }
+  }
+  if (dirty) {
+    fs.writeFileSync(getReviewsIndexPath(), JSON.stringify(index, null, 2));
   }
 }
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -28,7 +28,7 @@ import { useKeyboardShortcuts, type ShortcutMap } from '../../lib/use-keyboard-s
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../components/ui/dialog';
 import { Avatar, AvatarFallback, AvatarImage } from '../../components/ui/avatar';
 import { riskConfig, safeConfigLookup } from '../../lib/constants';
-import type { ModelId, Preferences, Provider, PrSearchResult, ReviewGuide, ReviewHistoryEntry } from '../../lib/types';
+import type { ModelId, Preferences, Provider, PrSearchResult, ReviewGuide, ReviewHistoryEntry, UpdateInfo } from '../../lib/types';
 import { timeAgo, formatDuration, formatBytes, groupReviewsByPR } from '../../lib/utils';
 
 interface Props {
@@ -168,6 +168,10 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [aboutOpen, setAboutOpen] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<'all' | 'closed' | null>(null);
 
+  // Update availability — rendered as a newspaper "Extra" notice
+  const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
+  const [readyVersion, setReadyVersion] = useState<string | null>(null);
+
   // Has the user EVER had a pending PR from GitHub? Persisted in
   // localStorage so we know whether the empty Suggested-for-you
   // section should render its teaching placeholder (first-time
@@ -222,6 +226,16 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
     });
     return () => {
       window.electronAPI.offNewReviewInHistory();
+    };
+  }, []);
+
+  // Listen for app update events
+  useEffect(() => {
+    window.electronAPI.onUpdateAvailable((info) => setUpdateInfo(info));
+    window.electronAPI.onUpdateReady((version) => setReadyVersion(version));
+    return () => {
+      window.electronAPI.offUpdateAvailable();
+      window.electronAPI.offUpdateReady();
     };
   }, []);
 
@@ -844,6 +858,58 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
             </p>
             <hr className="newspaper-rule--double" />
           </header>
+
+          {/* ── EXTRA: Update available ── Rendered as a newspaper
+              "Extra" notice strip between the masthead and content.
+              Auto-update platforms show "will install on restart";
+              manual platforms show a download link. */}
+          {(() => {
+            const supportsAutoUpdate = window.electronAPI.platform !== 'linux' && window.electronAPI.isPackaged;
+            if (supportsAutoUpdate && readyVersion) {
+              return (
+                <div className="newspaper-extra">
+                  <span className="newspaper-extra-label">Extra</span>
+                  <span className="newspaper-extra-text">
+                    Gnosis <strong>v{readyVersion}</strong> will install on next restart
+                  </span>
+                  <button
+                    onClick={() => setReadyVersion(null)}
+                    className="newspaper-extra-dismiss"
+                    aria-label="Dismiss"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </div>
+              );
+            }
+            if (updateInfo && !supportsAutoUpdate) {
+              return (
+                <div className="newspaper-extra">
+                  <span className="newspaper-extra-label">Extra</span>
+                  <span className="newspaper-extra-text">
+                    Gnosis <strong>v{updateInfo.version}</strong> is available
+                  </span>
+                  <button
+                    onClick={() => void window.electronAPI.openExternal(updateInfo.releaseUrl)}
+                    className="text-xs text-[var(--ring)] hover:underline transition-colors"
+                  >
+                    Download →
+                  </button>
+                  <button
+                    onClick={() => {
+                      void window.electronAPI.dismissUpdate(updateInfo.version);
+                      setUpdateInfo(null);
+                    }}
+                    className="newspaper-extra-dismiss"
+                    aria-label="Dismiss"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </div>
+              );
+            }
+            return null;
+          })()}
 
           {/* ── Welcome / About ── Inline hero, newspaper style */}
           {(firstRunOpen || aboutOpen) && (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -197,6 +197,9 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
     }
   });
 
+  const mainRef = useRef<HTMLElement>(null);
+  const scrollToTop = () => mainRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+
   // Compose-row progressive disclosure. Each section starts collapsed
   // so the default state of the page is one-line-of-intent. Instructions
   // automatically expand if the user already has saved instructions
@@ -310,7 +313,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
     }
     setAboutOpen(false);
     setFirstRunOpen(true);
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    scrollToTop();
   }
 
   // Command palette commands for the home screen. Recently-used
@@ -714,13 +717,16 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
     day: 'numeric',
   });
 
-  // Newspaper edition number — days since an arbitrary epoch
+  // Newspaper edition number — days since an arbitrary epoch,
+  // normalized to local midnight so it doesn't drift with UTC.
+  const todayLocal = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const editionEpoch = new Date(2024, 0, 1);
   const editionNumber = Math.floor(
-    (today.getTime() - new Date('2024-01-01').getTime()) / 86_400_000
+    (todayLocal.getTime() - editionEpoch.getTime()) / 86_400_000
   );
 
   return (
-    <main className="h-screen overflow-y-auto">
+    <main ref={mainRef} className="h-screen overflow-y-auto">
       <ShortcutOverlay open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
       <CommandPalette
         open={paletteOpen}
@@ -1433,22 +1439,17 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                       className={`${idx === 0 ? 'newspaper-article--featured' : 'newspaper-article'} group`}
                       onClick={() => isClickable && handleLoadFromHistory(latestId)}
                     >
-                      {/* Headline */}
-                      <button
-                        onClick={() => isClickable && handleLoadFromHistory(latestId)}
-                        className="text-left w-full"
-                        disabled={!isClickable}
+                      {/* Headline — the article-level onClick handles navigation,
+                          so this is just a presentational heading, not a button. */}
+                      <h3
+                        className={
+                          idx === 0
+                            ? 'newspaper-article-headline--featured'
+                            : `newspaper-article-headline ${isUnread ? 'newspaper-article-headline--unread' : ''}`
+                        }
                       >
-                        <h3
-                          className={
-                            idx === 0
-                              ? 'newspaper-article-headline--featured'
-                              : `newspaper-article-headline ${isUnread ? 'newspaper-article-headline--unread' : ''}`
-                          }
-                        >
-                          {group.prTitle}
-                        </h3>
-                      </button>
+                        {group.prTitle}
+                      </h3>
 
                       {/* Byline & meta */}
                       <p className="newspaper-article-meta">
@@ -1543,14 +1544,15 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                         )}
                         {hasMultiple && (
                           <button
-                            onClick={() =>
+                            onClick={(e) => {
+                              e.stopPropagation();
                               setExpandedPRs((prev) => {
                                 const next = new Set(prev);
                                 if (next.has(group.prUrl)) next.delete(group.prUrl);
                                 else next.add(group.prUrl);
                                 return next;
-                              })
-                            }
+                              });
+                            }}
                             className="slide-meta hover:text-foreground transition-colors ml-auto"
                           >
                             {isExpanded ? 'Hide' : `${group.reviews.length} reviews`}
@@ -1619,7 +1621,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
           {/* ── Newspaper footer ── */}
           <hr className="newspaper-rule--double mt-8" />
           <div className="newspaper-footer">
-            <button onClick={() => { setAboutOpen(true); window.scrollTo({ top: 0, behavior: 'smooth' }); }}>
+            <button onClick={() => { setAboutOpen(true); scrollToTop(); }}>
               About
             </button>
             <button onClick={() => setShortcutsOpen(true)}>Shortcuts</button>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1439,33 +1439,49 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                       className={`${idx === 0 ? 'newspaper-article--featured' : 'newspaper-article'} group`}
                       onClick={() => isClickable && handleLoadFromHistory(latestId)}
                     >
-                      {/* Headline — the article-level onClick handles navigation,
-                          so this is just a presentational heading, not a button. */}
-                      <h3
-                        className={
-                          idx === 0
-                            ? 'newspaper-article-headline--featured'
-                            : `newspaper-article-headline ${isUnread ? 'newspaper-article-headline--unread' : ''}`
-                        }
-                      >
-                        {group.prTitle}
-                      </h3>
-
-                      {/* Byline & meta */}
-                      <p className="newspaper-article-meta">
-                        {group.repoRef} · {group.author} · {timeAgo(group.latestReview.savedAt)}
-                        {hasMultiple && ` · ${group.reviews.length} reviews`}
-                      </p>
-
-                      {/* Article lede — the AI summary, truncated */}
-                      {group.latestReview.summary && (
-                        <p className="newspaper-article-lede">
-                          {group.latestReview.summary}
-                        </p>
+                      {/* Featured articles use a two-column layout:
+                          left = headline + meta + badges, right = lede.
+                          Regular articles keep the flat stack. */}
+                      {idx === 0 ? (
+                        <>
+                          <div className="newspaper-featured-left">
+                            <h3 className="newspaper-article-headline--featured">
+                              {group.prTitle}
+                            </h3>
+                            <p className="newspaper-article-meta">
+                              {group.repoRef} · {group.author} · {timeAgo(group.latestReview.savedAt)}
+                              {hasMultiple && ` · ${group.reviews.length} reviews`}
+                            </p>
+                          </div>
+                          {group.latestReview.summary ? (
+                            <div className="newspaper-featured-right">
+                              <p className="newspaper-article-lede !mt-0">
+                                {group.latestReview.summary}
+                              </p>
+                            </div>
+                          ) : <div />}
+                        </>
+                      ) : (
+                        <>
+                          <h3
+                            className={`newspaper-article-headline ${isUnread ? 'newspaper-article-headline--unread' : ''}`}
+                          >
+                            {group.prTitle}
+                          </h3>
+                          <p className="newspaper-article-meta">
+                            {group.repoRef} · {group.author} · {timeAgo(group.latestReview.savedAt)}
+                            {hasMultiple && ` · ${group.reviews.length} reviews`}
+                          </p>
+                          {group.latestReview.summary && (
+                            <p className="newspaper-article-lede">
+                              {group.latestReview.summary}
+                            </p>
+                          )}
+                        </>
                       )}
 
-                      {/* Status badges */}
-                      <div className="flex items-center gap-2 mt-2 flex-wrap">
+                      {/* Status badges — spans full width in featured layout */}
+                      <div className={`flex items-center gap-2 mt-2 flex-wrap ${idx === 0 ? 'newspaper-featured-footer' : ''}`}>
                         {prState === 'open' && !isOutdated && (
                           <Badge variant="outline" className="text-[10px] border-[var(--color-success)]/35 text-[var(--color-success)]">
                             <GitPullRequest className="h-2.5 w-2.5 mr-0.5" /> Open
@@ -1508,13 +1524,13 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
 
                       {/* Byte stats for generating reviews */}
                       {latestStatus === 'generating' && bytes && bytes.inputBytes > 0 && (
-                        <p className="slide-meta opacity-60 mt-1">
+                        <p className={`slide-meta opacity-60 mt-1 ${idx === 0 ? 'newspaper-featured-footer' : ''}`}>
                           ↑{formatBytes(bytes.inputBytes)} ↓{formatBytes(bytes.outputBytes)}
                         </p>
                       )}
 
                       {/* Action row — visible on hover */}
-                      <div className="flex items-center gap-1 mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <div className={`flex items-center gap-1 mt-2 opacity-0 group-hover:opacity-100 transition-opacity ${idx === 0 ? 'newspaper-featured-footer' : ''}`}>
                         {latestStatus === 'generating' && (
                           <button
                             onClick={(e) => { e.stopPropagation(); void window.electronAPI.cancelReview(latestId); }}
@@ -1562,7 +1578,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
 
                       {/* Expanded sub-reviews */}
                       {hasMultiple && isExpanded && (
-                        <div className="mt-2 pt-2 border-t border-border/40 flex flex-col gap-1">
+                        <div className={`mt-2 pt-2 border-t border-border/40 flex flex-col gap-1 ${idx === 0 ? 'newspaper-featured-footer' : ''}`}>
                           {group.reviews.map((review) => {
                             const reviewStatus = getEntryStatus(review);
                             const reviewRisk = safeConfigLookup(riskConfig, review.riskLevel, riskConfig.low);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -93,7 +93,7 @@ function ToggleSwitch({ id, label, description, checked, onToggle, badge }: Togg
             </>
           )}
         </label>
-        <p className="slide-meta">{description}</p>
+        <p className="text-xs text-muted-foreground">{description}</p>
       </div>
       <button
         id={id}
@@ -166,6 +166,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   // welcome content after the first-run flag has been flipped. Same
   // copy as the inline welcome hero, just reachable from the top bar.
   const [aboutOpen, setAboutOpen] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState<'all' | 'closed' | null>(null);
 
   // Has the user EVER had a pending PR from GitHub? Persisted in
   // localStorage so we know whether the empty Suggested-for-you
@@ -591,7 +592,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       setHistory(updated);
       setPrUrl('');
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Couldn't start the review.");
+      setError(err instanceof Error ? err.message : "Couldn't start the review. Check the URL and try again.");
     } finally {
       setSubmitting(false);
     }
@@ -636,7 +637,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       setHistory((prev) => prev.map((e) => (e.id === id ? { ...e, unread: false } : e)));
       onReviewReady(review);
     } catch {
-      setError("Couldn't load that review.");
+      setError("Couldn't load that review. The file may have been deleted.");
     }
   }
 
@@ -688,9 +689,24 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   }
 
   const isAuthenticated = typeof authStatus === 'object';
+  const login = isAuthenticated ? (authStatus as { login: string }).login : '';
+
+  // Format today as a newspaper dateline
+  const today = new Date();
+  const dateline = today.toLocaleDateString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  // Newspaper edition number — days since an arbitrary epoch
+  const editionNumber = Math.floor(
+    (today.getTime() - new Date('2024-01-01').getTime()) / 86_400_000
+  );
 
   return (
-    <main className="min-h-screen overflow-y-auto px-10 lg:px-12 py-8">
+    <main className="h-screen overflow-y-auto">
       <ShortcutOverlay open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
       <CommandPalette
         open={paletteOpen}
@@ -698,27 +714,33 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
         commands={paletteCommands}
         placeholder="Jump to a review or run a command…"
       />
-      <div className="w-full flex flex-col gap-12">
-        {/* Auth section */}
-        {authStatus === 'checking' && (
-          <div className="flex justify-center pt-[20vh]">
-            <span className="slide-meta animate-pulse">Loading…</span>
-          </div>
-        )}
 
-        {authStatus === 'unauthenticated' && (
-          <div className="max-w-md mx-auto w-full pt-[12vh] flex flex-col gap-8">
+      {/* ── Pre-auth states ── */}
+      {authStatus === 'checking' && (
+        <div className="flex justify-center pt-[20vh]">
+          <span className="slide-meta animate-pulse">Loading…</span>
+        </div>
+      )}
+
+      {authStatus === 'unauthenticated' && (
+        <div className="newspaper">
+          <header className="newspaper-masthead">
+            <hr className="newspaper-rule--double" />
+            <h1>Gnosis</h1>
+            <p className="newspaper-tagline">Code Review, Narrated</p>
+            <hr className="newspaper-rule--double" />
+          </header>
+          <div className="max-w-md mx-auto w-full pt-8 flex flex-col gap-8">
             {authError && (
               <Alert variant="destructive">
                 <AlertDescription>{authError}</AlertDescription>
               </Alert>
             )}
-            <div className="flex flex-col gap-4">
-              <div className="slide-chapter">
-                <span>Welcome to Gnosis</span>
-              </div>
-              <h1 className="slide-title">Sign in with your GitHub account.</h1>
-              <p className="slide-prose">
+            <div className="flex flex-col gap-4 text-center">
+              <p className="newspaper-lede">
+                Sign in with your GitHub account to begin reading.
+              </p>
+              <p className="slide-meta max-w-[52ch] mx-auto">
                 Gnosis uses your GitHub account to fetch pull request diffs, post review comments, and remember which
                 reviews are yours. Nothing leaves your machine besides the requests to GitHub.
               </p>
@@ -729,7 +751,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
             </Button>
             <button
               type="button"
-              className="slide-meta hover:text-foreground transition-colors flex items-center gap-1.5 self-start"
+              className="slide-meta hover:text-foreground transition-colors flex items-center gap-1.5 self-center"
               onClick={() => {
                 setPatExpanded((v) => !v);
                 setPatError(null);
@@ -781,881 +803,765 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
               </div>
             )}
           </div>
-        )}
+        </div>
+      )}
 
-        {authStatus === 'signing-in' && (
-          <div className="flex flex-col items-center gap-2 text-center pt-[20vh]">
-            <span className="slide-meta animate-pulse">
-              Waiting for GitHub… complete sign-in in your browser.
-            </span>
-          </div>
-        )}
+      {authStatus === 'signing-in' && (
+        <div className="flex flex-col items-center gap-2 text-center pt-[20vh]">
+          <span className="slide-meta animate-pulse">
+            Waiting for GitHub… complete sign-in in your browser.
+          </span>
+        </div>
+      )}
 
-        {/* Authenticated layout — four full-width zones stacked top to
-            bottom. The page is intentionally edge-to-edge (no max-w
-            cap) so wide monitors get a true reading desk. */}
-        {isAuthenticated && (
-          <>
-            {/* ── Zone 1: Top bar ── Wordmark + account row, no border. */}
-            <div className="flex items-center justify-between">
-              <span className="font-serif text-lg leading-none tracking-tight text-foreground">Gnosis</span>
-              <div className="flex items-center gap-5 slide-meta">
-                <span className="flex items-center gap-2">
-                  <Avatar className="h-5 w-5">
-                    <AvatarImage
-                      src={`https://github.com/${(authStatus as { login: string }).login}.png`}
-                      alt={(authStatus as { login: string }).login}
-                    />
-                    <AvatarFallback className="text-[10px]">
-                      {(authStatus as { login: string }).login.slice(0, 2).toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
-                  @{(authStatus as { login: string }).login}
-                </span>
-                <button
-                  onClick={() => {
-                    setAboutOpen(true);
-                    // Scroll to top so the panel is visible if the
-                    // user clicked About from deep in the history.
-                    window.scrollTo({ top: 0, behavior: 'smooth' });
-                  }}
-                  className="hover:text-foreground transition-colors"
-                >
-                  About
-                </button>
-                <button
-                  onClick={() => setShortcutsOpen(true)}
-                  className="hover:text-foreground transition-colors"
-                  title="Keyboard shortcuts (?)"
-                >
-                  Shortcuts
-                </button>
-                <button
-                  onClick={() => setSettingsOpen(true)}
-                  className="hover:text-foreground transition-colors"
-                >
-                  Settings
-                </button>
-                <button onClick={handleSignOut} className="hover:text-foreground transition-colors">
-                  Sign out
-                </button>
-              </div>
-            </div>
+      {/* ══════════════════════════════════════════════════════════
+          ██  THE NEWSPAPER  ██
+          Broadsheet-style layout: masthead, above-the-fold lead
+          story, dispatches sidebar, classified submission form,
+          and a multi-column archives grid.
+          ══════════════════════════════════════════════════════════ */}
+      {isAuthenticated && (
+        <div className="newspaper">
+          {/* ── Masthead ── */}
+          <header className="newspaper-masthead">
+            <hr className="newspaper-rule--double" />
+            <h1>Gnosis</h1>
+            <p className="newspaper-tagline">Code Review, Narrated</p>
+            <p className="newspaper-dateline">
+              No. {editionNumber} · {dateline} ·{' '}
+              <span className="inline-flex items-center gap-1.5">
+                <Avatar className="h-3.5 w-3.5 inline-block align-middle">
+                  <AvatarImage
+                    src={`https://github.com/${login}.png`}
+                    alt={login}
+                  />
+                  <AvatarFallback className="text-[8px]">
+                    {login.slice(0, 2).toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+                @{login}
+              </span>
+            </p>
+            <hr className="newspaper-rule--double" />
+          </header>
 
-            {/* ── Welcome / About hero ── Replaces the Pick-up hero
-                slot on the first ever visit (firstRunOpen) and any
-                time the user reopens the panel from the top bar
-                (aboutOpen). Inlined onto the page, not modal — the
-                user learns the layout and the welcome at the same
-                time. Pickup hero is suppressed while this is open. */}
-            {(firstRunOpen || aboutOpen) && (
-              <section className="flex flex-col gap-5 pt-4 pb-2 max-w-[68ch]">
-                <p className="editorial-label">
-                  {firstRunOpen ? 'Welcome to Gnosis' : 'About Gnosis'}
+          {/* ── Welcome / About ── Inline hero, newspaper style */}
+          {(firstRunOpen || aboutOpen) && (
+            <section className="py-6 border-b border-border max-w-[68ch] mx-auto text-center">
+              <p className="newspaper-section">
+                {firstRunOpen ? 'Welcome' : 'About Gnosis'}
+              </p>
+              <h2 className="newspaper-headline--lead !text-center">
+                A pull request is a story. Read it like one.
+              </h2>
+              <div className="newspaper-lede mx-auto mt-4 text-center max-w-[56ch]">
+                <p>
+                  Gnosis turns a GitHub pull request into an ordered walkthrough you can read like a chapter.
+                  Foundation changes first, then the features built on top, then the tests and config — each on
+                  its own slide, each with a short narrative explaining <em>why</em> the change is there.
                 </p>
-                <h1 className="slide-title">A pull request is a story. Read it like one.</h1>
-                <div className="slide-prose flex flex-col gap-3">
-                  <p>
-                    Gnosis turns a GitHub pull request into an ordered walkthrough you can read like a chapter.
-                    Foundation changes first, then the features built on top, then the tests and config — each on
-                    its own slide, each with a short narrative explaining <em>why</em> the change is there.
-                  </p>
-                  <p>
-                    You'll still see every diff. Everything runs locally on your machine — nothing leaves except
-                    requests to GitHub.
-                  </p>
-                </div>
-                <div className="flex items-center gap-6 pt-1">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (firstRunOpen) {
-                        dismissFirstRun();
-                      } else {
-                        setAboutOpen(false);
-                      }
-                    }}
-                    className="text-sm text-foreground underline underline-offset-4 hover:opacity-80 transition-opacity"
-                  >
-                    {firstRunOpen ? 'Continue →' : 'Close'}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (firstRunOpen) dismissFirstRun();
-                      setAboutOpen(false);
-                      setShortcutsOpen(true);
-                    }}
-                    className="slide-meta hover:text-foreground transition-colors"
-                  >
-                    See keyboard shortcuts
-                  </button>
-                </div>
-              </section>
-            )}
-
-            {/* ── Zone 2: Pick up where you left off ── The visual
-                anchor of the page when there's an unread review.
-                Disappears entirely when nothing is unread, yielding
-                the real estate to the composer and history. While
-                the welcome / about panel is open it takes priority
-                so the user isn't pulled in two directions. */}
-            {latestUnreadGroup && !firstRunOpen && !aboutOpen && (
-              <section className="flex flex-col gap-3 pt-4">
-                <p className="editorial-label">Pick up where you left off</p>
+                <p className="mt-3">
+                  You'll still see every diff. Everything runs locally on your machine — nothing leaves except
+                  requests to GitHub.
+                </p>
+              </div>
+              <div className="flex items-center justify-center gap-6 pt-5">
                 <button
                   type="button"
-                  onClick={() => void handleLoadFromHistory(latestUnreadGroup.latestReview.id)}
-                  className="slide-title text-left hover:opacity-90 transition-opacity max-w-[60ch]"
+                  onClick={() => {
+                    if (firstRunOpen) dismissFirstRun();
+                    else setAboutOpen(false);
+                    // Focus the PR input so the user can paste immediately
+                    setTimeout(() => prInputRef.current?.focus(), 100);
+                  }}
+                  className="text-sm text-foreground underline underline-offset-4 hover:opacity-80 transition-opacity"
                 >
-                  {latestUnreadGroup.prTitle}
+                  {firstRunOpen ? 'Paste a PR URL to get started →' : 'Close'}
                 </button>
-                <div className="flex items-center gap-5">
-                  <span className="slide-meta">
-                    {latestUnreadGroup.repoRef} · {latestUnreadGroup.author} ·{' '}
-                    generated {timeAgo(latestUnreadGroup.latestReview.savedAt)}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => void handleLoadFromHistory(latestUnreadGroup.latestReview.id)}
-                    className="text-sm text-foreground underline underline-offset-4 hover:opacity-80 transition-opacity"
-                  >
-                    Open review →
-                  </button>
-                  {unreadGroups.length > 1 && (
-                    <button
-                      type="button"
-                      onClick={scrollToNextUnread}
-                      className="slide-meta hover:text-foreground transition-colors"
-                    >
-                      + {unreadGroups.length - 1} more unread
-                    </button>
-                  )}
-                </div>
-              </section>
-            )}
-
-            {/* ── Zone 3: Compose ── One line of intent + one line of
-                options. Instructions, model selection, and preferences
-                are progressive disclosures so the default visual state
-                stays calm. */}
-            <section className="flex flex-col gap-4">
-              {!latestUnreadGroup && (
-                <p className="editorial-label">Start a new review</p>
-              )}
-              <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-                {/* Line 1 — the input row */}
-                <div className="flex items-end gap-4 flex-wrap">
-                  <div className="flex-1 min-w-[320px] flex items-end gap-3">
-                    <input
-                      ref={prInputRef}
-                      id="pr-url"
-                      type="url"
-                      placeholder="Paste a pull request URL"
-                      value={prUrl}
-                      onChange={(e) => setPrUrl(e.target.value)}
-                      className="flex-1 bg-transparent border-0 border-b border-border px-0 py-3 text-base placeholder:text-muted-foreground/60 transition-colors"
-                      required
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setPrPickerOpen(true)}
-                      className="slide-meta hover:text-foreground transition-colors pb-3"
-                    >
-                      Browse
-                    </button>
-                  </div>
-                  <Button type="submit" className="gap-2 px-6 py-3 h-auto" disabled={submitting}>
-                    {submitting ? (
-                      <>
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        Starting review…
-                      </>
-                    ) : (
-                      <>
-                        <Play className="h-4 w-4" />
-                        Generate review
-                      </>
-                    )}
-                  </Button>
-                </div>
-
-                {/* Line 2 — quiet options row */}
-                <div className="flex items-center gap-6 slide-meta">
-                  <button
-                    type="button"
-                    onClick={() => setModelMenuExpanded((v) => !v)}
-                    className={`pb-0.5 border-b transition-colors ${
-                      modelMenuExpanded
-                        ? 'text-foreground border-[var(--ring)]'
-                        : 'border-transparent hover:text-foreground'
-                    }`}
-                  >
-                    {PROVIDERS[provider].label} ·{' '}
-                    {PROVIDERS[provider].models.find((m) => m.id === model)?.label ?? model}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setInstructionsExpanded((v) => !v)}
-                    className={`pb-0.5 border-b transition-colors ${
-                      instructionsExpanded || instructions
-                        ? 'text-foreground border-[var(--ring)]'
-                        : 'border-transparent hover:text-foreground'
-                    }`}
-                  >
-                    {instructions ? 'Instructions' : 'Add instructions'}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setPrefsExpanded((v) => !v)}
-                    className={`pb-0.5 border-b transition-colors ${
-                      prefsExpanded
-                        ? 'text-foreground border-[var(--ring)]'
-                        : 'border-transparent hover:text-foreground'
-                    }`}
-                  >
-                    Preferences
-                  </button>
-                </div>
-
-                {/* Quiet keyboard discoverability hint — only renders
-                    until the user opens the cheatsheet for the first
-                    time, then disappears forever (persisted via
-                    localStorage). Dismissable manually too. */}
-                {!keyboardHintDismissed && (
-                  <p className="slide-meta flex items-center gap-2 -mt-1">
-                    <span>
-                      <kbd className="kbd">n</kbd> to focus ·{' '}
-                      <kbd className="kbd">⌘ K</kbd> to search ·{' '}
-                      <kbd className="kbd">?</kbd> for shortcuts
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setKeyboardHintDismissed(true);
-                        try {
-                          localStorage.setItem('gnosis-keyboard-hint-dismissed', '1');
-                        } catch {
-                          /* non-fatal */
-                        }
-                      }}
-                      className="hover:text-foreground transition-colors"
-                      aria-label="Dismiss keyboard hint"
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  </p>
-                )}
-
-                {/* Disclosure: model menu */}
-                <div
-                  className={`grid transition-[grid-template-rows] duration-200 ease-out ${
-                    modelMenuExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
-                  }`}
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (firstRunOpen) dismissFirstRun();
+                    setAboutOpen(false);
+                    setShortcutsOpen(true);
+                  }}
+                  className="slide-meta hover:text-foreground transition-colors"
                 >
-                  <div className="overflow-hidden">
-                    <div className="flex flex-col gap-3 pt-1 pb-2">
-                      <div className="flex items-center gap-5 slide-meta">
-                        <span className="text-foreground/60">Provider</span>
-                        {(['claude', 'gemini'] as const).map((p) => (
-                          <button
-                            key={p}
-                            type="button"
-                            onClick={() => handleProviderChange(p)}
-                            className={`pb-0.5 border-b transition-colors ${
-                              provider === p
-                                ? 'text-foreground border-[var(--ring)]'
-                                : 'border-transparent hover:text-foreground'
-                            }`}
-                          >
-                            {PROVIDERS[p].label}
-                          </button>
-                        ))}
-                      </div>
-                      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 slide-meta">
-                        <span className="text-foreground/60">Model</span>
-                        {PROVIDERS[provider].models.map((m) => (
-                          <button
-                            key={m.id}
-                            type="button"
-                            onClick={() => setModel(m.id)}
-                            className={`pb-0.5 border-b transition-colors ${
-                              model === m.id
-                                ? 'text-foreground border-[var(--ring)]'
-                                : 'border-transparent hover:text-foreground'
-                            }`}
-                          >
-                            {m.label}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Disclosure: instructions textarea */}
-                <div
-                  className={`grid transition-[grid-template-rows] duration-200 ease-out ${
-                    instructionsExpanded || instructions ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
-                  }`}
-                >
-                  <div className="overflow-hidden">
-                    <textarea
-                      id="instructions"
-                      rows={4}
-                      placeholder="What should the reviewer pay special attention to?"
-                      value={instructions}
-                      onChange={(e) => setInstructions(e.target.value)}
-                      onBlur={() => savePrefs()}
-                      className="w-full bg-transparent border-0 border-b border-border px-0 py-2 text-sm placeholder:text-muted-foreground/60 transition-colors resize-none mt-1"
-                    />
-                  </div>
-                </div>
-
-                {/* Disclosure: preferences (the 6 toggles in a horizontal grid) */}
-                <div
-                  className={`grid transition-[grid-template-rows] duration-200 ease-out ${
-                    prefsExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
-                  }`}
-                >
-                  <div className="overflow-hidden">
-                    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-10 gap-y-5 pt-2">
-                      <ToggleSwitch
-                        id="include-all-files"
-                        label="Include all files"
-                        description={
-                          includeAllFiles
-                            ? 'All changed files included in the review'
-                            : 'You will choose which files to include'
-                        }
-                        checked={includeAllFiles}
-                        onToggle={() => setIncludeAllFiles((v) => !v)}
-                      />
-                      {provider === 'claude' && (
-                        <ToggleSwitch
-                          id="thinking"
-                          label="Extended thinking"
-                          description="Deeper reasoning before writing. Catches subtle bugs that standard mode misses. Takes longer."
-                          checked={thinking}
-                          onToggle={() => setThinking((t) => !t)}
-                        />
-                      )}
-                      <ToggleSwitch
-                        id="smart-imports"
-                        label="Smart imports"
-                        description="Pull in related files across all languages, not just imports the parser sees"
-                        checked={smartImports}
-                        onToggle={() => setSmartImports((s) => !s)}
-                        badge="Experimental"
-                      />
-                      <ToggleSwitch
-                        id="review-suggestions"
-                        label="Review suggestions"
-                        description="Generate 'What to check' for each slide"
-                        checked={reviewSuggestions}
-                        onToggle={() => setReviewSuggestions((r) => !r)}
-                      />
-                      {provider === 'claude' && (
-                        <ToggleSwitch
-                          id="web-research"
-                          label="Web research"
-                          description="Search for framework docs and best practices (slower)"
-                          checked={webResearch}
-                          onToggle={() => setWebResearch((w) => !w)}
-                        />
-                      )}
-                    </div>
-                  </div>
-                </div>
-
-                {error && (
-                  <Alert variant="destructive">
-                    <AlertDescription>{error}</AlertDescription>
-                  </Alert>
-                )}
-              </form>
-
-              <PRPickerDialog open={prPickerOpen} onOpenChange={setPrPickerOpen} onSelect={setPrUrl} />
-              <SettingsDialog
-                open={settingsOpen}
-                onOpenChange={setSettingsOpen}
-                onReplayOnboarding={replayOnboarding}
-              />
-              <FilePickerDialog
-                open={filePickerOpen}
-                onOpenChange={setFilePickerOpen}
-                prUrl={prUrl.trim()}
-                onConfirm={(excluded) => {
-                  setFilePickerOpen(false);
-                  void doStartReview(excluded);
-                }}
-              />
-
-              <Dialog open={cliNotFound !== null} onOpenChange={() => setCliNotFound(null)}>
-                <DialogContent className="bg-card sm:max-w-md">
-                  <DialogHeader>
-                    <DialogTitle>
-                      {cliNotFound?.provider === 'claude' ? 'Claude' : 'Gemini'} CLI not found
-                    </DialogTitle>
-                  </DialogHeader>
-                  <div className="flex flex-col gap-3 text-sm text-muted-foreground">
-                    <p>
-                      Gnosis runs reviews against your local{' '}
-                      {cliNotFound?.provider === 'claude' ? 'Claude' : 'Gemini'} CLI, but couldn't find it on
-                      your machine.
-                    </p>
-                    <p>
-                      {cliNotFound?.provider === 'claude'
-                        ? 'Install it from claude.ai/code and authenticate with `claude auth`.'
-                        : 'Install it from github.com/google-gemini/gemini-cli and authenticate.'}
-                    </p>
-                    <p>Already installed? Set the path manually in Settings.</p>
-                  </div>
-                  <div className="flex gap-2 justify-end pt-2">
-                    <Button variant="outline" onClick={() => setCliNotFound(null)}>
-                      Dismiss
-                    </Button>
-                    <Button
-                      onClick={() => {
-                        setCliNotFound(null);
-                        setSettingsOpen(true);
-                      }}
-                    >
-                      Open Settings
-                    </Button>
-                  </div>
-                </DialogContent>
-              </Dialog>
+                  Keyboard shortcuts
+                </button>
+              </div>
             </section>
+          )}
 
-            {/* ── Suggested for you ── PRs GitHub asked the user to
-                review. Each row is one click to fill the URL field
-                AND has an explicit "Generate review →" link. When the
-                list is empty AND the user has never had a pending PR
-                here yet, we render a quiet teaching placeholder so
-                first-timers learn what the section is for. Once they
-                ever have a pending PR, the empty state hides forever
-                so we don't keep teaching returning users. */}
-            {(visiblePendingReviews.length > 0 || !hasEverHadPendingReviews) && (
-              <section className="flex flex-col gap-3">
-                <div className="flex items-baseline justify-between">
-                  <p className="editorial-label">Suggested for you</p>
-                  <div className="flex items-center gap-3 slide-meta">
-                    <span>GitHub asked you to review these</span>
+          {/* ── Above the fold: Lead story + Dispatches sidebar ──
+              Only show when there's actual content: an unread review
+              to feature OR pending dispatches to show. Skip entirely
+              for first-time users with no reviews — the newsroom
+              section handles that case. */}
+          {(latestUnreadGroup || visiblePendingReviews.length > 0) &&
+            !firstRunOpen &&
+            !aboutOpen && (
+            <div className="newspaper-above-fold">
+              {/* Lead story — latest unread review */}
+              <div className="newspaper-lead">
+                {latestUnreadGroup ? (
+                  <>
+                    <span className="newspaper-section">{(() => {
+                      const age = Date.now() - new Date(latestUnreadGroup.latestReview.savedAt).getTime();
+                      if (age < 3_600_000) return 'Breaking';
+                      if (age < 86_400_000) return 'New';
+                      return 'Unread';
+                    })()}</span>
                     <button
                       type="button"
-                      onClick={fetchPendingReviews}
-                      disabled={pendingLoading}
-                      className="hover:text-foreground disabled:opacity-40 transition-colors"
-                      aria-label="Reload pending reviews"
+                      onClick={() => void handleLoadFromHistory(latestUnreadGroup.latestReview.id)}
+                      className="text-left"
                     >
-                      <RefreshCw className={`h-3 w-3 ${pendingLoading ? 'animate-spin' : ''}`} />
+                      <h2 className="newspaper-headline--lead">
+                        {latestUnreadGroup.prTitle}
+                      </h2>
                     </button>
-                  </div>
+                    <p className="newspaper-byline mt-2">
+                      By {latestUnreadGroup.author} · {latestUnreadGroup.repoRef} · {timeAgo(latestUnreadGroup.latestReview.savedAt)}
+                    </p>
+                    <p className="newspaper-lede">
+                      {latestUnreadGroup.latestReview.summary
+                        ?? (latestUnreadGroup.latestReview.riskLevel === 'high'
+                          ? 'Elevated risk — proceed with scrutiny.'
+                          : latestUnreadGroup.latestReview.riskLevel === 'medium'
+                            ? 'Moderate complexity. Worth a careful read.'
+                            : 'A straightforward set of changes.')}
+                    </p>
+                    <div className="flex items-center gap-5 mt-4">
+                      <button
+                        type="button"
+                        onClick={() => void handleLoadFromHistory(latestUnreadGroup.latestReview.id)}
+                        className="text-sm text-[var(--ring)] hover:underline transition-colors"
+                      >
+                        Read the full review →
+                      </button>
+                      {unreadGroups.length > 1 && (
+                        <button
+                          type="button"
+                          onClick={scrollToNextUnread}
+                          className="slide-meta hover:text-foreground transition-colors"
+                        >
+                          + {unreadGroups.length - 1} more unread
+                        </button>
+                      )}
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <span className="newspaper-section">All Clear</span>
+                    <h2 className="newspaper-headline--secondary">
+                      Nothing unread.
+                    </h2>
+                    <p className="newspaper-lede">
+                      No unread reviews on file. Paste a pull request URL below to start a new one.
+                    </p>
+                  </>
+                )}
+              </div>
+
+              {/* Sidebar — dispatches (pending review requests) */}
+              <aside className="newspaper-sidebar">
+                <div className="flex items-baseline justify-between">
+                  <span className="newspaper-section mb-1">Dispatches</span>
+                  <button
+                    type="button"
+                    onClick={fetchPendingReviews}
+                    disabled={pendingLoading}
+                    className="slide-meta hover:text-foreground disabled:opacity-40 transition-colors"
+                    aria-label="Reload pending reviews"
+                  >
+                    <RefreshCw className={`h-3 w-3 ${pendingLoading ? 'animate-spin' : ''}`} />
+                  </button>
                 </div>
                 {visiblePendingReviews.length === 0 ? (
-                  <p className="slide-prose text-sm text-muted-foreground max-w-[68ch]">
-                    Nothing here yet. PRs you're asked to review — or that you open yourself — will appear in
-                    this list.
+                  <p className="text-xs text-muted-foreground leading-relaxed">
+                    {hasEverHadPendingReviews
+                      ? 'No pending reviews right now.'
+                      : 'When someone requests your review on GitHub, it will appear here.'}
                   </p>
                 ) : (
-                  <ul className="flex flex-col">
-                    {visiblePendingReviews.slice(0, 10).map((pr) => (
-                    <li
-                      key={pr.url}
-                      className="group flex items-center gap-4 py-3 border-b border-border/60 hover:bg-muted/30 transition-colors -mx-3 px-3"
-                    >
-                      <button
-                        type="button"
-                        onClick={() => setPrUrl(pr.url)}
-                        className="flex items-baseline gap-3 text-left flex-1 min-w-0"
-                      >
-                        <span className="slide-meta shrink-0">
-                          {pr.repoName}#{pr.number}
-                        </span>
-                        <span className="font-serif text-base truncate text-foreground/85 group-hover:text-foreground transition-colors">
-                          {pr.title}
-                        </span>
-                        <span className="slide-meta truncate hidden md:inline">· {pr.author}</span>
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => void startReviewForUrl(pr.url)}
-                        className="slide-meta opacity-0 group-hover:opacity-100 hover:text-foreground transition-opacity shrink-0"
-                      >
-                        Generate review →
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => dismissPendingPr(pr.url)}
-                        className="shrink-0 text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity"
-                        aria-label="Dismiss"
-                      >
-                        <X className="h-3 w-3" />
-                      </button>
-                    </li>
-                  ))}
-                    {visiblePendingReviews.length > 10 && (
+                  <div className="flex flex-col">
+                    {visiblePendingReviews.slice(0, 8).map((pr) => (
+                      <div key={pr.url} className="newspaper-sidebar-item group">
+                        <button
+                          type="button"
+                          onClick={() => void startReviewForUrl(pr.url)}
+                          className="text-left"
+                        >
+                          <span className="newspaper-sidebar-headline">
+                            {pr.title}
+                          </span>
+                        </button>
+                        <div className="flex items-center justify-between">
+                          <span className="slide-meta">
+                            {pr.repoName}#{pr.number} · {pr.author}
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => dismissPendingPr(pr.url)}
+                            className="shrink-0 text-muted-foreground hover:text-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+                            aria-label="Dismiss"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                    {visiblePendingReviews.length > 8 && (
                       <button
                         type="button"
                         onClick={() => setPrPickerOpen(true)}
-                        className="slide-meta hover:text-foreground py-2 text-left"
+                        className="slide-meta hover:text-foreground pt-2 text-left"
                       >
-                        Show {visiblePendingReviews.length - 10} more…
+                        + {visiblePendingReviews.length - 8} more dispatches…
                       </button>
                     )}
-                  </ul>
+                  </div>
                 )}
-              </section>
-            )}
+              </aside>
+            </div>
+          )}
 
-            {/* ── Empty state ── Actionable teaching note shown when
-                the user has no review history yet. Sits directly
-                under the Suggested-for-you section so it reads as
-                "what to do next" rather than as a footer note. */}
-            {prGroups.length === 0 && (
-              <section className="flex flex-col gap-3 max-w-[68ch]">
-                <p className="editorial-label">No reviews yet.</p>
-                <p className="slide-prose">
-                  Paste a PR URL above and press <span className="editorial-label">Generate review</span>. Your
-                  review takes 2–4 minutes to generate locally — Gnosis spawns the Claude or Gemini CLI you
-                  already have installed and turns the diff into a slide-by-slide walkthrough you can read at
-                  your own pace.
-                </p>
-                <p className="slide-prose">
-                  Once you've generated one, it lives here grouped by pull request, so you can return without
-                  re-running the model. Reviews never leave your machine.
-                </p>
-              </section>
-            )}
+          <hr className="newspaper-rule--thin mt-6" />
 
-            {/* ── Zone 4: Your reviews ── Full-width history list.
-                Unread rows get bold serif titles at a larger size
-                instead of the previous tiny dot. Reviews stay in
-                chronological order; the hero zone above pulls the
-                latest unread out for emphasis. */}
-            {prGroups.length > 0 && (
-              <section className="flex flex-col gap-3">
-                <div className="flex items-baseline justify-between">
-                  <p className="editorial-label">Your reviews</p>
-                  <div className="flex items-center gap-3 slide-meta">
-                    <span>
-                      {prGroups.length} {prGroups.length === 1 ? 'pull request' : 'pull requests'}
-                      {unreadGroups.length > 0 && ` · ${unreadGroups.length} unread`}
-                    </span>
-                    {prGroups.some((g) => {
-                      const state = livePrStates.get(g.prUrl)?.prState ?? g.latestReview.prState;
-                      return state === 'merged' || state === 'closed';
-                    }) && (
-                      <button
-                        onClick={() => void handleDeleteClosedPRs()}
-                        className="hover:text-foreground transition-colors"
-                        title="Remove merged & closed PRs"
-                        aria-label="Remove merged and closed PRs"
-                      >
-                        <Eraser className="h-3.5 w-3.5" />
-                      </button>
-                    )}
-                    <button
-                      onClick={handleDeleteAllHistory}
-                      className="hover:text-foreground transition-colors"
-                      title="Delete all history"
-                      aria-label="Delete all history"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </button>
+          {/* ── The Newsroom: compose form ── */}
+          <section className="newspaper-newsroom">
+            <span className="newspaper-section">
+              {prGroups.length === 0 ? 'Start Your First Review' : 'The Newsroom'}
+            </span>
+            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+              <div className="flex items-end gap-4 flex-wrap">
+                <div className="flex-1 min-w-[280px] flex items-end gap-3">
+                  <input
+                    ref={prInputRef}
+                    id="pr-url"
+                    type="url"
+                    placeholder="Paste a pull request URL — github.com/owner/repo/pull/123"
+                    value={prUrl}
+                    onChange={(e) => setPrUrl(e.target.value)}
+                    className="flex-1 bg-transparent border-0 border-b border-border px-0 py-2.5 text-base placeholder:text-muted-foreground/60 transition-colors"
+                    required
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setPrPickerOpen(true)}
+                    className="slide-meta hover:text-foreground transition-colors pb-2.5"
+                  >
+                    Browse
+                  </button>
+                </div>
+                <Button type="submit" className="gap-2 px-6 py-2.5 h-auto" disabled={submitting}>
+                  {submitting ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Starting review…
+                    </>
+                  ) : (
+                    <>
+                      <Play className="h-4 w-4" />
+                      Generate review
+                    </>
+                  )}
+                </Button>
+              </div>
+
+              {/* Options row */}
+              <div className="flex items-center gap-6 slide-meta">
+                <button
+                  type="button"
+                  onClick={() => setModelMenuExpanded((v) => !v)}
+                  className={`pb-0.5 border-b transition-colors ${
+                    modelMenuExpanded
+                      ? 'text-foreground border-[var(--ring)]'
+                      : 'border-transparent hover:text-foreground'
+                  }`}
+                >
+                  {PROVIDERS[provider].label} ·{' '}
+                  {PROVIDERS[provider].models.find((m) => m.id === model)?.label ?? model}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setInstructionsExpanded((v) => !v)}
+                  className={`pb-0.5 border-b transition-colors ${
+                    instructionsExpanded || instructions
+                      ? 'text-foreground border-[var(--ring)]'
+                      : 'border-transparent hover:text-foreground'
+                  }`}
+                >
+                  {instructions ? 'Instructions' : 'Add instructions'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPrefsExpanded((v) => !v)}
+                  className={`pb-0.5 border-b transition-colors ${
+                    prefsExpanded
+                      ? 'text-foreground border-[var(--ring)]'
+                      : 'border-transparent hover:text-foreground'
+                  }`}
+                >
+                  Preferences
+                </button>
+              </div>
+
+              {!keyboardHintDismissed && (
+                <p className="slide-meta flex items-center gap-2 -mt-1">
+                  <span>
+                    <kbd className="kbd">n</kbd> to focus ·{' '}
+                    <kbd className="kbd">⌘ K</kbd> to search ·{' '}
+                    <kbd className="kbd">?</kbd> for shortcuts
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setKeyboardHintDismissed(true);
+                      try { localStorage.setItem('gnosis-keyboard-hint-dismissed', '1'); } catch { /* non-fatal */ }
+                    }}
+                    className="hover:text-foreground transition-colors"
+                    aria-label="Dismiss keyboard hint"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </p>
+              )}
+
+              {/* Model menu disclosure */}
+              <div className={`grid transition-[grid-template-rows] duration-200 ease-out ${modelMenuExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+                <div className="overflow-hidden">
+                  <div className="flex flex-col gap-3 pt-1 pb-2">
+                    <div className="flex items-center gap-5 slide-meta">
+                      <span className="text-foreground/60">Provider</span>
+                      {(['claude', 'gemini'] as const).map((p) => (
+                        <button
+                          key={p}
+                          type="button"
+                          onClick={() => handleProviderChange(p)}
+                          className={`pb-0.5 border-b transition-colors ${provider === p ? 'text-foreground border-[var(--ring)]' : 'border-transparent hover:text-foreground'}`}
+                        >
+                          {PROVIDERS[p].label}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-x-5 gap-y-2 slide-meta">
+                      <span className="text-foreground/60">Model</span>
+                      {PROVIDERS[provider].models.map((m) => (
+                        <button
+                          key={m.id}
+                          type="button"
+                          onClick={() => setModel(m.id)}
+                          className={`pb-0.5 border-b transition-colors ${model === m.id ? 'text-foreground border-[var(--ring)]' : 'border-transparent hover:text-foreground'}`}
+                        >
+                          {m.label}
+                        </button>
+                      ))}
+                    </div>
                   </div>
                 </div>
-                <ul>
-                  {prGroups.map((group) => {
-                    const latestStatus = getEntryStatus(group.latestReview);
-                    const risk = safeConfigLookup(riskConfig, group.latestReview.riskLevel, riskConfig.low);
-                    const hasMultiple = group.reviews.length > 1;
-                    const isExpanded = expandedPRs.has(group.prUrl);
-                    const isClickable = latestStatus === 'completed';
-                    const latestId = group.latestReview.id;
-                    const elapsed = elapsedSeconds.get(latestId) ?? 0;
-                    const bytes = reviewBytes.get(latestId);
-                    const liveState = livePrStates.get(group.prUrl);
-                    const prState = liveState?.prState ?? group.latestReview.prState;
-                    const isOutdated =
-                      liveState?.prState === 'open' && liveState.headSha !== group.latestReview.prHeadSha;
-                    const isUnread = group.latestReview.unread;
+              </div>
 
-                    return (
-                      <li key={group.prUrl} data-pr-url={group.prUrl}>
-                        <div
-                          className={`flex items-center gap-3 px-1 py-4 border-b border-border/60 hover:bg-muted/30 transition-colors group ${
-                            isClickable ? 'cursor-pointer' : ''
-                          }`}
+              {/* Instructions disclosure */}
+              <div className={`grid transition-[grid-template-rows] duration-200 ease-out ${instructionsExpanded || instructions ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+                <div className="overflow-hidden">
+                  <textarea
+                    id="instructions"
+                    rows={4}
+                    placeholder="What should the reviewer pay special attention to?"
+                    value={instructions}
+                    onChange={(e) => setInstructions(e.target.value)}
+                    onBlur={() => savePrefs()}
+                    className="w-full bg-transparent border-0 border-b border-border px-0 py-2 text-sm placeholder:text-muted-foreground/60 transition-colors resize-none mt-1"
+                  />
+                </div>
+              </div>
+
+              {/* Preferences disclosure */}
+              <div className={`grid transition-[grid-template-rows] duration-200 ease-out ${prefsExpanded ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}`}>
+                <div className="overflow-hidden">
+                  <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-10 gap-y-5 pt-2">
+                    <ToggleSwitch
+                      id="include-all-files"
+                      label="Include all files"
+                      description={includeAllFiles ? 'All changed files included in the review' : 'You will choose which files to include'}
+                      checked={includeAllFiles}
+                      onToggle={() => setIncludeAllFiles((v) => !v)}
+                    />
+                    {provider === 'claude' && (
+                      <ToggleSwitch
+                        id="thinking"
+                        label="Extended thinking"
+                        description="Deeper reasoning before writing. Catches subtle bugs that standard mode misses. Takes longer."
+                        checked={thinking}
+                        onToggle={() => setThinking((t) => !t)}
+                      />
+                    )}
+                    <ToggleSwitch
+                      id="smart-imports"
+                      label="Smart imports"
+                      description="Pull in related files across all languages, not just imports the parser sees"
+                      checked={smartImports}
+                      onToggle={() => setSmartImports((s) => !s)}
+                      badge="Experimental"
+                    />
+                    <ToggleSwitch
+                      id="review-suggestions"
+                      label="Review suggestions"
+                      description="Generate 'What to check' for each slide"
+                      checked={reviewSuggestions}
+                      onToggle={() => setReviewSuggestions((r) => !r)}
+                    />
+                    {provider === 'claude' && (
+                      <ToggleSwitch
+                        id="web-research"
+                        label="Web research"
+                        description="Search for framework docs and best practices (slower)"
+                        checked={webResearch}
+                        onToggle={() => setWebResearch((w) => !w)}
+                      />
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {error && (
+                <Alert variant="destructive">
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+            </form>
+          </section>
+
+          {/* Dialogs (unchanged — just mounted here) */}
+          <PRPickerDialog open={prPickerOpen} onOpenChange={setPrPickerOpen} onSelect={setPrUrl} />
+          <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} onReplayOnboarding={replayOnboarding} />
+          <FilePickerDialog
+            open={filePickerOpen}
+            onOpenChange={setFilePickerOpen}
+            prUrl={prUrl.trim()}
+            onConfirm={(excluded) => { setFilePickerOpen(false); void doStartReview(excluded); }}
+          />
+          <Dialog open={cliNotFound !== null} onOpenChange={() => setCliNotFound(null)}>
+            <DialogContent className="bg-card sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle>{cliNotFound?.provider === 'claude' ? 'Claude' : 'Gemini'} CLI not found</DialogTitle>
+              </DialogHeader>
+              <div className="flex flex-col gap-3 text-sm text-muted-foreground">
+                <p>Gnosis runs reviews against your local {cliNotFound?.provider === 'claude' ? 'Claude' : 'Gemini'} CLI, but couldn't find it on your machine.</p>
+                <p>{cliNotFound?.provider === 'claude' ? 'Install it from claude.ai/code and authenticate with `claude auth`.' : 'Install it from github.com/google-gemini/gemini-cli and authenticate.'}</p>
+                <p>Already installed? Set the path manually in Settings.</p>
+              </div>
+              <div className="flex gap-2 justify-end pt-2">
+                <Button variant="outline" onClick={() => setCliNotFound(null)}>Dismiss</Button>
+                <Button onClick={() => { setCliNotFound(null); setSettingsOpen(true); }}>Open Settings</Button>
+              </div>
+            </DialogContent>
+          </Dialog>
+
+          {/* ── Delete confirmation dialog ── */}
+          <Dialog open={confirmDelete !== null} onOpenChange={() => setConfirmDelete(null)}>
+            <DialogContent className="bg-card sm:max-w-sm">
+              <DialogHeader>
+                <DialogTitle>
+                  {confirmDelete === 'all' ? 'Delete all reviews?' : 'Delete closed PRs?'}
+                </DialogTitle>
+              </DialogHeader>
+              <p className="text-sm text-muted-foreground">
+                {confirmDelete === 'all'
+                  ? `This will permanently delete all ${prGroups.length} reviews. This cannot be undone.`
+                  : 'This will permanently remove reviews for merged and closed pull requests. Open PRs are not affected.'}
+              </p>
+              <div className="flex gap-2 justify-end pt-2">
+                <Button variant="outline" onClick={() => setConfirmDelete(null)}>Cancel</Button>
+                <Button
+                  variant="destructive"
+                  onClick={() => {
+                    if (confirmDelete === 'all') void handleDeleteAllHistory();
+                    else void handleDeleteClosedPRs();
+                    setConfirmDelete(null);
+                  }}
+                >
+                  {confirmDelete === 'all' ? 'Delete all' : 'Delete closed'}
+                </Button>
+              </div>
+            </DialogContent>
+          </Dialog>
+
+          {/* ── Empty state ── Only shown for first-time users.
+              Explains what will appear here and sets expectations. */}
+          {prGroups.length === 0 && (
+            <section className="py-8 max-w-[56ch] mx-auto">
+              <p className="newspaper-section">The Archives</p>
+              <p className="text-sm text-muted-foreground">
+                Your reviews will appear here, grouped by pull request.
+                Each review takes 2–4 minutes to generate and is stored locally on your machine.
+              </p>
+            </section>
+          )}
+
+          {/* ═══════════════════════════════════════════════════════
+              ██  THE ARCHIVES  ██
+              Multi-column newspaper grid. The first article spans
+              full width as a secondary lead; the rest fill a 3-col
+              grid with vertical column rules.
+              ═══════════════════════════════════════════════════════ */}
+          {prGroups.length > 0 && (
+            <section>
+              <div className="flex items-baseline justify-between mb-3">
+                <span className="newspaper-section !mb-0">
+                  The Archives
+                  <span className="font-normal text-muted-foreground ml-2">
+                    {prGroups.length} {prGroups.length === 1 ? 'review' : 'reviews'}
+                    {unreadGroups.length > 0 && ` · ${unreadGroups.length} unread`}
+                  </span>
+                </span>
+                <div className="flex items-center gap-3 slide-meta">
+                  {prGroups.some((g) => {
+                    const state = livePrStates.get(g.prUrl)?.prState ?? g.latestReview.prState;
+                    return state === 'merged' || state === 'closed';
+                  }) && (
+                    <button
+                      onClick={() => setConfirmDelete('closed')}
+                      className="hover:text-foreground transition-colors flex items-center gap-1"
+                      title="Remove merged & closed PRs"
+                    >
+                      <Eraser className="h-3.5 w-3.5" />
+                      <span>Clear closed</span>
+                    </button>
+                  )}
+                  <button
+                    onClick={() => setConfirmDelete('all')}
+                    className="hover:text-foreground transition-colors flex items-center gap-1"
+                    title="Delete all history"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                    <span>Clear all</span>
+                  </button>
+                </div>
+              </div>
+
+              <hr className="newspaper-rule" />
+
+              <div className="newspaper-grid">
+                {prGroups.map((group, idx) => {
+                  const latestStatus = getEntryStatus(group.latestReview);
+                  const risk = safeConfigLookup(riskConfig, group.latestReview.riskLevel, riskConfig.low);
+                  const hasMultiple = group.reviews.length > 1;
+                  const isExpanded = expandedPRs.has(group.prUrl);
+                  const isClickable = latestStatus === 'completed';
+                  const latestId = group.latestReview.id;
+                  const elapsed = elapsedSeconds.get(latestId) ?? 0;
+                  const bytes = reviewBytes.get(latestId);
+                  const liveState = livePrStates.get(group.prUrl);
+                  const prState = liveState?.prState ?? group.latestReview.prState;
+                  const isOutdated =
+                    liveState?.prState === 'open' && liveState.headSha !== group.latestReview.prHeadSha;
+                  const isUnread = group.latestReview.unread;
+
+                  return (
+                    <article
+                      key={group.prUrl}
+                      data-pr-url={group.prUrl}
+                      className={`${idx === 0 ? 'newspaper-article--featured' : 'newspaper-article'} group`}
+                      onClick={() => isClickable && handleLoadFromHistory(latestId)}
+                    >
+                      {/* Headline */}
+                      <button
+                        onClick={() => isClickable && handleLoadFromHistory(latestId)}
+                        className="text-left w-full"
+                        disabled={!isClickable}
+                      >
+                        <h3
+                          className={
+                            idx === 0
+                              ? 'newspaper-article-headline--featured'
+                              : `newspaper-article-headline ${isUnread ? 'newspaper-article-headline--unread' : ''}`
+                          }
                         >
-                          <div className="shrink-0 w-5 flex items-center justify-center">
-                            {hasMultiple && (
-                              <button
-                                onClick={() =>
-                                  setExpandedPRs((prev) => {
-                                    const next = new Set(prev);
-                                    if (next.has(group.prUrl)) next.delete(group.prUrl);
-                                    else next.add(group.prUrl);
-                                    return next;
-                                  })
-                                }
-                                className="p-0.5 text-muted-foreground hover:text-foreground transition-colors"
-                                aria-label={isExpanded ? 'Collapse' : 'Expand'}
-                              >
-                                {isExpanded ? (
-                                  <ChevronDown className="h-3.5 w-3.5" />
-                                ) : (
-                                  <ChevronRight className="h-3.5 w-3.5" />
-                                )}
-                              </button>
-                            )}
-                          </div>
-                          <button
-                            onClick={() => isClickable && handleLoadFromHistory(latestId)}
-                            className={`group/btn flex-1 min-w-0 flex items-center gap-4 text-left ${
-                              !isClickable ? 'cursor-default' : ''
-                            }`}
-                            disabled={!isClickable}
-                          >
-                            <div className="flex-1 min-w-0 flex flex-col gap-0.5">
-                              <span
-                                className={`font-serif truncate group-hover/btn:text-foreground transition-colors ${
-                                  isUnread
-                                    ? 'text-lg font-medium text-foreground leading-snug'
-                                    : 'text-base font-normal text-foreground/75 leading-snug'
-                                }`}
-                              >
-                                {group.prTitle}
-                              </span>
-                              <span className="slide-meta truncate">
-                                {group.repoRef} · {group.author} · {timeAgo(group.latestReview.savedAt)}
-                                {hasMultiple && ` · ${group.reviews.length} reviews`}
-                              </span>
-                              {latestStatus === 'generating' && bytes && bytes.inputBytes > 0 && (
-                                <span className="slide-meta opacity-60">
-                                  ↑{formatBytes(bytes.inputBytes)} ↓{formatBytes(bytes.outputBytes)}
-                                </span>
-                              )}
-                            </div>
-                          </button>
-                          {prState && (
-                            <>
-                              {prState === 'open' && !isOutdated && (
-                                <Badge
-                                  variant="outline"
-                                  className="shrink-0 text-xs border-[var(--color-success)]/35 text-[var(--color-success)]"
-                                >
-                                  <GitPullRequest className="h-3 w-3 mr-1" />
-                                  Open
-                                </Badge>
-                              )}
-                              {prState === 'open' && isOutdated && (
-                                <Badge
-                                  variant="outline"
-                                  className="shrink-0 text-xs border-[var(--color-warning)]/35 text-[var(--color-warning)]"
-                                >
-                                  <AlertTriangle className="h-3 w-3 mr-1" />
-                                  Outdated
-                                </Badge>
-                              )}
-                              {prState === 'merged' && (
-                                <Badge
-                                  variant="outline"
-                                  className="shrink-0 text-xs border-[var(--color-info)]/35 text-[var(--color-info)]"
-                                >
-                                  <GitMerge className="h-3 w-3 mr-1" />
-                                  Merged
-                                </Badge>
-                              )}
-                              {prState === 'closed' && (
-                                <Badge
-                                  variant="outline"
-                                  className="shrink-0 text-xs border-[var(--color-danger)]/35 text-[var(--color-danger)]"
-                                >
-                                  <GitPullRequestClosed className="h-3 w-3 mr-1" />
-                                  Closed
-                                </Badge>
-                              )}
-                            </>
-                          )}
-                          {latestStatus === 'generating' && (
-                            <Badge
-                              variant="outline"
-                              className="shrink-0 text-xs border-[var(--ring)]/40 text-[var(--ring)]"
-                            >
-                              <Loader2 className="h-3 w-3 animate-spin mr-1" />
-                              {reviewPhases.get(latestId) ?? 'Starting'}
-                              {elapsed > 0 && ` · ${formatDuration(elapsed * 1000)}`}
-                            </Badge>
-                          )}
-                          {latestStatus === 'failed' && (
-                            <Badge
-                              variant="outline"
-                              className="shrink-0 text-xs border-[var(--color-danger)]/35 text-[var(--color-danger)] max-w-[200px]"
-                              title={group.latestReview.error ?? 'Failed'}
-                            >
-                              <CircleX className="h-3 w-3 mr-1 shrink-0" />
-                              <span className="truncate">{group.latestReview.error ?? 'Failed'}</span>
-                            </Badge>
-                          )}
-                          {latestStatus === 'completed' && (
-                            <Badge variant="outline" className={`shrink-0 text-xs ${risk.badgeClassName}`}>
-                              {risk.label}
-                            </Badge>
-                          )}
-                          <div className="shrink-0 flex items-center gap-0.5">
-                            {!hasMultiple && latestStatus === 'generating' && (
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  void window.electronAPI.cancelReview(latestId);
-                                }}
-                                className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive transition-opacity px-1"
-                                aria-label="Cancel review"
-                                title="Cancel this review"
-                              >
-                                <X className="h-3.5 w-3.5" />
-                              </button>
-                            )}
-                            {!hasMultiple && latestStatus !== 'generating' && (
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  void window.electronAPI.openReviewPrompt(latestId);
-                                }}
-                                className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-foreground transition-opacity px-1"
-                                aria-label="View prompt"
-                                title="Open the prompt sent to the AI"
-                              >
-                                <FileText className="h-3.5 w-3.5" />
-                              </button>
-                            )}
-                            {!hasMultiple && latestStatus !== 'generating' && (
-                              <button
-                                onClick={(e) => handleDeleteFromHistory(e, latestId)}
-                                className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive transition-opacity px-1"
-                                aria-label="Delete"
-                              >
-                                <Trash2 className="h-3.5 w-3.5" />
-                              </button>
-                            )}
-                          </div>
-                        </div>
+                          {group.prTitle}
+                        </h3>
+                      </button>
 
-                        {hasMultiple && isExpanded && (
-                          <ul className="border-b border-border/60">
-                            {group.reviews.map((review) => {
-                              const reviewStatus = getEntryStatus(review);
-                              const reviewRisk = safeConfigLookup(riskConfig, review.riskLevel, riskConfig.low);
-                              const reviewClickable = reviewStatus === 'completed';
-                              const reviewElapsed = elapsedSeconds.get(review.id) ?? 0;
-                              const reviewBytesEntry = reviewBytes.get(review.id);
-                              return (
-                                <li key={review.id}>
-                                  <button
-                                    onClick={() => reviewClickable && handleLoadFromHistory(review.id)}
-                                    className={`w-full flex items-center gap-3 pl-10 pr-4 py-2 text-left hover:bg-muted/30 transition-colors group/review ${
-                                      !reviewClickable ? 'cursor-default' : ''
-                                    }`}
-                                    disabled={!reviewClickable}
-                                  >
-                                    <div className="flex-1 min-w-0 flex flex-col gap-0.5">
-                                      <span className="text-xs text-muted-foreground truncate">
-                                        {review.model ? (MODEL_LABELS[review.model] ?? review.model) : 'Unknown'}
-                                        {review.generationDurationMs != null &&
-                                          ` · ${formatDuration(review.generationDurationMs)}`}
-                                        {' · '}
-                                        {timeAgo(review.savedAt)}
-                                      </span>
-                                      {reviewStatus === 'generating' &&
-                                        reviewBytesEntry &&
-                                        reviewBytesEntry.inputBytes > 0 && (
-                                          <span className="text-xs text-muted-foreground/60 truncate">
-                                            ↑{formatBytes(reviewBytesEntry.inputBytes)} ↓
-                                            {formatBytes(reviewBytesEntry.outputBytes)}
-                                          </span>
-                                        )}
-                                    </div>
-                                    {reviewStatus === 'generating' && (
-                                      <Badge
-                                        variant="outline"
-                                        className="shrink-0 text-xs border-[var(--ring)]/40 text-[var(--ring)]"
-                                      >
-                                        <Loader2 className="h-3 w-3 animate-spin mr-1" />
-                                        {reviewPhases.get(review.id) ?? 'Starting'}
-                                        {reviewElapsed > 0 && ` · ${formatDuration(reviewElapsed * 1000)}`}
-                                      </Badge>
-                                    )}
-                                    {reviewStatus === 'failed' && (
-                                      <Badge
-                                        variant="outline"
-                                        className="shrink-0 text-xs border-[var(--color-danger)]/35 text-[var(--color-danger)] max-w-[200px]"
-                                        title={review.error ?? 'Failed'}
-                                      >
-                                        <CircleX className="h-3 w-3 mr-1 shrink-0" />
-                                        <span className="truncate">{review.error ?? 'Failed'}</span>
-                                      </Badge>
-                                    )}
-                                    {reviewStatus === 'completed' && (
-                                      <Badge
-                                        variant="outline"
-                                        className={`shrink-0 text-xs ${reviewRisk.badgeClassName}`}
-                                      >
-                                        {reviewRisk.label}
-                                      </Badge>
-                                    )}
-                                    {reviewStatus === 'generating' && (
-                                      <button
-                                        onClick={(e) => {
-                                          e.stopPropagation();
-                                          void window.electronAPI.cancelReview(review.id);
-                                        }}
-                                        className="shrink-0 opacity-0 group-hover/review:opacity-100 text-muted-foreground hover:text-destructive transition-opacity px-1"
-                                        aria-label="Cancel review"
-                                        title="Cancel this review"
-                                      >
-                                        <X className="h-3.5 w-3.5" />
-                                      </button>
-                                    )}
-                                    {reviewStatus !== 'generating' && (
-                                      <button
-                                        onClick={(e) => {
-                                          e.stopPropagation();
-                                          void window.electronAPI.openReviewPrompt(review.id);
-                                        }}
-                                        className="shrink-0 opacity-0 group-hover/review:opacity-100 text-muted-foreground hover:text-foreground transition-opacity px-1"
-                                        aria-label="View prompt"
-                                        title="Open the prompt sent to the AI"
-                                      >
-                                        <FileText className="h-3.5 w-3.5" />
-                                      </button>
-                                    )}
-                                    {reviewStatus !== 'generating' && (
-                                      <button
-                                        onClick={(e) => handleDeleteFromHistory(e, review.id)}
-                                        className="shrink-0 opacity-0 group-hover/review:opacity-100 text-muted-foreground hover:text-destructive transition-opacity px-1"
-                                        aria-label="Delete"
-                                      >
-                                        <Trash2 className="h-3.5 w-3.5" />
-                                      </button>
-                                    )}
-                                  </button>
-                                </li>
-                              );
-                            })}
-                          </ul>
+                      {/* Byline & meta */}
+                      <p className="newspaper-article-meta">
+                        {group.repoRef} · {group.author} · {timeAgo(group.latestReview.savedAt)}
+                        {hasMultiple && ` · ${group.reviews.length} reviews`}
+                      </p>
+
+                      {/* Article lede — the AI summary, truncated */}
+                      {group.latestReview.summary && (
+                        <p className="newspaper-article-lede">
+                          {group.latestReview.summary}
+                        </p>
+                      )}
+
+                      {/* Status badges */}
+                      <div className="flex items-center gap-2 mt-2 flex-wrap">
+                        {prState === 'open' && !isOutdated && (
+                          <Badge variant="outline" className="text-[10px] border-[var(--color-success)]/35 text-[var(--color-success)]">
+                            <GitPullRequest className="h-2.5 w-2.5 mr-0.5" /> Open
+                          </Badge>
                         )}
-                      </li>
-                    );
-                  })}
-                </ul>
-              </section>
-            )}
+                        {prState === 'open' && isOutdated && (
+                          <Badge variant="outline" className="text-[10px] border-[var(--color-warning)]/35 text-[var(--color-warning)]">
+                            <AlertTriangle className="h-2.5 w-2.5 mr-0.5" /> Outdated
+                          </Badge>
+                        )}
+                        {prState === 'merged' && (
+                          <Badge variant="outline" className="text-[10px] border-[var(--color-info)]/35 text-[var(--color-info)]">
+                            <GitMerge className="h-2.5 w-2.5 mr-0.5" /> Merged
+                          </Badge>
+                        )}
+                        {prState === 'closed' && (
+                          <Badge variant="outline" className="text-[10px] border-[var(--color-danger)]/35 text-[var(--color-danger)]">
+                            <GitPullRequestClosed className="h-2.5 w-2.5 mr-0.5" /> Closed
+                          </Badge>
+                        )}
+                        {latestStatus === 'generating' && (
+                          <Badge variant="outline" className="text-[10px] border-[var(--ring)]/40 text-[var(--ring)]">
+                            <Loader2 className="h-2.5 w-2.5 animate-spin mr-0.5" />
+                            {reviewPhases.get(latestId) ?? 'Starting'}
+                            {elapsed > 0 && ` · ${formatDuration(elapsed * 1000)}`}
+                          </Badge>
+                        )}
+                        {latestStatus === 'failed' && (
+                          <Badge variant="outline" className="text-[10px] border-[var(--color-danger)]/35 text-[var(--color-danger)] max-w-[180px]">
+                            <CircleX className="h-2.5 w-2.5 mr-0.5 shrink-0" />
+                            <span className="truncate">{group.latestReview.error ?? 'Failed'}</span>
+                          </Badge>
+                        )}
+                        {latestStatus === 'completed' && (
+                          <Badge variant="outline" className={`text-[10px] ${risk.badgeClassName}`}>
+                            {risk.label}
+                          </Badge>
+                        )}
+                      </div>
 
-          </>
-        )}
-      </div>
+                      {/* Byte stats for generating reviews */}
+                      {latestStatus === 'generating' && bytes && bytes.inputBytes > 0 && (
+                        <p className="slide-meta opacity-60 mt-1">
+                          ↑{formatBytes(bytes.inputBytes)} ↓{formatBytes(bytes.outputBytes)}
+                        </p>
+                      )}
+
+                      {/* Action row — visible on hover */}
+                      <div className="flex items-center gap-1 mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                        {latestStatus === 'generating' && (
+                          <button
+                            onClick={(e) => { e.stopPropagation(); void window.electronAPI.cancelReview(latestId); }}
+                            className="slide-meta hover:text-destructive transition-colors"
+                            title="Cancel"
+                          >
+                            Cancel
+                          </button>
+                        )}
+                        {latestStatus !== 'generating' && (
+                          <>
+                            <button
+                              onClick={(e) => { e.stopPropagation(); void window.electronAPI.openReviewPrompt(latestId); }}
+                              className="text-muted-foreground hover:text-foreground transition-colors"
+                              title="View prompt"
+                            >
+                              <FileText className="h-3 w-3" />
+                            </button>
+                            <button
+                              onClick={(e) => handleDeleteFromHistory(e, latestId)}
+                              className="text-muted-foreground hover:text-destructive transition-colors"
+                              title="Delete"
+                            >
+                              <Trash2 className="h-3 w-3" />
+                            </button>
+                          </>
+                        )}
+                        {hasMultiple && (
+                          <button
+                            onClick={() =>
+                              setExpandedPRs((prev) => {
+                                const next = new Set(prev);
+                                if (next.has(group.prUrl)) next.delete(group.prUrl);
+                                else next.add(group.prUrl);
+                                return next;
+                              })
+                            }
+                            className="slide-meta hover:text-foreground transition-colors ml-auto"
+                          >
+                            {isExpanded ? 'Hide' : `${group.reviews.length} reviews`}
+                          </button>
+                        )}
+                      </div>
+
+                      {/* Expanded sub-reviews */}
+                      {hasMultiple && isExpanded && (
+                        <div className="mt-2 pt-2 border-t border-border/40 flex flex-col gap-1">
+                          {group.reviews.map((review) => {
+                            const reviewStatus = getEntryStatus(review);
+                            const reviewRisk = safeConfigLookup(riskConfig, review.riskLevel, riskConfig.low);
+                            const reviewClickable = reviewStatus === 'completed';
+                            const reviewElapsed = elapsedSeconds.get(review.id) ?? 0;
+                            return (
+                              <button
+                                key={review.id}
+                                onClick={() => reviewClickable && handleLoadFromHistory(review.id)}
+                                className={`flex items-center justify-between gap-2 py-1 text-left group/review ${!reviewClickable ? 'cursor-default' : 'hover:text-foreground'}`}
+                                disabled={!reviewClickable}
+                              >
+                                <span className="slide-meta truncate">
+                                  {review.model ? (MODEL_LABELS[review.model] ?? review.model) : 'Unknown'}
+                                  {review.generationDurationMs != null && ` · ${formatDuration(review.generationDurationMs)}`}
+                                  {' · '}{timeAgo(review.savedAt)}
+                                </span>
+                                <div className="flex items-center gap-1 shrink-0">
+                                  {reviewStatus === 'generating' && (
+                                    <Badge variant="outline" className="text-[10px] border-[var(--ring)]/40 text-[var(--ring)]">
+                                      <Loader2 className="h-2.5 w-2.5 animate-spin mr-0.5" />
+                                      {reviewPhases.get(review.id) ?? 'Starting'}
+                                      {reviewElapsed > 0 && ` · ${formatDuration(reviewElapsed * 1000)}`}
+                                    </Badge>
+                                  )}
+                                  {reviewStatus === 'completed' && (
+                                    <Badge variant="outline" className={`text-[10px] ${reviewRisk.badgeClassName}`}>
+                                      {reviewRisk.label}
+                                    </Badge>
+                                  )}
+                                  {reviewStatus === 'failed' && (
+                                    <Badge variant="outline" className="text-[10px] border-[var(--color-danger)]/35 text-[var(--color-danger)]">
+                                      <CircleX className="h-2.5 w-2.5 mr-0.5" /> Failed
+                                    </Badge>
+                                  )}
+                                  <button
+                                    onClick={(e) => handleDeleteFromHistory(e, review.id)}
+                                    className="shrink-0 opacity-0 group-hover/review:opacity-100 text-muted-foreground hover:text-destructive transition-opacity"
+                                    aria-label="Delete"
+                                  >
+                                    <Trash2 className="h-3 w-3" />
+                                  </button>
+                                </div>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </article>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          {/* ── Newspaper footer ── */}
+          <hr className="newspaper-rule--double mt-8" />
+          <div className="newspaper-footer">
+            <button onClick={() => { setAboutOpen(true); window.scrollTo({ top: 0, behavior: 'smooth' }); }}>
+              About
+            </button>
+            <button onClick={() => setShortcutsOpen(true)}>Shortcuts</button>
+            <button onClick={() => setSettingsOpen(true)}>Settings</button>
+            <button onClick={handleSignOut}>Sign Out</button>
+          </div>
+        </div>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Redesigns the homepage as a broadsheet newspaper front page with masthead, lead story, dispatches sidebar, and multi-column archives grid
- Stores AI summary in the review index so each archive article shows a lede excerpt
- Polished through five design skill passes: `/critique`, `/typeset`, `/clarify`, `/onboard`, `/arrange`

## What it looks like

**Masthead**: Centered "GNOSIS" with Oxford double rules, edition number, dateline, and user avatar

**Above the fold**: Latest unread review as a lead story (with time-gated labels: Breaking → New → Unread) alongside a dispatches sidebar for pending review requests

**The Newsroom**: Compose form with progressive disclosure for model, instructions, and preferences

**The Archives**: Three-column grid with column rules. First article spans full width as a featured piece. Article ledes (AI summaries) clamped to 3 lines in grid, shown in full for the featured article.

## Design passes applied
- **`/critique`**: Identified 5 priority issues (28/40 heuristics score, 20/25 anti-pattern scan)
- **`/typeset`**: Tightened masthead, clarified headline scale (four clean tiers), bumped lede readability, added hover states
- **`/clarify`**: Dropped forced metaphors (correspondent, classified, Gazette, editions), made error messages actionable, specific delete button labels, toggle descriptions in sans-serif
- **`/onboard`**: Welcome hero now auto-focuses input on dismiss, above-the-fold hidden for first-time users, example URL in placeholder, improved empty states
- **`/arrange`**: Eliminated all inline styles, consolidated spacing into CSS, fixed vertical rhythm, simplified featured article layout, fixed sidebar hover layout shift

## Test plan
- [ ] First-time user flow: sign in → welcome hero → dismiss → PR input is focused, above-the-fold is hidden
- [ ] Returning user with unread: lead story shows with correct time-gated label
- [ ] Generate a new review: summary appears as article lede in the archives grid
- [ ] Old reviews: summaries backfilled from full JSON on first load
- [ ] Delete confirmation: "Clear all" and "Clear closed" show confirmation dialogs
- [ ] Responsive: 3-col → 2-col → 1-col grid, sidebar stacks on mobile
- [ ] Dark mode: all newspaper borders, hovers, and rules render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)