### PR TITLE
feat: parallel review generation + improved onboarding

### DIFF
--- a/components/OnboardingRepoSetup.tsx
+++ b/components/OnboardingRepoSetup.tsx
@@ -53,12 +53,20 @@ export function OnboardingRepoSetup({ open, onComplete, onSkip }: Props) {
         onEscapeKeyDown={(e) => e.preventDefault()}
       >
         <DialogHeader>
-          <DialogTitle>Watch repos for automatic reviews</DialogTitle>
+          <DialogTitle>Welcome to Gnosis</DialogTitle>
         </DialogHeader>
 
-        <p className="text-sm text-muted-foreground">
-          Gnosis can automatically review every open PR in repos you pick. You'll get reviews without pasting a single URL.
-        </p>
+        <div className="flex flex-col gap-2 text-sm text-muted-foreground">
+          <p>
+            Pick repos to watch and Gnosis will automatically review every open PR — no URL pasting needed.
+          </p>
+          <p>
+            Each review becomes a guided walkthrough: diffs grouped by theme, ordered by dependency, with a short narrative on every slide explaining <em>why</em> the change is there.
+          </p>
+          <p>
+            Reviews refresh when PRs update and you'll get a notification when they're ready.
+          </p>
+        </div>
 
         {/* Search input */}
         <div className="relative">

--- a/components/OnboardingRepoSetup.tsx
+++ b/components/OnboardingRepoSetup.tsx
@@ -1,0 +1,155 @@
+import { useState, useRef, useCallback } from 'react';
+import { X, Search, Eye } from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import type { RepoSearchResult } from '../lib/types';
+
+interface Props {
+  open: boolean;
+  onComplete: (repos: string[]) => void;
+  onSkip: () => void;
+}
+
+export function OnboardingRepoSetup({ open, onComplete, onSkip }: Props) {
+  const [query, setQuery] = useState('');
+  const [suggestions, setSuggestions] = useState<RepoSearchResult[]>([]);
+  const [selectedRepos, setSelectedRepos] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const search = useCallback((q: string) => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (q.trim().length < 2) {
+      setSuggestions([]);
+      return;
+    }
+    setLoading(true);
+    debounceRef.current = setTimeout(() => {
+      void window.electronAPI.searchRepos(q.trim()).then((results) => {
+        setSuggestions(results.filter((r) => !selectedRepos.includes(r.fullName)));
+        setLoading(false);
+      });
+    }, 300);
+  }, [selectedRepos]);
+
+  function addRepo(fullName: string) {
+    setSelectedRepos((prev) => prev.includes(fullName) ? prev : [...prev, fullName]);
+    setQuery('');
+    setSuggestions([]);
+    inputRef.current?.focus();
+  }
+
+  function removeRepo(fullName: string) {
+    setSelectedRepos((prev) => prev.filter((r) => r !== fullName));
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={() => {}}>
+      <DialogContent
+        className="bg-card sm:max-w-md"
+        showCloseButton={false}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>Watch repos for automatic reviews</DialogTitle>
+        </DialogHeader>
+
+        <p className="text-sm text-muted-foreground">
+          Gnosis can automatically review every open PR in repos you pick. You'll get reviews without pasting a single URL.
+        </p>
+
+        {/* Search input */}
+        <div className="relative">
+          <div className="flex items-center gap-2 border-b border-border">
+            <Search className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              placeholder="Search for a repo..."
+              onChange={(e) => {
+                setQuery(e.target.value);
+                search(e.target.value);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && query.includes('/')) {
+                  e.preventDefault();
+                  addRepo(query.trim());
+                }
+              }}
+              className="flex-1 bg-transparent border-0 px-0 py-2 text-sm text-foreground placeholder:text-muted-foreground/60 outline-none"
+              autoFocus
+            />
+          </div>
+
+          {/* Suggestions dropdown */}
+          {suggestions.length > 0 && (
+            <ul className="absolute z-50 top-full left-0 right-0 mt-1 bg-popover border border-border rounded-md shadow-md max-h-48 overflow-y-auto">
+              {suggestions.map((repo) => (
+                <li key={repo.fullName}>
+                  <button
+                    type="button"
+                    className="w-full text-left px-3 py-2 text-sm hover:bg-accent transition-colors flex flex-col gap-0.5"
+                    onMouseDown={(e) => { e.preventDefault(); addRepo(repo.fullName); }}
+                  >
+                    <span className="font-mono text-xs text-foreground">{repo.fullName}</span>
+                    {repo.description && (
+                      <span className="text-xs text-muted-foreground truncate">{repo.description}</span>
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {loading && query.length >= 2 && suggestions.length === 0 && (
+            <p className="text-xs text-muted-foreground mt-2">Searching...</p>
+          )}
+        </div>
+
+        {/* Selected repos */}
+        {selectedRepos.length > 0 && (
+          <div className="flex flex-wrap gap-2 mt-1">
+            {selectedRepos.map((repo) => (
+              <span
+                key={repo}
+                className="inline-flex items-center gap-1 px-2 py-1 text-xs font-mono bg-accent rounded-md text-foreground"
+              >
+                <Eye className="h-3 w-3 text-muted-foreground" />
+                {repo}
+                <button
+                  type="button"
+                  onClick={() => removeRepo(repo)}
+                  className="ml-0.5 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex gap-2 justify-end pt-2">
+          <Button variant="outline" onClick={onSkip}>
+            Skip for now
+          </Button>
+          <Button
+            onClick={() => onComplete(selectedRepos)}
+            disabled={selectedRepos.length === 0}
+          >
+            {selectedRepos.length > 0
+              ? `Watch ${selectedRepos.length} repo${selectedRepos.length > 1 ? 's' : ''}`
+              : 'Select repos to watch'}
+          </Button>
+        </div>
+
+        <p className="text-xs text-muted-foreground text-center">
+          You can change this anytime in Settings.
+        </p>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/OnboardingRepoSetup.tsx
+++ b/components/OnboardingRepoSetup.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { X, Search, Eye } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
@@ -10,6 +10,8 @@ interface Props {
   onSkip: () => void;
 }
 
+const REPO_REF_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
 export function OnboardingRepoSetup({ open, onComplete, onSkip }: Props) {
   const [query, setQuery] = useState('');
   const [suggestions, setSuggestions] = useState<RepoSearchResult[]>([]);
@@ -17,23 +19,49 @@ export function OnboardingRepoSetup({ open, onComplete, onSkip }: Props) {
   const [loading, setLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const requestIdRef = useRef(0);
+
+  // Reset state when the dialog is reopened
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setSuggestions([]);
+      setSelectedRepos([]);
+      setLoading(false);
+    }
+  }, [open]);
+
+  // Cleanup debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
 
   const search = useCallback((q: string) => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     if (q.trim().length < 2) {
       setSuggestions([]);
+      setLoading(false);
       return;
     }
     setLoading(true);
-    debounceRef.current = setTimeout(() => {
-      void window.electronAPI.searchRepos(q.trim()).then((results) => {
+    const reqId = ++requestIdRef.current;
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const results = await window.electronAPI.searchRepos(q.trim());
+        if (reqId !== requestIdRef.current) return; // stale
         setSuggestions(results.filter((r) => !selectedRepos.includes(r.fullName)));
-        setLoading(false);
-      });
+      } catch {
+        if (reqId === requestIdRef.current) setSuggestions([]);
+      } finally {
+        if (reqId === requestIdRef.current) setLoading(false);
+      }
     }, 300);
   }, [selectedRepos]);
 
   function addRepo(fullName: string) {
+    if (!REPO_REF_RE.test(fullName)) return;
     setSelectedRepos((prev) => prev.includes(fullName) ? prev : [...prev, fullName]);
     setQuery('');
     setSuggestions([]);
@@ -58,7 +86,7 @@ export function OnboardingRepoSetup({ open, onComplete, onSkip }: Props) {
 
         <div className="flex flex-col gap-2 text-sm text-muted-foreground">
           <p>
-            Pick repos to watch and Gnosis will automatically review every open PR — no URL pasting needed.
+            Pick repos to watch and Gnosis will automatically review recently updated open PRs — no URL pasting needed.
           </p>
           <p>
             Each review becomes a guided walkthrough: diffs grouped by theme, ordered by dependency, with a short narrative on every slide explaining <em>why</em> the change is there.
@@ -82,7 +110,7 @@ export function OnboardingRepoSetup({ open, onComplete, onSkip }: Props) {
                 search(e.target.value);
               }}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && query.includes('/')) {
+                if (e.key === 'Enter' && REPO_REF_RE.test(query.trim())) {
                   e.preventDefault();
                   addRepo(query.trim());
                 }

--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -119,6 +119,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
   const [notifications, setNotifications] = useState(true);
   const [trayEnabled, setTrayEnabled] = useState(true);
   const [maxPrsPerRepo, setMaxPrsPerRepo] = useState(10);
+  const [parallelReview, setParallelReview] = useState(false);
   const [claudePath, setClaudePath] = useState('');
   const [geminiPath, setGeminiPath] = useState('');
   const [claudeDetected, setClaudeDetected] = useState('');
@@ -139,6 +140,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
       setNotifications(prefs.notifications);
       setTrayEnabled(prefs.trayEnabled);
       setMaxPrsPerRepo(prefs.maxPrsPerRepo);
+      setParallelReview(prefs.parallelReview);
       setClaudePath(prefs.claudePath || '');
       setGeminiPath(prefs.geminiPath || '');
     });
@@ -238,6 +240,21 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
                   const next = !enableTools;
                   setEnableTools(next);
                   saveField({ enableTools: next });
+                }}
+              />
+            </SettingRow>
+
+            <SettingRow
+              label="Parallel review"
+              description="Split generation into a planner step then parallel writers per topic. Faster for large PRs."
+            >
+              <Toggle
+                checked={parallelReview}
+                ariaLabel="Parallel review"
+                onChange={() => {
+                  const next = !parallelReview;
+                  setParallelReview(next);
+                  saveField({ parallelReview: next });
                 }}
               />
             </SettingRow>

--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -118,6 +118,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [notifications, setNotifications] = useState(true);
   const [trayEnabled, setTrayEnabled] = useState(true);
+  const [maxPrsPerRepo, setMaxPrsPerRepo] = useState(10);
   const [claudePath, setClaudePath] = useState('');
   const [geminiPath, setGeminiPath] = useState('');
   const [claudeDetected, setClaudeDetected] = useState('');
@@ -137,6 +138,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
       setWatchedRepos(prefs.watchedRepos ?? []);
       setNotifications(prefs.notifications);
       setTrayEnabled(prefs.trayEnabled);
+      setMaxPrsPerRepo(prefs.maxPrsPerRepo);
       setClaudePath(prefs.claudePath || '');
       setGeminiPath(prefs.geminiPath || '');
     });
@@ -334,6 +336,27 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
                     ))}
                   </ul>
                 )}
+              <div className="flex items-center justify-between gap-4 mt-2">
+                <div className="flex flex-col gap-0.5">
+                  <label className="text-sm font-medium text-foreground">Max PRs per repo</label>
+                  <p className="text-xs text-muted-foreground">
+                    How many of the latest open PRs to review per watched repo.
+                  </p>
+                </div>
+                <select
+                  value={maxPrsPerRepo}
+                  onChange={(e) => {
+                    const next = Number(e.target.value);
+                    setMaxPrsPerRepo(next);
+                    saveField({ maxPrsPerRepo: next });
+                  }}
+                  className="bg-transparent border border-border rounded-md px-2 py-1 text-sm text-foreground"
+                >
+                  {[5, 10, 15, 20, 30, 50].map((n) => (
+                    <option key={n} value={n}>{n}</option>
+                  ))}
+                </select>
+              </div>
               </div>
             )}
 

--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -357,7 +357,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
                 <div className="flex flex-col gap-0.5">
                   <label className="text-sm font-medium text-foreground">Max PRs per repo</label>
                   <p className="text-xs text-muted-foreground">
-                    How many of the latest open PRs to review per watched repo.
+                    How many recently updated open PRs to review per watched repo.
                   </p>
                 </div>
                 <select

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -438,26 +438,37 @@ export async function generateSlide(
 
   const userMessage = topicContext + WRITER_USER_SUFFIX;
 
-  const fullText = await provider.generate({
-    content: userMessage,
-    systemPrompt: system,
-    model,
-    thinking,
-    onChunk,
-    signal,
-  });
+  async function attempt(extra: string = ''): Promise<WriterSlideOutput> {
+    const fullText = await provider.generate({
+      content: userMessage + extra,
+      systemPrompt: system,
+      model,
+      thinking,
+      onChunk,
+      signal,
+    });
 
-  const jsonText = extractJson(fullText);
-  let parsed: unknown;
+    const jsonText = extractJson(fullText);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonText);
+    } catch (err) {
+      throw new Error(`Writer JSON parse failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    if (!validateWriterOutput(parsed)) {
+      throw new Error('Writer response missing required fields (narrative)');
+    }
+
+    return parsed;
+  }
+
   try {
-    parsed = JSON.parse(jsonText);
+    return await attempt();
   } catch (err) {
-    throw new Error(`Writer JSON parse failed: ${err instanceof Error ? err.message : String(err)}`);
+    const msg = err instanceof Error ? err.message : '';
+    if (msg.includes('rate limit') || msg.includes('prompt is too long')) throw err;
+    console.warn(`[writer] First attempt failed (${msg}), retrying concisely`);
+    return await attempt('\n\nIMPORTANT: Return only raw JSON starting with { and ending with }. Keep narrative under 3 sentences. No markdown fences.');
   }
-
-  if (!validateWriterOutput(parsed)) {
-    throw new Error('Writer response missing required fields (narrative)');
-  }
-
-  return parsed;
 }

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -437,6 +437,7 @@ export async function generateSlide(
   }
 
   const userMessage = topicContext + WRITER_USER_SUFFIX;
+  console.log(`[writer] Starting ${providerName} (${model}) with ${userMessage.length} chars`);
 
   async function attempt(extra: string = ''): Promise<WriterSlideOutput> {
     const fullText = await provider.generate({

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -283,6 +283,10 @@ GROUPING: Group hunks that are logically related and should be understood togeth
 - Refactoring and its tests are separate topics
 - Trivial changes (whitespace, imports, formatting) should be merged into a single "Minor changes" topic at the end, or omitted entirely
 
+STORY ARC: Write a 2-3 sentence narrative thread that connects all topics into a coherent story. This tells each slide writer how their topic fits into the bigger picture. Example: "This PR migrates the auth layer from session cookies to JWT tokens. The foundation is a new Token type and validation middleware, which the route handlers then adopt, followed by test updates."
+
+NARRATIVE BRIEF per topic: Write a 1-2 sentence direction for each topic's slide writer. Explain what angle to take, what to emphasize, and how this topic relates to others. Example: "This introduces the core Token type that all subsequent auth changes depend on. Emphasize the design choices in the token structure and expiry handling."
+
 RISK: Assess based on: auth/payment/data model changes = high; new features with tests = medium; refactoring with coverage = low; docs/config = low.
 
 IMPORTANCE per topic:
@@ -301,6 +305,7 @@ Respond with JSON matching this schema exactly:
   "summary": string,
   "riskLevel": "low" | "medium" | "high",
   "riskRationale": string,
+  "storyArc": string,
   "topics": [
     {
       "title": string,
@@ -308,7 +313,8 @@ Respond with JSON matching this schema exactly:
       "importance": "critical" | "important" | "minor",
       "hunkIds": ["hunk-0", "hunk-3", ...],
       "dependsOn": [],
-      "order": 1
+      "order": 1,
+      "narrativeBrief": string
     }
   ]
 }`;
@@ -363,12 +369,16 @@ export async function planReview(
 
 // ── Writer: generates a single slide for one topic ──────────────
 
-const WRITER_SYSTEM = `You are an expert code reviewer writing one slide of a guided code review. You are given a specific topic with its relevant diff hunks and file contents. Write a clear, focused narrative explaining WHY this changed and what the reviewer should pay attention to.
+const WRITER_SYSTEM = `You are an expert code reviewer writing one slide of a guided code review. You are given a specific topic with its relevant diff hunks, file contents, and narrative direction from the review planner.
+
+CONTEXT: You are writing ONE slide in a multi-slide review. The <story_arc> tells you the overall PR narrative. The <narrative_brief> tells you what angle to take for THIS slide. Follow these directions to maintain consistency across slides.
 
 NARRATIVE: 2–4 short paragraphs. Lead with motivation, explain what changed, note anything non-obvious.
 - Short sentences. Plain words. One idea per sentence.
 - Use **bold** for emphasis, \`backticks\` for code symbols, markdown lists where helpful
 - No headings — just bold, lists, inline code
+- Reference how this topic connects to the broader PR story when relevant
+- If this topic depends on earlier topics, briefly acknowledge what was established (e.g., "Building on the Token type introduced earlier...")
 
 REVIEW FOCUS: 2–4 actionable checks as a markdown bullet list. Focus on what could go wrong.
 

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -1,5 +1,5 @@
 import { getProvider } from './provider';
-import type { AIReviewGuide, ModelId, Provider } from './types';
+import type { AIReviewGuide, ModelId, PlannerOutput, Provider, WriterSlideOutput } from './types';
 
 // ── System prompt & schema constants ─────────────────────────────
 
@@ -269,4 +269,185 @@ export async function generateReviewGuide(
       );
     }
   }
+}
+
+// ── Two-phase generation: Planner + Writers ──────────────────────
+
+const PLANNER_SYSTEM = `You are a code review architect. Given a pull request's metadata and its diff hunk index, your job is to plan the review structure — grouping related hunks into logical topics and ordering them for optimal understanding.
+
+ORDERING: Foundations first (types, interfaces, schemas) → implementations → consumers → tests → config/docs.
+
+GROUPING: Group hunks that are logically related and should be understood together.
+- A change to an interface and its implementation belong in the same topic
+- Unrelated changes to the same file should be in different topics
+- Refactoring and its tests are separate topics
+- Trivial changes (whitespace, imports, formatting) should be merged into a single "Minor changes" topic at the end, or omitted entirely
+
+RISK: Assess based on: auth/payment/data model changes = high; new features with tests = medium; refactoring with coverage = low; docs/config = low.
+
+IMPORTANCE per topic:
+- "critical" = auth, security, data integrity, public API contracts, payment/billing
+- "important" = core logic, new features, significant refactors, error handling
+- "minor" = config, docs, test boilerplate, import reordering, whitespace
+
+Respond with valid JSON only. No explanation outside the JSON.`;
+
+const PLANNER_USER_SUFFIX = `
+
+Plan the review structure for this pull request. Group the hunks into logical topics and order them for optimal review flow.
+
+Respond with JSON matching this schema exactly:
+{
+  "summary": string,
+  "riskLevel": "low" | "medium" | "high",
+  "riskRationale": string,
+  "topics": [
+    {
+      "title": string,
+      "slideType": "foundation" | "feature" | "refactor" | "bugfix" | "test" | "config" | "docs",
+      "importance": "critical" | "important" | "minor",
+      "hunkIds": ["hunk-0", "hunk-3", ...],
+      "dependsOn": [],
+      "order": 1
+    }
+  ]
+}`;
+
+function validatePlannerOutput(obj: unknown): obj is PlannerOutput {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return (
+    typeof o.summary === 'string' &&
+    typeof o.riskLevel === 'string' &&
+    Array.isArray(o.topics) &&
+    o.topics.length > 0
+  );
+}
+
+export async function planReview(
+  hunkIndex: string,
+  prMetadata: string,
+  providerName: Provider,
+  model: ModelId,
+  onChunk?: (chunk: string, isThinking: boolean) => void,
+  thinking: boolean = false,
+  signal?: AbortSignal
+): Promise<PlannerOutput> {
+  const provider = getProvider(providerName);
+  const userMessage = prMetadata + '\n' + hunkIndex + PLANNER_USER_SUFFIX;
+
+  console.log(`[planner] Calling ${providerName} (${model}) with ${userMessage.length} chars...`);
+  const fullText = await provider.generate({
+    content: userMessage,
+    systemPrompt: PLANNER_SYSTEM,
+    model,
+    thinking,
+    onChunk,
+    signal,
+  });
+
+  const jsonText = extractJson(fullText);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (err) {
+    throw new Error(`Planner JSON parse failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  if (!validatePlannerOutput(parsed)) {
+    throw new Error('Planner response missing required fields (summary, riskLevel, topics)');
+  }
+
+  return parsed;
+}
+
+// ── Writer: generates a single slide for one topic ──────────────
+
+const WRITER_SYSTEM = `You are an expert code reviewer writing one slide of a guided code review. You are given a specific topic with its relevant diff hunks and file contents. Write a clear, focused narrative explaining WHY this changed and what the reviewer should pay attention to.
+
+NARRATIVE: 2–4 short paragraphs. Lead with motivation, explain what changed, note anything non-obvious.
+- Short sentences. Plain words. One idea per sentence.
+- Use **bold** for emphasis, \`backticks\` for code symbols, markdown lists where helpful
+- No headings — just bold, lists, inline code
+
+REVIEW FOCUS: 2–4 actionable checks as a markdown bullet list. Focus on what could go wrong.
+
+REVIEW CHECKS: Same items as reviewFocus in structured form.
+- "text" = the check sentence
+- "filePath" must exactly match a file in the provided hunks
+- "startLine" is the new-file line number within a hunk range
+- Set filePath and startLine to null for general checks
+
+MERMAID DIAGRAM: Include only when it genuinely helps understanding (sequence diagrams for flows, flowcharts for branching, class diagrams for data models). Keep small: 5–8 nodes max. Omit (null) when not useful.
+
+Respond with valid JSON only. No explanation outside the JSON.`;
+
+const WRITER_USER_SUFFIX = `
+
+Write the slide content for this topic. Respond with JSON matching this schema exactly:
+{
+  "narrative": string,
+  "reviewFocus": string | null,
+  "contextSnippets": string[],
+  "mermaidDiagram": string | null,
+  "reviewChecks": [
+    {
+      "text": string,
+      "filePath": string | null,
+      "startLine": number | null
+    }
+  ]
+}`;
+
+function validateWriterOutput(obj: unknown): obj is WriterSlideOutput {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return typeof o.narrative === 'string';
+}
+
+export async function generateSlide(
+  topicContext: string,
+  providerName: Provider,
+  model: ModelId,
+  instructions?: string,
+  reviewSuggestions: boolean = true,
+  onChunk?: (chunk: string, isThinking: boolean) => void,
+  thinking: boolean = false,
+  signal?: AbortSignal
+): Promise<WriterSlideOutput> {
+  const provider = getProvider(providerName);
+
+  const reviewSuggestionsDirective = reviewSuggestions
+    ? ''
+    : '\nSet "reviewFocus" to null. Do not generate review focus content.\n';
+
+  let system = WRITER_SYSTEM + reviewSuggestionsDirective;
+  if (instructions?.trim()) {
+    system += `\n\nCUSTOM REVIEWER INSTRUCTIONS (take precedence over style guidelines):\n${instructions.trim()}`;
+  }
+
+  const userMessage = topicContext + WRITER_USER_SUFFIX;
+
+  const fullText = await provider.generate({
+    content: userMessage,
+    systemPrompt: system,
+    model,
+    thinking,
+    onChunk,
+    signal,
+  });
+
+  const jsonText = extractJson(fullText);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (err) {
+    throw new Error(`Writer JSON parse failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  if (!validateWriterOutput(parsed)) {
+    throw new Error('Writer response missing required fields (narrative)');
+  }
+
+  return parsed;
 }

--- a/lib/context-builder.ts
+++ b/lib/context-builder.ts
@@ -1,4 +1,5 @@
-import type { PrMetadata, ChangedFile } from './types';
+import type { PrMetadata, ChangedFile, TopicPlan } from './types';
+import type { IndexedHunk } from './diff-parse';
 
 const CHARS_PER_TOKEN = 4;
 const MAX_TOKENS = 150_000;
@@ -179,4 +180,109 @@ ${expandedDiff}
   );
 
   return finalPackage;
+}
+
+/**
+ * Build a lightweight context string for the planner phase — only PR metadata and hunk index.
+ */
+export function buildPlannerContext(
+  prData: PrMetadata,
+  changedFiles: ChangedFile[],
+  hunkIndex: string,
+  excludedFilesSummary?: string,
+): string {
+  const totalAdditions = changedFiles.reduce((s, f) => s + f.additions, 0);
+  const totalDeletions = changedFiles.reduce((s, f) => s + f.deletions, 0);
+
+  let ctx = `<pr_metadata>
+Title: ${prData.title}
+Author: ${prData.author}
+Description: ${prData.description || '(no description)'}
+Base branch: ${prData.baseBranch}
+Files changed: ${changedFiles.length} | Lines added: ${totalAdditions} | Lines deleted: ${totalDeletions}
+</pr_metadata>`;
+
+  if (excludedFilesSummary) ctx += '\n\n' + excludedFilesSummary;
+  ctx += '\n\n' + hunkIndex;
+
+  return ctx;
+}
+
+/**
+ * Build scoped context for a single topic's writer call — only the hunks and file contents
+ * relevant to that topic.
+ */
+export function buildTopicContext(
+  topic: TopicPlan,
+  allHunks: IndexedHunk[],
+  fileContents: Record<string, string>,
+  headFileContents: Record<string, string>,
+  neighborFiles: Record<string, string>,
+  prTitle: string,
+  prDescription: string,
+): string {
+  const hunkSet = new Set(topic.hunkIds);
+  const relevantHunks = allHunks.filter((h) => hunkSet.has(h.id));
+
+  // Collect affected file paths
+  const affectedFiles = new Set(relevantHunks.map((h) => h.filePath));
+
+  let ctx = `<topic>
+Title: ${topic.title}
+Type: ${topic.slideType}
+Importance: ${topic.importance}
+PR: ${prTitle}
+PR Description: ${prDescription || '(none)'}
+</topic>
+
+<diff_hunks>
+`;
+  for (const hunk of relevantHunks) {
+    ctx += `--- ${hunk.filePath} (${hunk.fileStatus}) [${hunk.id}]\n`;
+    ctx += `${hunk.expandedHunkHeader}\n`;
+    ctx += `${hunk.expandedContent}\n\n`;
+  }
+  ctx += '</diff_hunks>';
+
+  // Scoped file contents — only for affected files
+  let hasBeforeContent = false;
+  let beforeSection = '\n\n<file_contents_before>\n';
+  for (const filePath of affectedFiles) {
+    if (fileContents[filePath]) {
+      beforeSection += `  <file path="${filePath}">\n${truncateFileContent(fileContents[filePath], MAX_FILE_LINES)}\n  </file>\n`;
+      hasBeforeContent = true;
+    }
+  }
+  beforeSection += '</file_contents_before>';
+  if (hasBeforeContent) ctx += beforeSection;
+
+  let hasAfterContent = false;
+  let afterSection = '\n\n<file_contents_after>\n';
+  for (const filePath of affectedFiles) {
+    if (headFileContents[filePath]) {
+      afterSection += `  <file path="${filePath}">\n${truncateFileContent(headFileContents[filePath], MAX_FILE_LINES)}\n  </file>\n`;
+      hasAfterContent = true;
+    }
+  }
+  afterSection += '</file_contents_after>';
+  if (hasAfterContent) ctx += afterSection;
+
+  // Scoped neighbor files — only imports relevant to affected files
+  let hasNeighbors = false;
+  let neighborSection = '\n\n<neighbor_files>\n';
+  for (const [path, content] of Object.entries(neighborFiles)) {
+    // Include neighbor if any affected file likely imports it
+    const base = path.replace(/\.[^.]+$/, '');
+    const isRelevant = [...affectedFiles].some(
+      (f) => fileContents[f]?.includes(base) || headFileContents[f]?.includes(base),
+    );
+    if (isRelevant) {
+      neighborSection += `  <file path="${path}">\n${truncateFileContent(content, MAX_FILE_LINES)}\n  </file>\n`;
+      hasNeighbors = true;
+    }
+  }
+  neighborSection += '</neighbor_files>';
+  if (hasNeighbors) ctx += neighborSection;
+
+  return ctx;
 }

--- a/lib/context-builder.ts
+++ b/lib/context-builder.ts
@@ -214,7 +214,7 @@ Files changed: ${changedFiles.length} | Lines added: ${totalAdditions} | Lines d
  */
 export function buildTopicContext(
   topic: TopicPlan,
-  allHunks: IndexedHunk[],
+  hunkMap: Map<string, IndexedHunk>,
   fileContents: Record<string, string>,
   headFileContents: Record<string, string>,
   neighborFiles: Record<string, string>,
@@ -223,8 +223,9 @@ export function buildTopicContext(
   storyArc: string,
   allTopics: TopicPlan[],
 ): string {
-  const hunkSet = new Set(topic.hunkIds);
-  const relevantHunks = allHunks.filter((h) => hunkSet.has(h.id));
+  const relevantHunks = topic.hunkIds
+    .map((id) => hunkMap.get(id))
+    .filter((h): h is IndexedHunk => h !== undefined);
 
   // Collect affected file paths
   const affectedFiles = new Set(relevantHunks.map((h) => h.filePath));

--- a/lib/context-builder.ts
+++ b/lib/context-builder.ts
@@ -220,6 +220,8 @@ export function buildTopicContext(
   neighborFiles: Record<string, string>,
   prTitle: string,
   prDescription: string,
+  storyArc: string,
+  allTopics: TopicPlan[],
 ): string {
   const hunkSet = new Set(topic.hunkIds);
   const relevantHunks = allHunks.filter((h) => hunkSet.has(h.id));
@@ -227,7 +229,18 @@ export function buildTopicContext(
   // Collect affected file paths
   const affectedFiles = new Set(relevantHunks.map((h) => h.filePath));
 
-  let ctx = `<topic>
+  // Build dependency context — briefs of topics this one depends on
+  const depSet = new Set(topic.dependsOn);
+  const depBriefs = allTopics
+    .filter((t) => depSet.has(t.title))
+    .map((t) => `- "${t.title}" (${t.slideType}): ${t.narrativeBrief}`)
+    .join('\n');
+
+  let ctx = `<story_arc>${storyArc}</story_arc>
+
+<narrative_brief>${topic.narrativeBrief}</narrative_brief>
+
+${depBriefs ? `<prior_topics>\nThis slide builds on:\n${depBriefs}\n</prior_topics>\n\n` : ''}<topic>
 Title: ${topic.title}
 Type: ${topic.slideType}
 Importance: ${topic.importance}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -50,16 +50,55 @@ export async function getPrMetadata(
   };
 }
 
-export async function getPrDiff(octokit: Octokit, owner: string, repo: string, pullNumber: number): Promise<string> {
-  const response = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
-    owner,
-    repo,
-    pull_number: pullNumber,
-    headers: {
-      accept: 'application/vnd.github.v3.diff',
-    },
-  });
-  return response.data as unknown as string;
+export async function getPrDiff(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+  changedFiles?: ChangedFile[],
+): Promise<string> {
+  try {
+    const response = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+      owner,
+      repo,
+      pull_number: pullNumber,
+      headers: {
+        accept: 'application/vnd.github.v3.diff',
+      },
+    });
+    return response.data as unknown as string;
+  } catch (err) {
+    // GitHub returns 'too_large' for diffs over 20k lines.
+    // Fall back to assembling from individual file patches.
+    const isTooLarge =
+      err instanceof Error && (err.message.includes('too_large') || err.message.includes('diff is too large'));
+    if (!isTooLarge) throw err;
+
+    console.warn('[github] Full diff too large, assembling from file patches');
+    if (!changedFiles) {
+      changedFiles = await getChangedFiles(octokit, owner, repo, pullNumber);
+    }
+    return assembleUnifiedDiff(changedFiles);
+  }
+}
+
+/** Reconstruct a unified diff from individual file patches returned by listFiles. */
+function assembleUnifiedDiff(files: ChangedFile[]): string {
+  const parts: string[] = [];
+  for (const f of files) {
+    if (!f.patch) continue;
+    const a = f.status === 'added' ? '/dev/null' : `a/${f.previous_filename ?? f.filename}`;
+    const b = f.status === 'deleted' ? '/dev/null' : `b/${f.filename}`;
+    parts.push(`diff --git ${a} ${b}`);
+    if (f.status === 'renamed' && f.previous_filename) {
+      parts.push(`rename from ${f.previous_filename}`);
+      parts.push(`rename to ${f.filename}`);
+    }
+    parts.push(`--- ${a}`);
+    parts.push(`+++ ${b}`);
+    parts.push(f.patch);
+  }
+  return parts.join('\n') + '\n';
 }
 
 export async function getChangedFiles(
@@ -86,6 +125,7 @@ export async function getChangedFiles(
         additions: f.additions,
         deletions: f.deletions,
         previous_filename: f.previous_filename,
+        patch: f.patch,
       });
     }
     if (data.length < 100) break;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -285,6 +285,7 @@ export interface ChangedFile {
   additions: number;
   deletions: number;
   previous_filename?: string;
+  patch?: string;
 }
 
 export interface FreshnessCommit {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -84,6 +84,32 @@ export interface AIReviewGuide {
   webSources?: WebSource[];
 }
 
+// Planner output for two-phase review generation
+export interface TopicPlan {
+  title: string;
+  slideType: SlideType;
+  importance: SlideImportance;
+  hunkIds: string[];
+  dependsOn: string[]; // IDs of other topics this depends on
+  order: number;
+}
+
+export interface PlannerOutput {
+  summary: string;
+  riskLevel: 'low' | 'medium' | 'high';
+  riskRationale: string;
+  topics: TopicPlan[];
+}
+
+// Writer output for a single slide in two-phase generation
+export interface WriterSlideOutput {
+  narrative: string;
+  reviewFocus: string | null;
+  contextSnippets: string[];
+  mermaidDiagram?: string | null;
+  reviewChecks?: ReviewCheck[];
+}
+
 export interface FileMetadata {
   filename: string;
   status: 'added' | 'modified' | 'deleted' | 'renamed';
@@ -219,6 +245,7 @@ export interface Preferences {
   theme: 'light' | 'dark' | 'system';
   trayEnabled: boolean;
   maxPrsPerRepo: number;
+  parallelReview: boolean;
 }
 
 export interface SendSlideChatRequest {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -90,14 +90,16 @@ export interface TopicPlan {
   slideType: SlideType;
   importance: SlideImportance;
   hunkIds: string[];
-  dependsOn: string[]; // IDs of other topics this depends on
+  dependsOn: string[];
   order: number;
+  narrativeBrief: string; // 1-2 sentence direction for the writer
 }
 
 export interface PlannerOutput {
   summary: string;
   riskLevel: 'low' | 'medium' | 'high';
   riskRationale: string;
+  storyArc: string; // Overall narrative thread connecting all topics
   topics: TopicPlan[];
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -218,6 +218,7 @@ export interface Preferences {
   firstRunSeen: boolean;
   theme: 'light' | 'dark' | 'system';
   trayEnabled: boolean;
+  maxPrsPerRepo: number;
 }
 
 export interface SendSlideChatRequest {

--- a/src/main.ts
+++ b/src/main.ts
@@ -520,7 +520,7 @@ async function runProactiveCheck() {
       prefs.watchedRepos.map(async (repoRef) => {
         const [owner, repo] = repoRef.split('/');
         if (!owner || !repo) return [];
-        return listRepoPullRequests(octokit, owner, repo);
+        return listRepoPullRequests(octokit, owner, repo, prefs.maxPrsPerRepo);
       })
     );
     const watchedPrs: PrSearchResult[] = [];
@@ -931,6 +931,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   firstRunSeen: false,
   theme: 'system',
   trayEnabled: true,
+  maxPrsPerRepo: 10,
 };
 
 function applyBinaryOverrides(prefs: Preferences): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,8 +20,8 @@ import {
   getReviewStatus,
 } from '../lib/github';
 import type { CiCheck, FileMetadata, PrMetadata, PrSearchResult, PrStatus } from '../lib/types';
-import { buildContextPackage } from '../lib/context-builder';
-import { generateReviewGuide } from '../lib/agent';
+import { buildContextPackage, buildPlannerContext, buildTopicContext } from '../lib/context-builder';
+import { generateReviewGuide, planReview, generateSlide } from '../lib/agent';
 import { checkForUpdate } from '../lib/updater';
 import { renderDiffHunk, reRenderAllHunks } from '../lib/highlight';
 import { parseDiffLines, parsePatchValidLines } from '../lib/diff-lines';
@@ -932,6 +932,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   theme: 'system',
   trayEnabled: true,
   maxPrsPerRepo: 10,
+  parallelReview: false,
 };
 
 function applyBinaryOverrides(prefs: Preferences): void {
@@ -1386,8 +1387,6 @@ async function runBackgroundGeneration(
       excludedFilesSummary
     );
 
-    broadcastToAllWindows('review-phase', { reviewId, phase: 'Generating review' });
-
     console.log(`[main] Generating review guide (${reviewId})...`);
     const generationStart = Date.now();
 
@@ -1406,106 +1405,192 @@ async function runBackgroundGeneration(
       allowedTools = WEB_ONLY_TOOLS;
     }
 
-    let aiResult;
-    let lastStreamPhase: string | null = null;
-    try {
-      aiResult = await generateReviewGuide(
-        contextPackage,
-        prUrl,
-        provider,
-        model,
-        instructions,
-        (chunk, isThinking) => {
-          const phase = isThinking ? 'Thinking' : 'Generating review';
-          if (phase !== lastStreamPhase) {
-            lastStreamPhase = phase;
-            broadcastToAllWindows('review-phase', { reviewId, phase });
-          }
-          broadcastToAllWindows('review-progress', { reviewId, chunk, isThinking });
-        },
-        thinking ?? false,
-        mcpConfigPath,
-        allowedTools,
-        reviewSuggestions ?? true,
-        webResearch ?? false,
-        (toolName) => broadcastToAllWindows('review-tool-use', { reviewId, toolName }),
-        (system, userMessage) => {
-          broadcastToAllWindows('review-stats', {
-            reviewId,
-            inputBytes: system.length + userMessage.length,
-          });
-          try {
-            ensureReviewsDir();
-            fs.writeFileSync(
-              path.join(getReviewsDir(), `${reviewId}-prompt.md`),
-              `# System Prompt\n\n${system}\n\n# User Message\n\n${userMessage}\n`
-            );
-          } catch {
-            // Best-effort — don't fail the review if prompt save fails
-          }
-        },
-        signal
-      );
-    } finally {
-      if (mcpConfigPath) cleanupMcpConfig(mcpConfigPath);
-    }
+    let resolvedSlides: Slide[];
+    let aiResult: Awaited<ReturnType<typeof generateReviewGuide>> | null = null;
+    let plannerSummary: string | undefined;
+    let plannerRiskLevel: 'low' | 'medium' | 'high' | undefined;
+    let plannerRiskRationale: string | undefined;
 
-    const generationDurationMs = Date.now() - generationStart;
-
-    // Append raw model response to prompt file (best-effort)
-    try {
-      const promptPath = path.join(getReviewsDir(), `${reviewId}-prompt.md`);
-      if (fs.existsSync(promptPath)) {
-        fs.appendFileSync(
-          promptPath,
-          `\n---\n\n# Model Response\n\n\`\`\`json\n${JSON.stringify(aiResult, null, 2)}\n\`\`\`\n`
-        );
-      }
-    } catch {
-      // Best-effort
-    }
-
-    // Resolve hunk IDs → real DiffHunk objects
     const hunkMap = new Map(indexedHunks.map((h) => [h.id, h]));
     const assignedIds = new Set<string>();
 
-    const resolvedSlides: Slide[] = aiResult.slides.map((aiSlide) => {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- AI response may omit fields
-      const ids = aiSlide.diffHunkIds ?? [];
-      const diffHunks: DiffHunk[] = ids
-        .filter((id: string) => hunkMap.has(id) && !assignedIds.has(id))
-        .map((id: string) => {
-          assignedIds.add(id);
-          const h = hunkMap.get(id);
-          if (!h) throw new Error(`Hunk ${id} not found in index`);
-          return {
-            filePath: h.filePath,
-            hunkHeader: h.expandedHunkHeader,
-            content: h.expandedContent,
-            language: h.language,
-            renderedHtml: '',
-          };
-        });
+    if (prefs.parallelReview) {
+      // ── Two-phase: planner → parallel writers ──
+      broadcastToAllWindows('review-phase', { reviewId, phase: 'Planning review structure' });
 
-      return {
-        id: aiSlide.id,
-        slideNumber: aiSlide.slideNumber,
-        title: aiSlide.title,
-        slideType: aiSlide.slideType,
-        narrative: aiSlide.narrative,
-        reviewFocus: aiSlide.reviewFocus,
-        diffHunks: sortDiffHunks(diffHunks),
+      const plannerContext = buildPlannerContext(prData, changedFiles, hunkIndex, excludedFilesSummary);
+      const plan = await planReview(
+        hunkIndex,
+        plannerContext,
+        provider,
+        model,
+        (chunk, isThinking) => broadcastToAllWindows('review-progress', { reviewId, chunk, isThinking }),
+        thinking ?? false,
+        signal,
+      );
+
+      plannerSummary = plan.summary;
+      plannerRiskLevel = plan.riskLevel;
+      plannerRiskRationale = plan.riskRationale;
+
+      console.log(`[main] Planner produced ${plan.topics.length} topics`);
+
+      // Sort topics by planner's order
+      const sortedTopics = [...plan.topics].sort((a, b) => a.order - b.order);
+
+      // Run writers in parallel with concurrency limit
+      const WRITER_CONCURRENCY = 3;
+      const slideResults: Slide[] = [];
+
+      for (let i = 0; i < sortedTopics.length; i += WRITER_CONCURRENCY) {
+        const batch = sortedTopics.slice(i, i + WRITER_CONCURRENCY);
+        const batchResults = await Promise.all(
+          batch.map(async (topic, batchIdx) => {
+            const slideNum = i + batchIdx + 1;
+            broadcastToAllWindows('review-phase', {
+              reviewId,
+              phase: `Writing slide ${slideNum}/${sortedTopics.length}: ${topic.title}`,
+            });
+
+            const topicCtx = buildTopicContext(
+              topic, indexedHunks, fileContents, headFileContents, neighborFiles,
+              prData.title, prData.description,
+            );
+
+            const writerOutput = await generateSlide(
+              topicCtx,
+              provider,
+              model,
+              instructions,
+              reviewSuggestions ?? true,
+              (chunk, isThinking) => broadcastToAllWindows('review-progress', { reviewId, chunk, isThinking }),
+              thinking ?? false,
+              signal,
+            );
+
+            // Resolve hunks for this topic
+            const hunkIds = topic.hunkIds ?? [];
+            const diffHunks: DiffHunk[] = hunkIds
+              .filter((id) => hunkMap.has(id) && !assignedIds.has(id))
+              .map((id) => {
+                assignedIds.add(id);
+                const h = hunkMap.get(id)!;
+                return {
+                  filePath: h.filePath,
+                  hunkHeader: h.expandedHunkHeader,
+                  content: h.expandedContent,
+                  language: h.language,
+                  renderedHtml: '',
+                };
+              });
+
+            return {
+              id: `slide-${slideNum}`,
+              slideNumber: slideNum,
+              title: topic.title,
+              slideType: topic.slideType,
+              narrative: writerOutput.narrative,
+              reviewFocus: writerOutput.reviewFocus,
+              diffHunks: sortDiffHunks(diffHunks),
+              contextSnippets: writerOutput.contextSnippets ?? [],
+              affectedFiles: [...new Set(diffHunks.map((h) => h.filePath))],
+              dependsOn: topic.dependsOn,
+              mermaidDiagram: writerOutput.mermaidDiagram,
+              reviewChecks: writerOutput.reviewChecks,
+              importance: topic.importance,
+            } satisfies Slide;
+          })
+        );
+        slideResults.push(...batchResults);
+      }
+
+      resolvedSlides = slideResults;
+    } else {
+      // ── Single-shot: existing approach ──
+      broadcastToAllWindows('review-phase', { reviewId, phase: 'Generating review' });
+
+      let lastStreamPhase: string | null = null;
+      try {
+        aiResult = await generateReviewGuide(
+          contextPackage,
+          prUrl,
+          provider,
+          model,
+          instructions,
+          (chunk, isThinking) => {
+            const phase = isThinking ? 'Thinking' : 'Generating review';
+            if (phase !== lastStreamPhase) {
+              lastStreamPhase = phase;
+              broadcastToAllWindows('review-phase', { reviewId, phase });
+            }
+            broadcastToAllWindows('review-progress', { reviewId, chunk, isThinking });
+          },
+          thinking ?? false,
+          mcpConfigPath,
+          allowedTools,
+          reviewSuggestions ?? true,
+          webResearch ?? false,
+          (toolName) => broadcastToAllWindows('review-tool-use', { reviewId, toolName }),
+          (system, userMessage) => {
+            broadcastToAllWindows('review-stats', {
+              reviewId,
+              inputBytes: system.length + userMessage.length,
+            });
+            try {
+              ensureReviewsDir();
+              fs.writeFileSync(
+                path.join(getReviewsDir(), `${reviewId}-prompt.md`),
+                `# System Prompt\n\n${system}\n\n# User Message\n\n${userMessage}\n`
+              );
+            } catch {
+              // Best-effort
+            }
+          },
+          signal
+        );
+      } finally {
+        if (mcpConfigPath) cleanupMcpConfig(mcpConfigPath);
+      }
+
+      resolvedSlides = aiResult.slides.map((aiSlide) => {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- AI response may omit fields
-        contextSnippets: aiSlide.contextSnippets ?? [],
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- AI response may omit fields
-        affectedFiles: aiSlide.affectedFiles ?? [],
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- AI response may omit fields
-        dependsOn: aiSlide.dependsOn ?? [],
-        mermaidDiagram: aiSlide.mermaidDiagram,
-        reviewChecks: aiSlide.reviewChecks,
-        importance: aiSlide.importance ?? 'important',
-      };
-    });
+        const ids = aiSlide.diffHunkIds ?? [];
+        const diffHunks: DiffHunk[] = ids
+          .filter((id: string) => hunkMap.has(id) && !assignedIds.has(id))
+          .map((id: string) => {
+            assignedIds.add(id);
+            const h = hunkMap.get(id)!;
+            return {
+              filePath: h.filePath,
+              hunkHeader: h.expandedHunkHeader,
+              content: h.expandedContent,
+              language: h.language,
+              renderedHtml: '',
+            };
+          });
+
+        return {
+          id: aiSlide.id,
+          slideNumber: aiSlide.slideNumber,
+          title: aiSlide.title,
+          slideType: aiSlide.slideType,
+          narrative: aiSlide.narrative,
+          reviewFocus: aiSlide.reviewFocus,
+          diffHunks: sortDiffHunks(diffHunks),
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- AI response may omit fields
+          contextSnippets: aiSlide.contextSnippets ?? [],
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- AI response may omit fields
+          affectedFiles: aiSlide.affectedFiles ?? [],
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- AI response may omit fields
+          dependsOn: aiSlide.dependsOn ?? [],
+          mermaidDiagram: aiSlide.mermaidDiagram,
+          reviewChecks: aiSlide.reviewChecks,
+          importance: aiSlide.importance ?? 'important',
+        };
+      });
+    }
+
+    const generationDurationMs = Date.now() - generationStart;
 
     // Sanitize reviewChecks — clear invalid file/line refs so they render as non-clickable
     for (const slide of resolvedSlides) {
@@ -1566,13 +1651,13 @@ async function runBackgroundGeneration(
     const fileMetadata = await fileMetadataPromise;
 
     const reviewGuide: ReviewGuide = {
-      prTitle: aiResult.prTitle || prData.title,
-      prDescription: aiResult.prDescription || prData.description,
+      prTitle: aiResult?.prTitle || prData.title,
+      prDescription: aiResult?.prDescription || prData.description,
       prUrl,
-      author: aiResult.author || prData.author,
-      summary: aiResult.summary,
-      riskLevel: aiResult.riskLevel,
-      riskRationale: aiResult.riskRationale,
+      author: aiResult?.author || prData.author,
+      summary: aiResult?.summary || plannerSummary || '',
+      riskLevel: aiResult?.riskLevel || plannerRiskLevel || 'low',
+      riskRationale: aiResult?.riskRationale || plannerRiskRationale || '',
       totalFilesChanged: changedFiles.length,
       totalLinesChanged: changedFiles.reduce((sum, f) => sum + f.additions + f.deletions, 0),
       neighborFileCount: Object.keys(neighborFiles).length,
@@ -1580,7 +1665,7 @@ async function runBackgroundGeneration(
       generationDurationMs,
       slides: resolvedSlides,
       headSha: prData.headSha,
-      webSources: aiResult.webSources,
+      webSources: aiResult?.webSources,
       changedFiles: fileMetadata,
     };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1272,6 +1272,27 @@ ipcMain.handle('get-pr-files', async (_event, prUrl: string): Promise<ChangedFil
 
 // ── Background review generation ────────────────────────────────
 
+/** Resolve hunk IDs to DiffHunk objects, skipping already-assigned ones. */
+function resolveDiffHunks(
+  ids: string[],
+  hunkMap: Map<string, import('../lib/diff-parse').IndexedHunk>,
+  assignedIds: Set<string>,
+): DiffHunk[] {
+  return ids
+    .filter((id) => hunkMap.has(id) && !assignedIds.has(id))
+    .map((id) => {
+      assignedIds.add(id);
+      const h = hunkMap.get(id)!;
+      return {
+        filePath: h.filePath,
+        hunkHeader: h.expandedHunkHeader,
+        content: h.expandedContent,
+        language: h.language,
+        renderedHtml: '',
+      };
+    });
+}
+
 async function runBackgroundGeneration(
   reviewId: string,
   request: GenerateReviewRequest,
@@ -1372,45 +1393,34 @@ async function runBackgroundGeneration(
 
     broadcastToAllWindows('review-phase', { reviewId, phase: 'Building context' });
 
-    // Parse diff into indexed hunks and build expanded diff (using filtered diff)
+    const prefs = loadPreferences();
+
+    // Parse diff into indexed hunks — always needed
     const indexedHunks = buildIndexedHunks(filteredDiff, fileContents, headFileContents);
-    const expandedDiff = expandFullDiff(filteredDiff, fileContents, headFileContents);
     const hunkIndex = formatHunkIndexForPrompt(indexedHunks);
 
-    const contextPackage = buildContextPackage(
-      prData,
-      expandedDiff,
-      changedFiles,
-      fileContents,
-      headFileContents,
-      neighborFiles,
-      hunkIndex,
-      excludedFilesSummary
-    );
+    // Full context package only needed for single-shot mode
+    let contextPackage = '';
+    if (!prefs.parallelReview) {
+      const expandedDiff = expandFullDiff(filteredDiff, fileContents, headFileContents);
+      contextPackage = buildContextPackage(
+        prData,
+        expandedDiff,
+        changedFiles,
+        fileContents,
+        headFileContents,
+        neighborFiles,
+        hunkIndex,
+        excludedFilesSummary
+      );
+    }
 
     console.log(`[main] Generating review guide (${reviewId})...`);
     const generationStart = Date.now();
 
-    const prefs = loadPreferences();
-    let mcpConfigPath: string | undefined;
-    let allowedTools: string[] | undefined;
-
-    if (prefs.enableTools && provider === 'claude') {
-      if (token) {
-        mcpConfigPath = writeMcpConfig(token);
-        allowedTools = ALLOWED_TOOLS;
-      } else {
-        allowedTools = WEB_ONLY_TOOLS;
-      }
-    } else if (webResearch && provider === 'claude') {
-      allowedTools = WEB_ONLY_TOOLS;
-    }
-
     let resolvedSlides: Slide[];
     let aiResult: Awaited<ReturnType<typeof generateReviewGuide>> | null = null;
-    let plannerSummary: string | undefined;
-    let plannerRiskLevel: 'low' | 'medium' | 'high' | undefined;
-    let plannerRiskRationale: string | undefined;
+    let plan: Awaited<ReturnType<typeof planReview>> | null = null;
 
     const hunkMap = new Map(indexedHunks.map((h) => [h.id, h]));
     const assignedIds = new Set<string>();
@@ -1420,7 +1430,7 @@ async function runBackgroundGeneration(
       broadcastToAllWindows('review-phase', { reviewId, phase: 'Planning review structure' });
 
       const plannerContext = buildPlannerContext(prData, changedFiles, hunkIndex, excludedFilesSummary);
-      const plan = await planReview(
+      plan = await planReview(
         hunkIndex,
         plannerContext,
         provider,
@@ -1430,16 +1440,12 @@ async function runBackgroundGeneration(
         signal,
       );
 
-      plannerSummary = plan.summary;
-      plannerRiskLevel = plan.riskLevel;
-      plannerRiskRationale = plan.riskRationale;
-
       console.log(`[main] Planner produced ${plan.topics.length} topics`);
 
       // Sort topics by planner's order
       const sortedTopics = [...plan.topics].sort((a, b) => a.order - b.order);
+      const storyArc = plan.storyArc;
 
-      // Run writers in parallel with concurrency limit
       // Fire all writers in parallel — the CLI/API handles its own rate limiting
       const slideResults: Slide[] = await Promise.all(
         sortedTopics.map(async (topic, idx) => {
@@ -1450,8 +1456,8 @@ async function runBackgroundGeneration(
             });
 
             const topicCtx = buildTopicContext(
-              topic, indexedHunks, fileContents, headFileContents, neighborFiles,
-              prData.title, prData.description, plan.storyArc, sortedTopics,
+              topic, hunkMap, fileContents, headFileContents, neighborFiles,
+              prData.title, prData.description, storyArc, sortedTopics,
             );
 
             const writerOutput = await generateSlide(
@@ -1465,21 +1471,7 @@ async function runBackgroundGeneration(
               signal,
             );
 
-            // Resolve hunks for this topic
-            const hunkIds = topic.hunkIds ?? [];
-            const diffHunks: DiffHunk[] = hunkIds
-              .filter((id) => hunkMap.has(id) && !assignedIds.has(id))
-              .map((id) => {
-                assignedIds.add(id);
-                const h = hunkMap.get(id)!;
-                return {
-                  filePath: h.filePath,
-                  hunkHeader: h.expandedHunkHeader,
-                  content: h.expandedContent,
-                  language: h.language,
-                  renderedHtml: '',
-                };
-              });
+            const diffHunks = resolveDiffHunks(topic.hunkIds ?? [], hunkMap, assignedIds);
 
             return {
               id: `slide-${slideNum}`,
@@ -1503,6 +1495,19 @@ async function runBackgroundGeneration(
     } else {
       // ── Single-shot: existing approach ──
       broadcastToAllWindows('review-phase', { reviewId, phase: 'Generating review' });
+
+      let mcpConfigPath: string | undefined;
+      let allowedTools: string[] | undefined;
+      if (prefs.enableTools && provider === 'claude') {
+        if (token) {
+          mcpConfigPath = writeMcpConfig(token);
+          allowedTools = ALLOWED_TOOLS;
+        } else {
+          allowedTools = WEB_ONLY_TOOLS;
+        }
+      } else if (webResearch && provider === 'claude') {
+        allowedTools = WEB_ONLY_TOOLS;
+      }
 
       let lastStreamPhase: string | null = null;
       try {
@@ -1549,20 +1554,8 @@ async function runBackgroundGeneration(
 
       resolvedSlides = aiResult.slides.map((aiSlide) => {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- AI response may omit fields
-        const ids = aiSlide.diffHunkIds ?? [];
-        const diffHunks: DiffHunk[] = ids
-          .filter((id: string) => hunkMap.has(id) && !assignedIds.has(id))
-          .map((id: string) => {
-            assignedIds.add(id);
-            const h = hunkMap.get(id)!;
-            return {
-              filePath: h.filePath,
-              hunkHeader: h.expandedHunkHeader,
-              content: h.expandedContent,
-              language: h.language,
-              renderedHtml: '',
-            };
-          });
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- AI response may omit fields
+        const diffHunks = resolveDiffHunks(aiSlide.diffHunkIds ?? [], hunkMap, assignedIds);
 
         return {
           id: aiSlide.id,
@@ -1619,13 +1612,7 @@ async function runBackgroundGeneration(
     // Catch-all slide for unassigned hunks
     const unassigned = indexedHunks.filter((h) => !assignedIds.has(h.id));
     if (unassigned.length > 0) {
-      const otherHunks: DiffHunk[] = unassigned.map((h) => ({
-        filePath: h.filePath,
-        hunkHeader: h.expandedHunkHeader,
-        content: h.expandedContent,
-        language: h.language,
-        renderedHtml: '',
-      }));
+      const otherHunks = resolveDiffHunks(unassigned.map((h) => h.id), hunkMap, assignedIds);
 
       resolvedSlides.push({
         id: 'other-changes',
@@ -1650,9 +1637,9 @@ async function runBackgroundGeneration(
       prDescription: aiResult?.prDescription || prData.description,
       prUrl,
       author: aiResult?.author || prData.author,
-      summary: aiResult?.summary || plannerSummary || '',
-      riskLevel: aiResult?.riskLevel || plannerRiskLevel || 'low',
-      riskRationale: aiResult?.riskRationale || plannerRiskRationale || '',
+      summary: aiResult?.summary || plan?.summary || '',
+      riskLevel: aiResult?.riskLevel || plan?.riskLevel || 'low',
+      riskRationale: aiResult?.riskRationale || plan?.riskRationale || '',
       totalFilesChanged: changedFiles.length,
       totalLinesChanged: changedFiles.reduce((sum, f) => sum + f.additions + f.deletions, 0),
       neighborFileCount: Object.keys(neighborFiles).length,

--- a/src/main.ts
+++ b/src/main.ts
@@ -932,7 +932,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   theme: 'system',
   trayEnabled: true,
   maxPrsPerRepo: 10,
-  parallelReview: false,
+  parallelReview: true,
 };
 
 function applyBinaryOverrides(prefs: Preferences): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1438,14 +1438,10 @@ async function runBackgroundGeneration(
       const sortedTopics = [...plan.topics].sort((a, b) => a.order - b.order);
 
       // Run writers in parallel with concurrency limit
-      const WRITER_CONCURRENCY = 3;
-      const slideResults: Slide[] = [];
-
-      for (let i = 0; i < sortedTopics.length; i += WRITER_CONCURRENCY) {
-        const batch = sortedTopics.slice(i, i + WRITER_CONCURRENCY);
-        const batchResults = await Promise.all(
-          batch.map(async (topic, batchIdx) => {
-            const slideNum = i + batchIdx + 1;
+      // Fire all writers in parallel — the CLI/API handles its own rate limiting
+      const slideResults: Slide[] = await Promise.all(
+        sortedTopics.map(async (topic, idx) => {
+            const slideNum = idx + 1;
             broadcastToAllWindows('review-phase', {
               reviewId,
               phase: `Writing slide ${slideNum}/${sortedTopics.length}: ${topic.title}`,
@@ -1498,10 +1494,8 @@ async function runBackgroundGeneration(
               reviewChecks: writerOutput.reviewChecks,
               importance: topic.importance,
             } satisfies Slide;
-          })
-        );
-        slideResults.push(...batchResults);
-      }
+        })
+      );
 
       resolvedSlides = slideResults;
     } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -516,11 +516,13 @@ async function runProactiveCheck() {
     const myPrs = await searchPullRequests(octokit, cachedLogin);
 
     // Source 3: watched repo PRs (fetched in parallel)
+    // Clamp maxPrsPerRepo to GitHub's supported range (1-100) and default to 10 if invalid
+    const maxPerRepo = Math.min(100, Math.max(1, Number.isFinite(prefs.maxPrsPerRepo) ? prefs.maxPrsPerRepo : 10));
     const watchedResults = await Promise.allSettled(
       prefs.watchedRepos.map(async (repoRef) => {
         const [owner, repo] = repoRef.split('/');
         if (!owner || !repo) return [];
-        return listRepoPullRequests(octokit, owner, repo, prefs.maxPrsPerRepo);
+        return listRepoPullRequests(octokit, owner, repo, maxPerRepo);
       })
     );
     const watchedPrs: PrSearchResult[] = [];

--- a/src/main.ts
+++ b/src/main.ts
@@ -1453,7 +1453,7 @@ async function runBackgroundGeneration(
 
             const topicCtx = buildTopicContext(
               topic, indexedHunks, fileContents, headFileContents, neighborFiles,
-              prData.title, prData.description,
+              prData.title, prData.description, plan.storyArc, sortedTopics,
             );
 
             const writerOutput = await generateSlide(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1286,10 +1286,9 @@ async function runBackgroundGeneration(
 
     broadcastToAllWindows('review-phase', { reviewId, phase: 'Fetching PR data' });
 
-    const [diff, allChangedFiles] = await Promise.all([
-      getPrDiff(octokit, owner, repo, pullNumber),
-      getChangedFiles(octokit, owner, repo, pullNumber),
-    ]);
+    // Fetch changed files first so we can pass them to getPrDiff as fallback
+    const allChangedFiles = await getChangedFiles(octokit, owner, repo, pullNumber);
+    const diff = await getPrDiff(octokit, owner, repo, pullNumber, allChangedFiles);
 
     // Fetch file metadata (age + churn) in the background while the
     // rest of the pipeline proceeds. We don't await it here — it

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -26,6 +26,7 @@ import { ShortcutOverlay } from '../../components/ShortcutOverlay';
 import { CommandPalette, type Command } from '../../components/CommandPalette';
 import { useKeyboardShortcuts, type ShortcutMap } from '../../lib/use-keyboard-shortcuts';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../components/ui/dialog';
+import { OnboardingRepoSetup } from '../../components/OnboardingRepoSetup';
 import { Avatar, AvatarFallback, AvatarImage } from '../../components/ui/avatar';
 import { riskConfig, safeConfigLookup } from '../../lib/constants';
 import type { ModelId, Preferences, Provider, PrSearchResult, ReviewGuide, ReviewHistoryEntry, UpdateInfo } from '../../lib/types';
@@ -160,6 +161,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [patError, setPatError] = useState<string | null>(null);
   const [patConnecting, setPatConnecting] = useState(false);
   const [firstRunOpen, setFirstRunOpen] = useState(false);
+  const [repoSetupOpen, setRepoSetupOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
   // The "About Gnosis" panel is the on-demand way to re-read the
@@ -296,6 +298,8 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
     void window.electronAPI.loadPreferences().then((current) => {
       void window.electronAPI.savePreferences({ ...current, firstRunSeen: true });
     });
+    // Show repo setup step after welcome hero
+    setRepoSetupOpen(true);
   }
 
   // Resets every onboarding flag — the firstRunSeen pref, the
@@ -1398,6 +1402,26 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
               </div>
             </DialogContent>
           </Dialog>
+
+          {/* ── Onboarding repo setup ── */}
+          <OnboardingRepoSetup
+            open={repoSetupOpen}
+            onComplete={(repos) => {
+              setRepoSetupOpen(false);
+              void window.electronAPI.loadPreferences().then((current) => {
+                void window.electronAPI.savePreferences({
+                  ...current,
+                  proactiveMode: true,
+                  watchedRepos: repos,
+                });
+              });
+              setTimeout(() => prInputRef.current?.focus(), 100);
+            }}
+            onSkip={() => {
+              setRepoSetupOpen(false);
+              setTimeout(() => prInputRef.current?.focus(), 100);
+            }}
+          />
 
           {/* ── Empty state ── Only shown for first-time users.
               Explains what will appear here and sets expectations. */}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -320,7 +320,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       /* non-fatal */
     }
     setAboutOpen(false);
-    setFirstRunOpen(true);
+    setRepoSetupOpen(true);
     scrollToTop();
   }
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -270,7 +270,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       setIncludeAllFiles(prefs.includeAllFiles);
       setPrefsLoaded(true);
       if (!prefs.firstRunSeen) {
-        setFirstRunOpen(true);
+        setRepoSetupOpen(true);
       }
     });
     return () => { cancelled = true; };
@@ -298,8 +298,6 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
     void window.electronAPI.loadPreferences().then((current) => {
       void window.electronAPI.savePreferences({ ...current, firstRunSeen: true });
     });
-    // Show repo setup step after welcome hero
-    setRepoSetupOpen(true);
   }
 
   // Resets every onboarding flag — the firstRunSeen pref, the
@@ -1411,6 +1409,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
               void window.electronAPI.loadPreferences().then((current) => {
                 void window.electronAPI.savePreferences({
                   ...current,
+                  firstRunSeen: true,
                   proactiveMode: true,
                   watchedRepos: repos,
                 });
@@ -1419,6 +1418,9 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
             }}
             onSkip={() => {
               setRepoSetupOpen(false);
+              void window.electronAPI.loadPreferences().then((current) => {
+                void window.electronAPI.savePreferences({ ...current, firstRunSeen: true });
+              });
               setTimeout(() => prInputRef.current?.focus(), 100);
             }}
           />


### PR DESCRIPTION
## Summary
- **Two-phase parallel review generation**: opt-in mode that splits review into a planner step (topic assignment) then fires all slide writers in parallel with scoped context and narrative consistency
- **Guided onboarding**: first-run dialog walks users through selecting repos to watch, replacing the old welcome hero
- **Configurable max PRs per repo**: dropdown in Settings (default 10)
- **GitHub diff size limit fix**: falls back to assembling from file patches when full diff exceeds 20k lines

## Parallel Review Architecture
1. **Planner** — lightweight call with hunk index only → outputs topic assignments, story arc, and narrative briefs
2. **Writers** — all topics fire simultaneously via Promise.all() → each gets scoped context (only relevant hunks + files) plus the story arc, its narrative brief, and dependency briefs for continuity
3. **Assembly** — merges slides in planner order, catches unassigned hunks, renders syntax highlighting

Behind feature flag: Settings > Parallel review (off by default).

## Test plan
- [ ] Enable Parallel review in Settings, generate a review — verify slides have narrative consistency
- [ ] Generate a review for a large PR (20+ files) — verify diff-too-large fallback works
- [ ] Delete preferences.json, restart — verify onboarding repo setup dialog appears after auth
- [ ] Verify max PRs per repo limits proactive polling
- [ ] Verify single-shot mode still works with parallel review disabled