### PR TITLE
feat: analytics opt-out in settings

### DIFF
--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -120,6 +120,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
   const [trayEnabled, setTrayEnabled] = useState(true);
   const [maxPrsPerRepo, setMaxPrsPerRepo] = useState(10);
   const [parallelReview, setParallelReview] = useState(false);
+  const [analytics, setAnalytics] = useState(true);
   const [claudePath, setClaudePath] = useState('');
   const [geminiPath, setGeminiPath] = useState('');
   const [claudeDetected, setClaudeDetected] = useState('');
@@ -141,6 +142,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
       setTrayEnabled(prefs.trayEnabled);
       setMaxPrsPerRepo(prefs.maxPrsPerRepo);
       setParallelReview(prefs.parallelReview);
+      setAnalytics(prefs.analytics);
       setClaudePath(prefs.claudePath || '');
       setGeminiPath(prefs.geminiPath || '');
     });
@@ -397,6 +399,21 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
                   const next = !trayEnabled;
                   setTrayEnabled(next);
                   saveField({ trayEnabled: next });
+                }}
+              />
+            </SettingRow>
+
+            <SettingRow
+              label="Anonymous usage analytics"
+              description="Sends anonymous app-usage events (e.g. launches, feature usage) to Aptabase, an open-source, privacy-first analytics service. No personal data, no IP addresses, no PRs, no source code — just anonymous event counts that help us decide what to build next."
+            >
+              <Toggle
+                checked={analytics}
+                ariaLabel="Anonymous usage analytics"
+                onChange={() => {
+                  const next = !analytics;
+                  setAnalytics(next);
+                  saveField({ analytics: next });
                 }}
               />
             </SettingRow>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -248,6 +248,7 @@ export interface Preferences {
   trayEnabled: boolean;
   maxPrsPerRepo: number;
   parallelReview: boolean;
+  analytics: boolean;
 }
 
 export interface SendSlideChatRequest {

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,7 +58,14 @@ declare const __GH_CLIENT_SECRET__: string;
 const GITHUB_CLIENT_ID = 'Ov23lifGr1yrXtcZD5Og';
 const GITHUB_CLIENT_SECRET: string = typeof __GH_CLIENT_SECRET__ !== 'undefined' ? __GH_CLIENT_SECRET__ : '';
 
-void initAptabase('A-EU-7599830434');
+const APTABASE_APP_KEY = 'A-EU-7599830434';
+let aptabaseInitialized = false;
+
+function enableAnalyticsIfAllowed(prefs: Preferences): void {
+  if (!prefs.analytics || aptabaseInitialized) return;
+  void initAptabase(APTABASE_APP_KEY);
+  aptabaseInitialized = true;
+}
 
 // ── In-memory cache ─────────────────────────────────────────────
 
@@ -672,7 +679,9 @@ void app.whenReady().then(() => {
   // Expose packaged state to preload via env var (before creating windows)
   process.env.APP_IS_PACKAGED = app.isPackaged ? '1' : '0';
 
-  void trackEvent('app_started');
+  const prefs = loadPreferences();
+  enableAnalyticsIfAllowed(prefs);
+  if (prefs.analytics) void trackEvent('app_started');
 
   // Mark any stale "generating" entries from a previous crash as failed
   cleanupStaleGeneratingEntries();
@@ -940,6 +949,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   trayEnabled: true,
   maxPrsPerRepo: 10,
   parallelReview: true,
+  analytics: true,
 };
 
 function applyBinaryOverrides(prefs: Preferences): void {
@@ -1095,6 +1105,9 @@ ipcMain.handle('save-preferences', (_event, prefs: Preferences) => {
   } else {
     destroyTray();
   }
+  // Pick up analytics opt-in turned on mid-session. Opt-out takes effect on
+  // next launch — the SDK has no deinit, so we just stop sending events.
+  enableAnalyticsIfAllowed(prefs);
 });
 
 ipcMain.handle('detect-binary-path', (_event, name: string) => {


### PR DESCRIPTION
Stacked on top of #77.

## Summary
- Adds `analytics: boolean` to `Preferences` (default `true`).
- Gates `initialize()` and `trackEvent()` on the preference.
- Adds an "Anonymous usage analytics" toggle in Settings with copy that names Aptabase and explains what gets sent (anonymous event counts) and what doesn't (personal data, IP addresses, PRs, source code).
- Opt-in turned on mid-session takes effect immediately; opt-out takes effect on next launch since the SDK has no deinit — we just stop sending events.

## Test plan
- [ ] Fresh install: toggle starts on; `app_started` is sent.
- [ ] Toggle off → relaunch → no events sent.
- [ ] Toggle off → toggle on same session → future events sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)