### PR TITLE
feat: editorial settings dialog with TOC rail + polish

### DIFF
--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -62,8 +62,9 @@ export function applyCodeFont(fontId: string) {
   }
 }
 
-// Quiet toggle switch — warm-amber active state, flat thumb, no shadcn
-// defaults. Used across all the on/off settings.
+// Quiet toggle switch — ink-on-paper active state, flat thumb. Keeps
+// brand claret reserved as punctuation (focus, active TOC marker, the
+// override rail) rather than coating every "on" control.
 function Toggle({
   checked,
   onChange,
@@ -80,8 +81,8 @@ function Toggle({
       aria-checked={checked}
       aria-label={ariaLabel}
       onClick={onChange}
-      className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border transition-colors ${
-        checked ? 'bg-[var(--ring)] border-[var(--ring)]' : 'bg-transparent border-border'
+      className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-card ${
+        checked ? 'bg-foreground border-foreground' : 'bg-transparent border-border'
       }`}
     >
       <span
@@ -95,8 +96,8 @@ function Toggle({
 
 // Quiet text-only chip. Active option gets a hairline brand-claret
 // underline. Used inside radiogroups — the group provides the label,
-// each chip reports aria-checked so screen readers announce the
-// current selection in context.
+// arrow-key traversal, and roving tabindex; each chip just reports
+// aria-checked so screen readers announce the current selection.
 function Chip({
   active,
   onClick,
@@ -116,6 +117,7 @@ function Chip({
       role="radio"
       aria-checked={active}
       aria-label={ariaLabel}
+      tabIndex={active ? 0 : -1}
       onClick={onClick}
       style={style}
       className={`text-sm pb-0.5 border-b transition-colors focus-visible:outline-none focus-visible:text-foreground ${
@@ -129,6 +131,11 @@ function Chip({
   );
 }
 
+// Radiogroup with W3C keyboard nav: ←/→/↑/↓ moves focus AND activates
+// the next/prev chip (wrapping at ends); Home/End jump to first/last.
+// Matches the roving-tabindex pattern — only the selected chip is in
+// the tab order, and arrow keys move BOTH focus and selection, which
+// is what screen readers announce as "radio group, Paper, 1 of 3."
 function ChipGroup({
   label,
   children,
@@ -136,8 +143,55 @@ function ChipGroup({
   label: string;
   children: React.ReactNode;
 }) {
+  const groupRef = useRef<HTMLDivElement | null>(null);
+
+  function move(delta: number | 'home' | 'end') {
+    const root = groupRef.current;
+    if (!root) return;
+    const chips = Array.from(root.querySelectorAll<HTMLButtonElement>('[role="radio"]'));
+    if (chips.length === 0) return;
+    const active = document.activeElement;
+    const currentIdx = chips.findIndex((c) => c === active);
+    const anchor = currentIdx === -1 ? chips.findIndex((c) => c.getAttribute('aria-checked') === 'true') : currentIdx;
+    const from = anchor === -1 ? 0 : anchor;
+    let next: number;
+    if (delta === 'home') next = 0;
+    else if (delta === 'end') next = chips.length - 1;
+    else next = (from + delta + chips.length) % chips.length;
+    const target = chips[next];
+    target.focus();
+    target.click();
+  }
+
   return (
-    <div role="radiogroup" aria-label={label} className="flex flex-wrap gap-x-4 gap-y-2">
+    <div
+      ref={groupRef}
+      role="radiogroup"
+      aria-label={label}
+      className="flex flex-wrap gap-x-4 gap-y-2"
+      onKeyDown={(e) => {
+        switch (e.key) {
+          case 'ArrowLeft':
+          case 'ArrowUp':
+            e.preventDefault();
+            move(-1);
+            break;
+          case 'ArrowRight':
+          case 'ArrowDown':
+            e.preventDefault();
+            move(1);
+            break;
+          case 'Home':
+            e.preventDefault();
+            move('home');
+            break;
+          case 'End':
+            e.preventDefault();
+            move('end');
+            break;
+        }
+      }}
+    >
       {children}
     </div>
   );
@@ -206,8 +260,16 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
   const [claudeDetected, setClaudeDetected] = useState('');
   const [geminiDetected, setGeminiDetected] = useState('');
 
-  const [activeSection, setActiveSection] = useState<SectionId>('appearance');
-  const [savedTick, setSavedTick] = useState(0);
+  const [activeSection, setActiveSection] = useState<SectionId>(() => {
+    // Remember which section the user last visited. Power users
+    // returning to tweak the same setting shouldn't have to scroll.
+    try {
+      const stored = localStorage.getItem('gnosis-settings-last-section');
+      if (stored && SECTIONS.some((s) => s.id === stored)) return stored as SectionId;
+    } catch { /* localStorage unavailable — fine, default */ }
+    return 'appearance';
+  });
+  const [saveStatus, setSaveStatus] = useState<{ tick: number; state: 'saved' | 'error' }>({ tick: 0, state: 'saved' });
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const sectionRefs = useRef<Record<SectionId, HTMLElement | null>>({
     appearance: null,
@@ -222,30 +284,15 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
 
   useEffect(() => {
     if (!open) return;
-    void window.electronAPI.loadPreferences().then((prefs) => {
-      setAppTheme(prefs.theme);
-      if (prefs.codeTheme) setCodeTheme(prefs.codeTheme as CodeTheme);
-      if (prefs.codeFont) setCodeFont(prefs.codeFont as CodeFont);
-      setEnableTools(prefs.enableTools);
-      setProactiveMode(prefs.proactiveMode);
-      setWatchedRepos(prefs.watchedRepos);
-      setNotifications(prefs.notifications);
-      setTrayEnabled(prefs.trayEnabled);
-      setMaxPrsPerRepo(prefs.maxPrsPerRepo);
-      setParallelReview(prefs.parallelReview);
-      setAnalytics(prefs.analytics);
-      setManualProvider(prefs.provider);
-      setManualModel(prefs.model);
-      setProactiveReviewOverrides(prefs.proactiveReviewOverrides);
-      setProactiveProvider(prefs.proactiveProvider);
-      setProactiveModel(prefs.proactiveModel);
-      setProactiveThinking(prefs.proactiveThinking);
-      setClaudePath(prefs.claudePath || '');
-      setGeminiPath(prefs.geminiPath || '');
-    });
+    void window.electronAPI.loadPreferences().then(applyLoadedPrefs);
     void window.electronAPI.detectBinaryPath('claude').then(setClaudeDetected);
     void window.electronAPI.detectBinaryPath('gemini').then(setGeminiDetected);
   }, [open]);
+
+  // Remember the last-visited section across opens.
+  useEffect(() => {
+    try { localStorage.setItem('gnosis-settings-last-section', activeSection); } catch { /* non-fatal */ }
+  }, [activeSection]);
 
   // Intersection-based TOC highlight. Picks the section whose top edge is
   // closest to (but not past) the scroll container's top. Only runs while
@@ -281,11 +328,40 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
   }
 
   function saveField(overrides: Partial<Preferences>) {
-    void window.electronAPI.loadPreferences().then((prefs) => {
-      void window.electronAPI.savePreferences({ ...prefs, ...overrides }).then(() => {
-        setSavedTick((n) => n + 1);
+    void window.electronAPI
+      .loadPreferences()
+      .then((prefs) => window.electronAPI.savePreferences({ ...prefs, ...overrides }))
+      .then(() => {
+        setSaveStatus((s) => ({ tick: s.tick + 1, state: 'saved' }));
+      })
+      .catch(() => {
+        setSaveStatus((s) => ({ tick: s.tick + 1, state: 'error' }));
+        // Reconcile optimistic UI with actually-persisted prefs so the
+        // user doesn't see a setting "stick" that never saved.
+        void window.electronAPI.loadPreferences().then(applyLoadedPrefs);
       });
-    });
+  }
+
+  function applyLoadedPrefs(prefs: Preferences) {
+    setAppTheme(prefs.theme);
+    if (prefs.codeTheme) setCodeTheme(prefs.codeTheme as CodeTheme);
+    if (prefs.codeFont) setCodeFont(prefs.codeFont as CodeFont);
+    setEnableTools(prefs.enableTools);
+    setProactiveMode(prefs.proactiveMode);
+    setWatchedRepos(prefs.watchedRepos);
+    setNotifications(prefs.notifications);
+    setTrayEnabled(prefs.trayEnabled);
+    setMaxPrsPerRepo(prefs.maxPrsPerRepo);
+    setParallelReview(prefs.parallelReview);
+    setAnalytics(prefs.analytics);
+    setManualProvider(prefs.provider);
+    setManualModel(prefs.model);
+    setProactiveReviewOverrides(prefs.proactiveReviewOverrides);
+    setProactiveProvider(prefs.proactiveProvider);
+    setProactiveModel(prefs.proactiveModel);
+    setProactiveThinking(prefs.proactiveThinking);
+    setClaudePath(prefs.claudePath || '');
+    setGeminiPath(prefs.geminiPath || '');
   }
 
   function addWatchedRepo(name: string) {
@@ -309,36 +385,81 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
     applyCodeFont(font);
   }
 
-  function scrollTo(id: SectionId) {
+  function scrollTo(id: SectionId, behavior: ScrollBehavior = 'smooth') {
     const el = sectionRefs.current[id];
-    if (el && scrollRef.current) {
-      scrollRef.current.scrollTo({ top: el.offsetTop - 8, behavior: 'smooth' });
-    }
+    const root = scrollRef.current;
+    if (!el || !root) return;
+    // rect math is robust to positioned-ancestor quirks that offsetTop
+    // doesn't handle.
+    const top = el.getBoundingClientRect().top - root.getBoundingClientRect().top + root.scrollTop;
+    root.scrollTo({ top: top - 4, behavior });
   }
+
+  // Restore scroll to the remembered section when the dialog opens.
+  useEffect(() => {
+    if (!open) return;
+    // Defer one tick so the section refs are mounted.
+    const t = setTimeout(() => scrollTo(activeSection, 'auto'), 0);
+    return () => clearTimeout(t);
+    // Intentionally only re-runs on `open`. Reading `activeSection`
+    // here captures the value at open-time, which is what we want —
+    // we don't want to re-scroll every time the user navigates.
+  }, [open]);
+
+  // Keyboard shortcuts: digits 1-5 jump to the matching section when
+  // focus isn't inside a text input. Typed digits inside the repo
+  // search or CLI path inputs still work normally.
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+      const n = Number(e.key);
+      if (!Number.isNaN(n) && n >= 1 && n <= SECTIONS.length) {
+        e.preventDefault();
+        const id = SECTIONS[n - 1].id;
+        setActiveSection(id);
+        scrollTo(id);
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-card p-0 sm:max-w-3xl overflow-hidden">
-        <div className="grid grid-cols-[160px_1fr] max-h-[min(85vh,720px)]">
+      {/* `zoom-in-100` + `zoom-out-100` cancel the default pop-zoom
+          entrance from the shadcn dialog primitive so the dialog just
+          fades in. Editorial motion — page-turn register, not SaaS. */}
+      <DialogContent className="bg-card p-0 sm:max-w-3xl overflow-hidden data-[state=open]:zoom-in-100 data-[state=closed]:zoom-out-100">
+        <div className="grid grid-cols-[168px_1fr] max-h-[min(85vh,720px)]">
           {/* Left rail — editorial TOC */}
           <nav
             aria-label="Settings sections"
-            className="flex flex-col gap-4 pl-6 pr-3 py-8 border-r border-border/60"
+            className="flex flex-col gap-5 pl-6 pr-3 py-8 border-r border-border/60"
           >
-            <DialogHeader className="mb-2">
-              <DialogTitle className="editorial-heading text-foreground">Settings</DialogTitle>
+            <DialogHeader className="mb-2 space-y-0.5">
+              <DialogTitle
+                asChild
+                className="slide-title !text-[1.65rem] !leading-none text-foreground"
+              >
+                <h1>Settings</h1>
+              </DialogTitle>
               <DialogDescription className="sr-only">
-                Appearance, review behaviour, proactive mode, system, and advanced options.
+                Appearance, review behaviour, proactive mode, system, and advanced options. Press 1 through 5 to jump sections.
               </DialogDescription>
             </DialogHeader>
             <ul className="flex flex-col gap-2">
-              {SECTIONS.map((s) => {
+              {SECTIONS.map((s, i) => {
                 const active = activeSection === s.id;
                 return (
                   <li key={s.id}>
                     <button
                       type="button"
-                      onClick={() => scrollTo(s.id)}
+                      onClick={() => { setActiveSection(s.id); scrollTo(s.id); }}
+                      aria-current={active ? 'location' : undefined}
+                      title={`Jump to ${s.label} (${i + 1})`}
                       className={`w-full text-left flex items-baseline gap-2 text-sm transition-colors ${
                         active ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
                       }`}
@@ -362,6 +483,9 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
                 );
               })}
             </ul>
+            <p className="slide-meta mt-auto pr-1 leading-relaxed">
+              Press <kbd className="kbd">1</kbd>–<kbd className="kbd">5</kbd> to jump.
+            </p>
           </nav>
 
           {/* Right pane — scrollable content */}
@@ -482,7 +606,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
 
                   <SettingRow
                     label="Proactive mode"
-                    description="Review your PRs, assigned reviews, and watched repos automatically. Re-generates when a PR updates."
+                    description="Review your PRs, assigned reviews, and watched repos automatically. Checks every 5 minutes; re-generates when a PR updates."
                   >
                     <Toggle
                       checked={proactiveMode}
@@ -500,57 +624,16 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
                       <div className="flex flex-col gap-2">
                         <span className="text-sm font-medium text-foreground">Watched repos</span>
                         <span className="slide-meta">All open PRs in these repos are reviewed automatically.</span>
-                        <div className="relative mt-1">
-                          <input
-                            type="text"
-                            value={watchedRepoInput}
-                            placeholder="Search for a repo…"
-                            onChange={(e) => {
-                              const val = e.target.value;
-                              setWatchedRepoInput(val);
-                              setSuggestionsDismissed(false);
-                              if (debounceRef.current) clearTimeout(debounceRef.current);
-                              if (val.trim().length >= 2) {
-                                debounceRef.current = setTimeout(() => {
-                                  void window.electronAPI.searchRepos(val.trim()).then((results) => {
-                                    setRepoSuggestions(results.filter((r) => !watchedRepos.includes(r.fullName)));
-                                  });
-                                }, 300);
-                              } else {
-                                setRepoSuggestions([]);
-                              }
-                            }}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter') {
-                                e.preventDefault();
-                                const trimmed = watchedRepoInput.trim();
-                                if (trimmed.includes('/')) addWatchedRepo(trimmed);
-                              }
-                              if (e.key === 'Escape') setSuggestionsDismissed(true);
-                            }}
-                            onFocus={() => setSuggestionsDismissed(false)}
-                            onBlur={() => setTimeout(() => setSuggestionsDismissed(true), 200)}
-                            className="w-full bg-transparent border-0 border-b border-border px-0 py-1 text-sm text-foreground placeholder:text-muted-foreground/60 transition-colors focus:outline-none focus:border-[var(--ring)]"
-                          />
-                          {showSuggestions && (
-                            <ul className="absolute z-50 top-full left-0 right-0 mt-1 bg-popover border border-border rounded-md shadow-md max-h-48 overflow-y-auto">
-                              {repoSuggestions.map((repo) => (
-                                <li key={repo.fullName}>
-                                  <button
-                                    type="button"
-                                    className="w-full text-left px-3 py-2 text-sm hover:bg-accent transition-colors flex flex-col gap-0.5"
-                                    onMouseDown={(e) => { e.preventDefault(); addWatchedRepo(repo.fullName); }}
-                                  >
-                                    <span className="font-mono text-xs text-foreground">{repo.fullName}</span>
-                                    {repo.description && (
-                                      <span className="text-xs text-muted-foreground truncate">{repo.description}</span>
-                                    )}
-                                  </button>
-                                </li>
-                              ))}
-                            </ul>
-                          )}
-                        </div>
+                        <WatchedRepoInput
+                          value={watchedRepoInput}
+                          setValue={setWatchedRepoInput}
+                          suggestions={showSuggestions ? repoSuggestions : []}
+                          setSuggestions={setRepoSuggestions}
+                          setSuggestionsDismissed={setSuggestionsDismissed}
+                          debounceRef={debounceRef}
+                          watchedRepos={watchedRepos}
+                          addWatchedRepo={addWatchedRepo}
+                        />
                         {watchedRepos.length > 0 && (
                           <ul className="flex flex-col gap-1 mt-2">
                             {watchedRepos.map((repo) => (
@@ -815,9 +898,10 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
               </div>
             </div>
 
-            {/* Unobtrusive save acknowledgement — fades in for ~1s after each save.
-               Re-keyed on savedTick so rapid saves reset the animation. */}
-            <SavedIndicator tick={savedTick} />
+            {/* Unobtrusive save acknowledgement — fades in for ~1s after each write.
+               Re-keyed on tick so rapid saves reset the animation. Reports
+               failures in the same slot so the user isn't left guessing. */}
+            <SaveIndicator status={saveStatus} />
           </div>
         </div>
       </DialogContent>
@@ -825,18 +909,148 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
   );
 }
 
-// Small "Saved" acknowledgement bottom-right of the content pane. Fades in
+// Small save acknowledgement bottom-right of the content pane. Fades in
 // for ~1.1s after each save, then fades out. Uses a keyed remount so
-// rapid consecutive saves reliably restart the animation.
-function SavedIndicator({ tick }: { tick: number }) {
-  if (tick === 0) return null;
+// rapid consecutive saves reliably restart the animation. Error state
+// uses --destructive so failures read as failures, not brand accent.
+function SaveIndicator({ status }: { status: { tick: number; state: 'saved' | 'error' } }) {
+  if (status.tick === 0) return null;
   return (
     <span
-      key={tick}
+      key={status.tick}
+      role="status"
       aria-live="polite"
-      className="pointer-events-none absolute bottom-3 right-5 slide-meta text-[var(--ring)] opacity-0 saved-flash"
+      className={`pointer-events-none absolute bottom-3 right-5 slide-meta opacity-0 saved-flash ${
+        status.state === 'saved' ? 'text-muted-foreground' : 'text-destructive'
+      }`}
     >
-      Saved.
+      {status.state === 'saved' ? 'Saved.' : "Couldn't save."}
     </span>
+  );
+}
+
+// Repo search with a proper combobox/listbox a11y contract. Typing
+// debounces to the backend; ArrowDown from the input moves focus into
+// the suggestion list; ArrowUp/Down cycle within the list; Enter
+// activates; Escape dismisses. Keyboard-only users can reach a
+// suggestion without ever touching the mouse.
+function WatchedRepoInput({
+  value,
+  setValue,
+  suggestions,
+  setSuggestions,
+  setSuggestionsDismissed,
+  debounceRef,
+  watchedRepos,
+  addWatchedRepo,
+}: {
+  value: string;
+  setValue: (v: string) => void;
+  suggestions: RepoSearchResult[];
+  setSuggestions: (s: RepoSearchResult[]) => void;
+  setSuggestionsDismissed: (b: boolean) => void;
+  debounceRef: React.RefObject<ReturnType<typeof setTimeout> | null>;
+  watchedRepos: string[];
+  addWatchedRepo: (name: string) => void;
+}) {
+  const listRef = useRef<HTMLUListElement | null>(null);
+  const trimmed = value.trim();
+  const hasSlash = trimmed.includes('/');
+  const hasError = trimmed.length > 0 && !hasSlash && suggestions.length === 0;
+
+  function focusOption(index: number) {
+    const list = listRef.current;
+    if (!list) return;
+    const options = Array.from(list.querySelectorAll<HTMLButtonElement>('[role="option"]'));
+    if (options.length === 0) return;
+    const clamped = (index + options.length) % options.length;
+    options[clamped]?.focus();
+  }
+
+  return (
+    <>
+      <div className="relative mt-1">
+        <input
+          type="text"
+          value={value}
+          role="combobox"
+          aria-autocomplete="list"
+          aria-expanded={suggestions.length > 0}
+          aria-controls="watched-repo-suggestions"
+          placeholder="owner/repo — or search by name"
+          onChange={(e) => {
+            const val = e.target.value;
+            setValue(val);
+            setSuggestionsDismissed(false);
+            if (debounceRef.current) clearTimeout(debounceRef.current);
+            if (val.trim().length >= 2) {
+              debounceRef.current = setTimeout(() => {
+                void window.electronAPI.searchRepos(val.trim()).then((results) => {
+                  setSuggestions(results.filter((r) => !watchedRepos.includes(r.fullName)));
+                });
+              }, 300);
+            } else {
+              setSuggestions([]);
+            }
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              if (hasSlash) addWatchedRepo(trimmed);
+            } else if (e.key === 'ArrowDown' && suggestions.length > 0) {
+              e.preventDefault();
+              focusOption(0);
+            } else if (e.key === 'Escape') {
+              setSuggestionsDismissed(true);
+            }
+          }}
+          onFocus={() => setSuggestionsDismissed(false)}
+          onBlur={(e) => {
+            // Don't dismiss when focus moves into the suggestion list.
+            const next = e.relatedTarget as HTMLElement | null;
+            if (next && listRef.current?.contains(next)) return;
+            setSuggestionsDismissed(true);
+          }}
+          className="w-full bg-transparent border-0 border-b border-border px-0 py-1 text-sm text-foreground placeholder:text-muted-foreground/60 transition-colors focus:outline-none focus:border-[var(--ring)]"
+        />
+        {suggestions.length > 0 && (
+          <ul
+            ref={listRef}
+            id="watched-repo-suggestions"
+            role="listbox"
+            className="absolute z-50 top-full left-0 right-0 mt-1 bg-popover border border-border rounded-md shadow-md max-h-48 overflow-y-auto"
+          >
+            {suggestions.map((repo, i) => (
+              <li key={repo.fullName}>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={false}
+                  tabIndex={-1}
+                  className="w-full text-left px-3 py-2 text-sm hover:bg-accent focus:bg-accent focus:outline-none transition-colors flex flex-col gap-0.5"
+                  onMouseDown={(e) => { e.preventDefault(); addWatchedRepo(repo.fullName); }}
+                  onClick={() => addWatchedRepo(repo.fullName)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'ArrowDown') { e.preventDefault(); focusOption(i + 1); }
+                    else if (e.key === 'ArrowUp') { e.preventDefault(); focusOption(i - 1); }
+                    else if (e.key === 'Escape') { setSuggestionsDismissed(true); }
+                  }}
+                >
+                  <span className="font-mono text-xs text-foreground">{repo.fullName}</span>
+                  {repo.description && (
+                    <span className="text-xs text-muted-foreground truncate">{repo.description}</span>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <span className={`slide-meta ${hasError ? 'text-destructive' : ''}`}>
+        {hasError
+          ? 'Needs `owner/repo` format, or pick from suggestions.'
+          : 'Tip: ↓ into suggestions · Enter to add · `owner/repo` format.'}
+      </span>
+    </>
   );
 }

--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -5,6 +5,9 @@ import type { CodeTheme, CodeFont } from '@/lib/constants';
 import { applyTheme, type ThemeChoice } from '@/lib/theme';
 import type { ModelId, Preferences, Provider, RepoSearchResult } from '@/lib/types';
 
+// Renderer-safe catalog of providers and their selectable models. Kept here
+// rather than imported from lib/providers/* because those modules pull in
+// Node APIs (child_process, fs) that can't run in the renderer.
 const PROVIDER_MODELS: Record<Provider, { label: string; models: { id: ModelId; label: string }[] }> = {
   claude: {
     label: 'Claude',
@@ -26,6 +29,20 @@ const PROVIDER_MODELS: Record<Provider, { label: string; models: { id: ModelId; 
   },
 };
 
+function modelLabel(provider: Provider, id: ModelId): string {
+  return PROVIDER_MODELS[provider].models.find((m) => m.id === id)?.label ?? id;
+}
+
+const SECTIONS = [
+  { id: 'appearance', num: '01', label: 'Appearance' },
+  { id: 'review', num: '02', label: 'Review' },
+  { id: 'proactive', num: '03', label: 'Proactive' },
+  { id: 'system', num: '04', label: 'System' },
+  { id: 'advanced', num: '05', label: 'Advanced' },
+] as const;
+
+type SectionId = (typeof SECTIONS)[number]['id'];
+
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -45,9 +62,8 @@ export function applyCodeFont(fontId: string) {
   }
 }
 
-// Quiet toggle switch — drops the bg-primary fill (now ink) and the
-// shadow-sm thumb in favor of a warm-amber active state and a flat
-// thumb. Used across all the on/off settings.
+// Quiet toggle switch — warm-amber active state, flat thumb, no shadcn
+// defaults. Used across all the on/off settings.
 function Toggle({
   checked,
   onChange,
@@ -77,30 +93,53 @@ function Toggle({
   );
 }
 
-// Quiet text-only chip — same vocabulary as DiffLayoutToggle. Active
-// option gets a hairline brand-amber underline; nothing else.
+// Quiet text-only chip. Active option gets a hairline brand-claret
+// underline. Used inside radiogroups — the group provides the label,
+// each chip reports aria-checked so screen readers announce the
+// current selection in context.
 function Chip({
   active,
   onClick,
   children,
   style,
+  ariaLabel,
 }: {
   active: boolean;
   onClick: () => void;
   children: React.ReactNode;
   style?: React.CSSProperties;
+  ariaLabel?: string;
 }) {
   return (
     <button
       type="button"
+      role="radio"
+      aria-checked={active}
+      aria-label={ariaLabel}
       onClick={onClick}
       style={style}
-      className={`text-sm pb-0.5 border-b transition-colors ${
-        active ? 'text-foreground border-[var(--ring)]' : 'border-transparent text-muted-foreground hover:text-foreground'
+      className={`text-sm pb-0.5 border-b transition-colors focus-visible:outline-none focus-visible:text-foreground ${
+        active
+          ? 'text-foreground border-[var(--ring)]'
+          : 'border-transparent text-muted-foreground hover:text-foreground focus-visible:border-[var(--ring)]/50'
       }`}
     >
       {children}
     </button>
+  );
+}
+
+function ChipGroup({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div role="radiogroup" aria-label={label} className="flex flex-wrap gap-x-4 gap-y-2">
+      {children}
+    </div>
   );
 }
 
@@ -111,17 +150,30 @@ function SettingRow({
   children,
 }: {
   label: string;
-  description?: string;
+  description?: React.ReactNode;
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center justify-between gap-4 py-1">
+    <div className="flex items-start justify-between gap-4 py-1">
       <div className="flex flex-col gap-0.5 min-w-0">
         <span className="text-sm font-medium text-foreground">{label}</span>
         {description && <span className="slide-meta">{description}</span>}
       </div>
-      <div className="shrink-0">{children}</div>
+      <div className="shrink-0 pt-0.5">{children}</div>
     </div>
+  );
+}
+
+// Editorial section header: "01  Appearance" in the content pane.
+function SectionHeader({ num, title, sub }: { num: string; title: string; sub?: string }) {
+  return (
+    <header className="flex flex-col gap-1">
+      <div className="flex items-baseline gap-3">
+        <span className="slide-chapter text-muted-foreground">{num}</span>
+        <h2 className="editorial-heading text-foreground">{title}</h2>
+      </div>
+      {sub && <p className="slide-meta">{sub}</p>}
+    </header>
   );
 }
 
@@ -142,6 +194,9 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
   const [maxPrsPerRepo, setMaxPrsPerRepo] = useState(10);
   const [parallelReview, setParallelReview] = useState(false);
   const [analytics, setAnalytics] = useState(true);
+  const [analyticsExpanded, setAnalyticsExpanded] = useState(false);
+  const [manualProvider, setManualProvider] = useState<Provider>('claude');
+  const [manualModel, setManualModel] = useState<ModelId>('claude-opus-4-7');
   const [proactiveReviewOverrides, setProactiveReviewOverrides] = useState(false);
   const [proactiveProvider, setProactiveProvider] = useState<Provider>('claude');
   const [proactiveModel, setProactiveModel] = useState<ModelId>('claude-sonnet-4-6');
@@ -150,6 +205,17 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
   const [geminiPath, setGeminiPath] = useState('');
   const [claudeDetected, setClaudeDetected] = useState('');
   const [geminiDetected, setGeminiDetected] = useState('');
+
+  const [activeSection, setActiveSection] = useState<SectionId>('appearance');
+  const [savedTick, setSavedTick] = useState(0);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const sectionRefs = useRef<Record<SectionId, HTMLElement | null>>({
+    appearance: null,
+    review: null,
+    proactive: null,
+    system: null,
+    advanced: null,
+  });
 
   // Clean up debounce timer on unmount
   useEffect(() => () => { if (debounceRef.current) clearTimeout(debounceRef.current); }, []);
@@ -162,12 +228,14 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
       if (prefs.codeFont) setCodeFont(prefs.codeFont as CodeFont);
       setEnableTools(prefs.enableTools);
       setProactiveMode(prefs.proactiveMode);
-      setWatchedRepos(prefs.watchedRepos ?? []);
+      setWatchedRepos(prefs.watchedRepos);
       setNotifications(prefs.notifications);
       setTrayEnabled(prefs.trayEnabled);
       setMaxPrsPerRepo(prefs.maxPrsPerRepo);
       setParallelReview(prefs.parallelReview);
       setAnalytics(prefs.analytics);
+      setManualProvider(prefs.provider);
+      setManualModel(prefs.model);
       setProactiveReviewOverrides(prefs.proactiveReviewOverrides);
       setProactiveProvider(prefs.proactiveProvider);
       setProactiveModel(prefs.proactiveModel);
@@ -179,6 +247,33 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
     void window.electronAPI.detectBinaryPath('gemini').then(setGeminiDetected);
   }, [open]);
 
+  // Intersection-based TOC highlight. Picks the section whose top edge is
+  // closest to (but not past) the scroll container's top. Only runs while
+  // the dialog is open.
+  useEffect(() => {
+    if (!open) return;
+    const root = scrollRef.current;
+    if (!root) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        // Pick the topmost entry that's currently intersecting. If multiple
+        // sections are visible, the one highest in the viewport wins.
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible[0]) {
+          setActiveSection(visible[0].target.getAttribute('data-section') as SectionId);
+        }
+      },
+      { root, rootMargin: '0px 0px -65% 0px', threshold: 0 }
+    );
+    SECTIONS.forEach((s) => {
+      const el = sectionRefs.current[s.id];
+      if (el) observer.observe(el);
+    });
+    return () => observer.disconnect();
+  }, [open]);
+
   function handleSelectAppTheme(theme: ThemeChoice) {
     setAppTheme(theme);
     saveField({ theme });
@@ -187,7 +282,9 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
 
   function saveField(overrides: Partial<Preferences>) {
     void window.electronAPI.loadPreferences().then((prefs) => {
-      void window.electronAPI.savePreferences({ ...prefs, ...overrides });
+      void window.electronAPI.savePreferences({ ...prefs, ...overrides }).then(() => {
+        setSavedTick((n) => n + 1);
+      });
     });
   }
 
@@ -212,377 +309,534 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
     applyCodeFont(font);
   }
 
+  function scrollTo(id: SectionId) {
+    const el = sectionRefs.current[id];
+    if (el && scrollRef.current) {
+      scrollRef.current.scrollTo({ top: el.offsetTop - 8, behavior: 'smooth' });
+    }
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-card sm:max-w-md max-h-[80vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle className="editorial-heading">Settings</DialogTitle>
-          <DialogDescription className="slide-meta">Configure your preferences</DialogDescription>
-        </DialogHeader>
+      <DialogContent className="bg-card p-0 sm:max-w-3xl overflow-hidden">
+        <div className="grid grid-cols-[160px_1fr] max-h-[min(85vh,720px)]">
+          {/* Left rail — editorial TOC */}
+          <nav
+            aria-label="Settings sections"
+            className="flex flex-col gap-4 pl-6 pr-3 py-8 border-r border-border/60"
+          >
+            <DialogHeader className="mb-2">
+              <DialogTitle className="editorial-heading text-foreground">Settings</DialogTitle>
+              <DialogDescription className="sr-only">
+                Appearance, review behaviour, proactive mode, system, and advanced options.
+              </DialogDescription>
+            </DialogHeader>
+            <ul className="flex flex-col gap-2">
+              {SECTIONS.map((s) => {
+                const active = activeSection === s.id;
+                return (
+                  <li key={s.id}>
+                    <button
+                      type="button"
+                      onClick={() => scrollTo(s.id)}
+                      className={`w-full text-left flex items-baseline gap-2 text-sm transition-colors ${
+                        active ? 'text-foreground' : 'text-muted-foreground hover:text-foreground'
+                      }`}
+                    >
+                      <span
+                        className={`font-mono text-[0.7rem] tracking-wider ${
+                          active ? 'text-[var(--ring)]' : ''
+                        }`}
+                      >
+                        {s.num}
+                      </span>
+                      <span
+                        className={`pb-0.5 border-b transition-colors ${
+                          active ? 'border-[var(--ring)]' : 'border-transparent'
+                        }`}
+                      >
+                        {s.label}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </nav>
 
-        <div className="flex flex-col gap-6 mt-2">
-          <section className="flex flex-col gap-3">
-            <label className="text-sm font-medium text-foreground">Theme</label>
-            <div className="flex flex-wrap gap-x-4 gap-y-2">
-              {(['light', 'dark', 'system'] as const).map((t) => (
-                <Chip key={t} active={appTheme === t} onClick={() => handleSelectAppTheme(t)}>
-                  {t === 'light' ? 'Paper' : t === 'dark' ? 'Study' : 'Match system'}
-                </Chip>
-              ))}
-            </div>
-          </section>
-
-          <section className="flex flex-col gap-3">
-            <label className="text-sm font-medium text-foreground">Code font</label>
-            <div className="flex flex-wrap gap-x-4 gap-y-2">
-              {CODE_FONTS.map((f) => (
-                <Chip
-                  key={f.id}
-                  active={codeFont === f.id}
-                  onClick={() => handleSelectFont(f.id)}
-                  style={{ fontFamily: `${f.family}, monospace` }}
+          {/* Right pane — scrollable content */}
+          <div className="relative">
+            <div
+              ref={scrollRef}
+              className="overflow-y-auto max-h-[min(85vh,720px)] px-7 py-8"
+            >
+              <div className="flex flex-col gap-10">
+                {/* ── 01 Appearance ── */}
+                <section
+                  ref={(el) => { sectionRefs.current.appearance = el; }}
+                  data-section="appearance"
+                  className="flex flex-col gap-5 scroll-mt-2"
                 >
-                  {f.label}
-                </Chip>
-              ))}
-            </div>
-          </section>
+                  <SectionHeader num="01" title="Appearance" sub="How the interface looks while you read." />
 
-          <section className="flex flex-col gap-3">
-            <label className="text-sm font-medium text-foreground">Code theme</label>
-            <div className="flex flex-wrap gap-x-4 gap-y-2">
-              {CODE_THEMES.map((t) => (
-                <Chip key={t.id} active={codeTheme === t.id} onClick={() => handleSelectTheme(t.id)}>
-                  {t.label}
-                </Chip>
-              ))}
-            </div>
-          </section>
-
-          <section className="flex flex-col gap-3 border-t border-border pt-5">
-            <SettingRow
-              label="Web search and context"
-              description="Let the model search the web and fetch GitHub context during generation. More thorough, but slower."
-            >
-              <Toggle
-                checked={enableTools}
-                ariaLabel="Enable AI tools"
-                onChange={() => {
-                  const next = !enableTools;
-                  setEnableTools(next);
-                  saveField({ enableTools: next });
-                }}
-              />
-            </SettingRow>
-
-            <SettingRow
-              label="Parallel review"
-              description="Split generation into a planner step then parallel writers per topic. Faster for large PRs."
-            >
-              <Toggle
-                checked={parallelReview}
-                ariaLabel="Parallel review"
-                onChange={() => {
-                  const next = !parallelReview;
-                  setParallelReview(next);
-                  saveField({ parallelReview: next });
-                }}
-              />
-            </SettingRow>
-
-            <SettingRow
-              label="Proactive mode"
-              description="Automatically review your PRs, assigned reviews, and watched repos. Re-generates when the PR updates."
-            >
-              <Toggle
-                checked={proactiveMode}
-                ariaLabel="Proactive mode"
-                onChange={() => {
-                  const next = !proactiveMode;
-                  setProactiveMode(next);
-                  saveField({ proactiveMode: next });
-                }}
-              />
-            </SettingRow>
-
-            {proactiveMode && (
-              <div className="flex flex-col gap-2 ml-0.5">
-                <label className="text-sm font-medium text-foreground">Watched repos</label>
-                <p className="text-xs text-muted-foreground">
-                  All open PRs in these repos will be reviewed automatically.
-                </p>
-                <div className="relative">
-                  <div className="flex items-end gap-2">
-                    <input
-                      type="text"
-                      value={watchedRepoInput}
-                      placeholder="Search for a repo…"
-                      onChange={(e) => {
-                        const val = e.target.value;
-                        setWatchedRepoInput(val);
-                        setSuggestionsDismissed(false);
-                        if (debounceRef.current) clearTimeout(debounceRef.current);
-                        if (val.trim().length >= 2) {
-                          debounceRef.current = setTimeout(() => {
-                            void window.electronAPI.searchRepos(val.trim()).then((results) => {
-                              setRepoSuggestions(results.filter((r) => !watchedRepos.includes(r.fullName)));
-                            });
-                          }, 300);
-                        } else {
-                          setRepoSuggestions([]);
-                        }
-                      }}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          e.preventDefault();
-                          const trimmed = watchedRepoInput.trim();
-                          if (trimmed.includes('/')) addWatchedRepo(trimmed);
-                        }
-                        if (e.key === 'Escape') setSuggestionsDismissed(true);
-                      }}
-                      onFocus={() => setSuggestionsDismissed(false)}
-                      onBlur={() => setTimeout(() => setSuggestionsDismissed(true), 200)}
-                      className="flex-1 bg-transparent border-0 border-b border-border px-0 py-1 text-sm text-foreground placeholder:text-muted-foreground/60 transition-colors"
-                    />
-                  </div>
-                  {showSuggestions && (
-                    <ul className="absolute z-50 top-full left-0 right-0 mt-1 bg-popover border border-border rounded-md shadow-md max-h-48 overflow-y-auto">
-                      {repoSuggestions.map((repo) => (
-                        <li key={repo.fullName}>
-                          <button
-                            type="button"
-                            className="w-full text-left px-3 py-2 text-sm hover:bg-accent transition-colors flex flex-col gap-0.5"
-                            onMouseDown={(e) => { e.preventDefault(); addWatchedRepo(repo.fullName); }}
-                          >
-                            <span className="font-mono text-xs text-foreground">{repo.fullName}</span>
-                            {repo.description && (
-                              <span className="text-xs text-muted-foreground truncate">{repo.description}</span>
-                            )}
-                          </button>
-                        </li>
+                  <div className="flex flex-col gap-3">
+                    <span className="text-sm font-medium text-foreground">Palette</span>
+                    <ChipGroup label="Palette">
+                      {(['light', 'dark', 'system'] as const).map((t) => (
+                        <Chip
+                          key={t}
+                          active={appTheme === t}
+                          onClick={() => handleSelectAppTheme(t)}
+                          ariaLabel={t === 'light' ? 'Paper (light)' : t === 'dark' ? 'Study (dark)' : 'Match system'}
+                        >
+                          {t === 'light' ? 'Paper' : t === 'dark' ? 'Study' : 'Match system'}
+                        </Chip>
                       ))}
-                    </ul>
+                    </ChipGroup>
+                  </div>
+
+                  <div className="flex flex-col gap-3">
+                    <span className="text-sm font-medium text-foreground">Code font</span>
+                    <ChipGroup label="Code font">
+                      {CODE_FONTS.map((f) => (
+                        <Chip
+                          key={f.id}
+                          active={codeFont === f.id}
+                          onClick={() => handleSelectFont(f.id)}
+                          style={{ fontFamily: `${f.family}, monospace` }}
+                          ariaLabel={f.label}
+                        >
+                          {f.label}
+                        </Chip>
+                      ))}
+                    </ChipGroup>
+                  </div>
+
+                  <div className="flex flex-col gap-3">
+                    <span className="text-sm font-medium text-foreground">Code theme</span>
+                    <ChipGroup label="Code theme">
+                      {CODE_THEMES.map((t) => (
+                        <Chip
+                          key={t.id}
+                          active={codeTheme === t.id}
+                          onClick={() => handleSelectTheme(t.id)}
+                          ariaLabel={t.label}
+                        >
+                          {t.label}
+                        </Chip>
+                      ))}
+                    </ChipGroup>
+                  </div>
+                </section>
+
+                {/* ── 02 Review ── */}
+                <section
+                  ref={(el) => { sectionRefs.current.review = el; }}
+                  data-section="review"
+                  className="flex flex-col gap-5 scroll-mt-2"
+                >
+                  <SectionHeader num="02" title="Review" sub="How reviews are generated." />
+
+                  <SettingRow
+                    label="Web search and context"
+                    description="Let the model search the web and fetch GitHub context. More thorough, slower."
+                  >
+                    <Toggle
+                      checked={enableTools}
+                      ariaLabel="Enable AI tools"
+                      onChange={() => {
+                        const next = !enableTools;
+                        setEnableTools(next);
+                        saveField({ enableTools: next });
+                      }}
+                    />
+                  </SettingRow>
+
+                  <SettingRow
+                    label="Parallel review"
+                    description="Split generation into a planner step, then parallel writers per topic. Faster on large PRs."
+                  >
+                    <Toggle
+                      checked={parallelReview}
+                      ariaLabel="Parallel review"
+                      onChange={() => {
+                        const next = !parallelReview;
+                        setParallelReview(next);
+                        saveField({ parallelReview: next });
+                      }}
+                    />
+                  </SettingRow>
+                </section>
+
+                {/* ── 03 Proactive ── */}
+                <section
+                  ref={(el) => { sectionRefs.current.proactive = el; }}
+                  data-section="proactive"
+                  className="flex flex-col gap-5 scroll-mt-2"
+                >
+                  <SectionHeader
+                    num="03"
+                    title="Proactive"
+                    sub="The reviews Gnosis prepares for you in the background."
+                  />
+
+                  <SettingRow
+                    label="Proactive mode"
+                    description="Review your PRs, assigned reviews, and watched repos automatically. Re-generates when a PR updates."
+                  >
+                    <Toggle
+                      checked={proactiveMode}
+                      ariaLabel="Proactive mode"
+                      onChange={() => {
+                        const next = !proactiveMode;
+                        setProactiveMode(next);
+                        saveField({ proactiveMode: next });
+                      }}
+                    />
+                  </SettingRow>
+
+                  {proactiveMode && (
+                    <div className="flex flex-col gap-5 pl-4 border-l border-border/70">
+                      <div className="flex flex-col gap-2">
+                        <span className="text-sm font-medium text-foreground">Watched repos</span>
+                        <span className="slide-meta">All open PRs in these repos are reviewed automatically.</span>
+                        <div className="relative mt-1">
+                          <input
+                            type="text"
+                            value={watchedRepoInput}
+                            placeholder="Search for a repo…"
+                            onChange={(e) => {
+                              const val = e.target.value;
+                              setWatchedRepoInput(val);
+                              setSuggestionsDismissed(false);
+                              if (debounceRef.current) clearTimeout(debounceRef.current);
+                              if (val.trim().length >= 2) {
+                                debounceRef.current = setTimeout(() => {
+                                  void window.electronAPI.searchRepos(val.trim()).then((results) => {
+                                    setRepoSuggestions(results.filter((r) => !watchedRepos.includes(r.fullName)));
+                                  });
+                                }, 300);
+                              } else {
+                                setRepoSuggestions([]);
+                              }
+                            }}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                e.preventDefault();
+                                const trimmed = watchedRepoInput.trim();
+                                if (trimmed.includes('/')) addWatchedRepo(trimmed);
+                              }
+                              if (e.key === 'Escape') setSuggestionsDismissed(true);
+                            }}
+                            onFocus={() => setSuggestionsDismissed(false)}
+                            onBlur={() => setTimeout(() => setSuggestionsDismissed(true), 200)}
+                            className="w-full bg-transparent border-0 border-b border-border px-0 py-1 text-sm text-foreground placeholder:text-muted-foreground/60 transition-colors focus:outline-none focus:border-[var(--ring)]"
+                          />
+                          {showSuggestions && (
+                            <ul className="absolute z-50 top-full left-0 right-0 mt-1 bg-popover border border-border rounded-md shadow-md max-h-48 overflow-y-auto">
+                              {repoSuggestions.map((repo) => (
+                                <li key={repo.fullName}>
+                                  <button
+                                    type="button"
+                                    className="w-full text-left px-3 py-2 text-sm hover:bg-accent transition-colors flex flex-col gap-0.5"
+                                    onMouseDown={(e) => { e.preventDefault(); addWatchedRepo(repo.fullName); }}
+                                  >
+                                    <span className="font-mono text-xs text-foreground">{repo.fullName}</span>
+                                    {repo.description && (
+                                      <span className="text-xs text-muted-foreground truncate">{repo.description}</span>
+                                    )}
+                                  </button>
+                                </li>
+                              ))}
+                            </ul>
+                          )}
+                        </div>
+                        {watchedRepos.length > 0 && (
+                          <ul className="flex flex-col gap-1 mt-2">
+                            {watchedRepos.map((repo) => (
+                              <li key={repo} className="flex items-center justify-between gap-2 text-sm text-foreground">
+                                <span className="font-mono text-xs">{repo}</span>
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    const next = watchedRepos.filter((r) => r !== repo);
+                                    setWatchedRepos(next);
+                                    saveField({ watchedRepos: next });
+                                  }}
+                                  className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+                                  aria-label={`Stop watching ${repo}`}
+                                >
+                                  Remove
+                                </button>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
+
+                      <div className="flex flex-col gap-3">
+                        <span className="text-sm font-medium text-foreground">Max PRs per repo</span>
+                        <span className="slide-meta">How many recent open PRs to review in each watched repo.</span>
+                        <ChipGroup label="Max PRs per repo">
+                          {[5, 10, 15, 20, 30, 50].map((n) => (
+                            <Chip
+                              key={n}
+                              active={maxPrsPerRepo === n}
+                              onClick={() => {
+                                setMaxPrsPerRepo(n);
+                                saveField({ maxPrsPerRepo: n });
+                              }}
+                              ariaLabel={`${n} PRs`}
+                            >
+                              {n}
+                            </Chip>
+                          ))}
+                        </ChipGroup>
+                      </div>
+
+                      <SettingRow
+                        label="Use different model for background reviews"
+                        description={
+                          <>
+                            Run proactive reviews on a faster or cheaper model while keeping your manual default.{' '}
+                            <span className="font-mono">
+                              Manual: {PROVIDER_MODELS[manualProvider].label} · {modelLabel(manualProvider, manualModel)}
+                            </span>
+                          </>
+                        }
+                      >
+                        <Toggle
+                          checked={proactiveReviewOverrides}
+                          ariaLabel="Use different model for background reviews"
+                          onChange={() => {
+                            const next = !proactiveReviewOverrides;
+                            setProactiveReviewOverrides(next);
+                            saveField({ proactiveReviewOverrides: next });
+                          }}
+                        />
+                      </SettingRow>
+
+                      {proactiveReviewOverrides && (
+                        <div className="flex flex-col gap-4 pl-4 border-l border-[var(--ring)]/40">
+                          <p className="slide-meta">For background runs only — manual reviews keep your main settings.</p>
+                          <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+                            <span className="text-sm text-muted-foreground">Provider</span>
+                            <ChipGroup label="Background provider">
+                              {(['claude', 'gemini'] as const).map((p) => (
+                                <Chip
+                                  key={p}
+                                  active={proactiveProvider === p}
+                                  onClick={() => {
+                                    const firstModel = PROVIDER_MODELS[p].models[0].id;
+                                    setProactiveProvider(p);
+                                    setProactiveModel(firstModel);
+                                    saveField({ proactiveProvider: p, proactiveModel: firstModel });
+                                  }}
+                                  ariaLabel={`Background provider ${PROVIDER_MODELS[p].label}`}
+                                >
+                                  {PROVIDER_MODELS[p].label}
+                                </Chip>
+                              ))}
+                            </ChipGroup>
+                          </div>
+                          <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+                            <span className="text-sm text-muted-foreground">Model</span>
+                            <ChipGroup label="Background model">
+                              {PROVIDER_MODELS[proactiveProvider].models.map((m) => (
+                                <Chip
+                                  key={m.id}
+                                  active={proactiveModel === m.id}
+                                  onClick={() => {
+                                    setProactiveModel(m.id);
+                                    saveField({ proactiveModel: m.id });
+                                  }}
+                                  ariaLabel={`Background model ${m.label}`}
+                                >
+                                  {m.label}
+                                </Chip>
+                              ))}
+                            </ChipGroup>
+                          </div>
+                          <SettingRow
+                            label="Extended thinking"
+                            description="Off is usually faster and cheaper for background runs."
+                          >
+                            <Toggle
+                              checked={proactiveThinking}
+                              ariaLabel="Background extended thinking"
+                              onChange={() => {
+                                const next = !proactiveThinking;
+                                setProactiveThinking(next);
+                                saveField({ proactiveThinking: next });
+                              }}
+                            />
+                          </SettingRow>
+                        </div>
+                      )}
+                    </div>
                   )}
-                </div>
-                {watchedRepos.length > 0 && (
-                  <ul className="flex flex-col gap-1 mt-1">
-                    {watchedRepos.map((repo) => (
-                      <li key={repo} className="flex items-center justify-between gap-2 text-sm text-foreground">
-                        <span className="font-mono text-xs">{repo}</span>
+                </section>
+
+                {/* ── 04 System ── */}
+                <section
+                  ref={(el) => { sectionRefs.current.system = el; }}
+                  data-section="system"
+                  className="flex flex-col gap-5 scroll-mt-2"
+                >
+                  <SectionHeader num="04" title="System" sub="How Gnosis shows up on your machine." />
+
+                  <SettingRow label="Desktop notifications" description="Notify when a review completes.">
+                    <Toggle
+                      checked={notifications}
+                      ariaLabel="Desktop notifications"
+                      onChange={() => {
+                        const next = !notifications;
+                        setNotifications(next);
+                        saveField({ notifications: next });
+                      }}
+                    />
+                  </SettingRow>
+
+                  <SettingRow label="Menu bar icon" description="Review status and quick actions in the menu bar.">
+                    <Toggle
+                      checked={trayEnabled}
+                      ariaLabel="Menu bar icon"
+                      onChange={() => {
+                        const next = !trayEnabled;
+                        setTrayEnabled(next);
+                        saveField({ trayEnabled: next });
+                      }}
+                    />
+                  </SettingRow>
+
+                  <SettingRow
+                    label="Anonymous usage analytics"
+                    description={
+                      <>
+                        Anonymous event counts help us decide what to build next.{' '}
+                        <button
+                          type="button"
+                          onClick={() => setAnalyticsExpanded((v) => !v)}
+                          className="underline decoration-dotted decoration-muted-foreground/60 underline-offset-2 hover:text-foreground transition-colors"
+                        >
+                          {analyticsExpanded ? 'Hide details' : 'What we send'}
+                        </button>
+                        {analyticsExpanded && (
+                          <span className="block mt-1 text-muted-foreground/90">
+                            Events like launches and feature usage go to{' '}
+                            <a
+                              href="https://aptabase.com"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                void window.electronAPI.openExternal('https://aptabase.com');
+                              }}
+                              className="underline decoration-dotted underline-offset-2 hover:text-foreground"
+                            >
+                              Aptabase
+                            </a>
+                            , an open-source privacy-first service. No personal data, no IP, no PRs, no source code.
+                          </span>
+                        )}
+                      </>
+                    }
+                  >
+                    <Toggle
+                      checked={analytics}
+                      ariaLabel="Anonymous usage analytics"
+                      onChange={() => {
+                        const next = !analytics;
+                        setAnalytics(next);
+                        saveField({ analytics: next });
+                      }}
+                    />
+                  </SettingRow>
+                </section>
+
+                {/* ── 05 Advanced ── */}
+                <section
+                  ref={(el) => { sectionRefs.current.advanced = el; }}
+                  data-section="advanced"
+                  className="flex flex-col gap-5 scroll-mt-2 pb-4"
+                >
+                  <SectionHeader num="05" title="Advanced" sub="You probably don't need to touch these." />
+
+                  <div className="flex flex-col gap-4 pl-4 border-l border-border/60">
+                    <div className="flex flex-col gap-1.5">
+                      <label htmlFor="claude-cli-path" className="text-sm font-medium text-foreground">Claude CLI path</label>
+                      <input
+                        id="claude-cli-path"
+                        type="text"
+                        value={claudePath}
+                        placeholder={claudeDetected || 'auto-detect'}
+                        onChange={(e) => setClaudePath(e.target.value)}
+                        onBlur={() => saveField({ claudePath })}
+                        className="bg-transparent border-0 border-b border-border px-0 py-1 text-sm text-foreground placeholder:text-muted-foreground/60 transition-colors focus:outline-none focus:border-[var(--ring)]"
+                      />
+                      <p className="slide-meta">Leave empty to auto-detect.</p>
+                    </div>
+
+                    <div className="flex flex-col gap-1.5">
+                      <label htmlFor="gemini-cli-path" className="text-sm font-medium text-foreground">Gemini CLI path</label>
+                      <input
+                        id="gemini-cli-path"
+                        type="text"
+                        value={geminiPath}
+                        placeholder={geminiDetected || 'auto-detect'}
+                        onChange={(e) => setGeminiPath(e.target.value)}
+                        onBlur={() => saveField({ geminiPath })}
+                        className="bg-transparent border-0 border-b border-border px-0 py-1 text-sm text-foreground placeholder:text-muted-foreground/60 transition-colors focus:outline-none focus:border-[var(--ring)]"
+                      />
+                      <p className="slide-meta">Leave empty to auto-detect.</p>
+                    </div>
+
+                    <div className="flex flex-col gap-2 pt-2 items-start">
+                      {onReplayOnboarding && (
                         <button
                           type="button"
                           onClick={() => {
-                            const next = watchedRepos.filter((r) => r !== repo);
-                            setWatchedRepos(next);
-                            saveField({ watchedRepos: next });
+                            onReplayOnboarding();
+                            onOpenChange(false);
                           }}
-                          className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+                          className="slide-meta hover:text-foreground transition-colors"
                         >
-                          Remove
+                          Replay first-time welcome →
                         </button>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              <div className="flex items-center justify-between gap-4 mt-2">
-                <div className="flex flex-col gap-0.5">
-                  <label className="text-sm font-medium text-foreground">Max PRs per repo</label>
-                  <p className="text-xs text-muted-foreground">
-                    How many recently updated open PRs to review per watched repo.
-                  </p>
-                </div>
-                <select
-                  value={maxPrsPerRepo}
-                  onChange={(e) => {
-                    const next = Number(e.target.value);
-                    setMaxPrsPerRepo(next);
-                    saveField({ maxPrsPerRepo: next });
-                  }}
-                  className="bg-transparent border border-border rounded-md px-2 py-1 text-sm text-foreground"
-                >
-                  {[5, 10, 15, 20, 30, 50].map((n) => (
-                    <option key={n} value={n}>{n}</option>
-                  ))}
-                </select>
-              </div>
-
-              <div className="mt-2 pt-3 border-t border-border flex items-center justify-between gap-4">
-                <div className="flex flex-col gap-0.5 min-w-0">
-                  <span className="text-sm font-medium text-foreground">Use different model for proactive reviews</span>
-                  <span className="slide-meta">
-                    Run background reviews on a faster/cheaper model (e.g. Sonnet) while keeping your manual default for hand-picked PRs.
-                  </span>
-                </div>
-                <div className="shrink-0">
-                  <Toggle
-                    checked={proactiveReviewOverrides}
-                    ariaLabel="Use different model for proactive reviews"
-                    onChange={() => {
-                      const next = !proactiveReviewOverrides;
-                      setProactiveReviewOverrides(next);
-                      saveField({ proactiveReviewOverrides: next });
-                    }}
-                  />
-                </div>
-              </div>
-
-              {proactiveReviewOverrides && (
-                <div className="flex flex-col gap-3 mt-1">
-                  <div className="flex items-center gap-5 slide-meta">
-                    <span className="text-foreground/60">Provider</span>
-                    {(['claude', 'gemini'] as const).map((p) => (
+                      )}
                       <button
-                        key={p}
                         type="button"
-                        onClick={() => {
-                          const firstModel = PROVIDER_MODELS[p].models[0].id;
-                          setProactiveProvider(p);
-                          setProactiveModel(firstModel);
-                          saveField({ proactiveProvider: p, proactiveModel: firstModel });
-                        }}
-                        className={`pb-0.5 border-b transition-colors ${
-                          proactiveProvider === p
-                            ? 'text-foreground border-[var(--ring)]'
-                            : 'border-transparent hover:text-foreground'
-                        }`}
+                        onClick={() => void window.electronAPI.openLogsDirectory()}
+                        className="slide-meta hover:text-foreground transition-colors"
                       >
-                        {PROVIDER_MODELS[p].label}
+                        Open logs directory →
                       </button>
-                    ))}
-                  </div>
-                  <div className="flex flex-wrap items-center gap-x-5 gap-y-2 slide-meta">
-                    <span className="text-foreground/60">Model</span>
-                    {PROVIDER_MODELS[proactiveProvider].models.map((m) => (
-                      <button
-                        key={m.id}
-                        type="button"
-                        onClick={() => {
-                          setProactiveModel(m.id);
-                          saveField({ proactiveModel: m.id });
-                        }}
-                        className={`pb-0.5 border-b transition-colors ${
-                          proactiveModel === m.id
-                            ? 'text-foreground border-[var(--ring)]'
-                            : 'border-transparent hover:text-foreground'
-                        }`}
-                      >
-                        {m.label}
-                      </button>
-                    ))}
-                  </div>
-                  <div className="flex items-center justify-between gap-4">
-                    <div className="flex flex-col gap-0.5 min-w-0">
-                      <span className="text-sm font-medium text-foreground">Extended thinking</span>
-                      <span className="slide-meta">Off is usually faster and cheaper for background runs.</span>
-                    </div>
-                    <div className="shrink-0">
-                      <Toggle
-                        checked={proactiveThinking}
-                        ariaLabel="Proactive extended thinking"
-                        onChange={() => {
-                          const next = !proactiveThinking;
-                          setProactiveThinking(next);
-                          saveField({ proactiveThinking: next });
-                        }}
-                      />
                     </div>
                   </div>
-                </div>
-              )}
+                </section>
               </div>
-            )}
-
-            <SettingRow label="Desktop notifications" description="Notify when a review completes">
-              <Toggle
-                checked={notifications}
-                ariaLabel="Desktop notifications"
-                onChange={() => {
-                  const next = !notifications;
-                  setNotifications(next);
-                  saveField({ notifications: next });
-                }}
-              />
-            </SettingRow>
-
-            <SettingRow label="Menu bar icon" description="Show review status and quick actions in the menu bar">
-              <Toggle
-                checked={trayEnabled}
-                ariaLabel="Menu bar icon"
-                onChange={() => {
-                  const next = !trayEnabled;
-                  setTrayEnabled(next);
-                  saveField({ trayEnabled: next });
-                }}
-              />
-            </SettingRow>
-
-            <SettingRow
-              label="Anonymous usage analytics"
-              description="Sends anonymous app-usage events (e.g. launches, feature usage) to Aptabase, an open-source, privacy-first analytics service. No personal data, no IP addresses, no PRs, no source code — just anonymous event counts that help us decide what to build next."
-            >
-              <Toggle
-                checked={analytics}
-                ariaLabel="Anonymous usage analytics"
-                onChange={() => {
-                  const next = !analytics;
-                  setAnalytics(next);
-                  saveField({ analytics: next });
-                }}
-              />
-            </SettingRow>
-          </section>
-
-          <section className="flex flex-col gap-4 border-t border-border pt-5">
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm font-medium text-foreground">Claude CLI path</label>
-              <input
-                type="text"
-                value={claudePath}
-                placeholder={claudeDetected || 'auto-detect'}
-                onChange={(e) => setClaudePath(e.target.value)}
-                onBlur={() => saveField({ claudePath })}
-                className="bg-transparent border-0 border-b border-border px-0 py-1 text-sm text-foreground placeholder:text-muted-foreground/60 transition-colors"
-              />
-              <p className="slide-meta">Leave empty to auto-detect.</p>
             </div>
 
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm font-medium text-foreground">Gemini CLI path</label>
-              <input
-                type="text"
-                value={geminiPath}
-                placeholder={geminiDetected || 'auto-detect'}
-                onChange={(e) => setGeminiPath(e.target.value)}
-                onBlur={() => saveField({ geminiPath })}
-                className="bg-transparent border-0 border-b border-border px-0 py-1 text-sm text-foreground placeholder:text-muted-foreground/60 transition-colors"
-              />
-              <p className="slide-meta">Leave empty to auto-detect.</p>
-            </div>
-          </section>
-
-          <section className="border-t border-border pt-5 flex flex-col gap-2 items-start">
-            {onReplayOnboarding && (
-              <button
-                type="button"
-                onClick={() => {
-                  onReplayOnboarding();
-                  onOpenChange(false);
-                }}
-                className="slide-meta hover:text-foreground transition-colors"
-              >
-                Replay first-time welcome →
-              </button>
-            )}
-            <button
-              type="button"
-              onClick={() => void window.electronAPI.openLogsDirectory()}
-              className="slide-meta hover:text-foreground transition-colors"
-            >
-              Open logs directory →
-            </button>
-          </section>
+            {/* Unobtrusive save acknowledgement — fades in for ~1s after each save.
+               Re-keyed on savedTick so rapid saves reset the animation. */}
+            <SavedIndicator tick={savedTick} />
+          </div>
         </div>
       </DialogContent>
     </Dialog>
+  );
+}
+
+// Small "Saved" acknowledgement bottom-right of the content pane. Fades in
+// for ~1.1s after each save, then fades out. Uses a keyed remount so
+// rapid consecutive saves reliably restart the animation.
+function SavedIndicator({ tick }: { tick: number }) {
+  if (tick === 0) return null;
+  return (
+    <span
+      key={tick}
+      aria-live="polite"
+      className="pointer-events-none absolute bottom-3 right-5 slide-meta text-[var(--ring)] opacity-0 saved-flash"
+    >
+      Saved.
+    </span>
   );
 }

--- a/src/globals.css
+++ b/src/globals.css
@@ -1440,6 +1440,20 @@ ul.review-focus-content > li::before {
    the app collapses to instantaneous changes for users who
    asked for it. The progress bar still updates — it just
    snaps instead of sliding. */
+/* Used by the Settings dialog's save acknowledgement. A short, quiet
+   fade-in/out that lets the user know their toggle was persisted
+   without announcing it as a success. Kept under 1.2s so rapid
+   changes don't queue up visually. */
+.saved-flash {
+  animation: saved-flash 1100ms ease-out forwards;
+}
+@keyframes saved-flash {
+  0% { opacity: 0; transform: translateY(1px); }
+  18% { opacity: 0.85; transform: translateY(0); }
+  70% { opacity: 0.85; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(0); }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,


### PR DESCRIPTION
Stacked on top of #82. Drives most of the findings from a \`/critique\` pass.

## Before / after

| | Before | After |
|---|---|---|
| Layout | Single column, 80vh scroll, 19 decisions in a linear list | Two columns: 160px numbered TOC rail + scrollable content. Sections anchored and active-highlighted via IntersectionObserver. |
| Max PRs | Native \`<select>\` — the only non-custom control in the dialog | Chip row, same vocabulary as theme/font |
| Save feedback | Silent — 18 write sites, zero acknowledgement | Subtle \"Saved.\" fade-in-out near bottom-right on every save |
| Analytics copy | 52-word defensive paragraph dominating the row | One sentence + \"What we send\" disclosure with Aptabase link |
| CLI paths | Always visible, competing with first-class settings | Moved to 05 Advanced |
| Override nesting | 2px indent, unclear scope | Real left hairline + \"For background runs only\" caption + \"Manual: Claude · Opus 4.7\" reference |
| Accessibility | Chip groups were plain buttons, no group context for SR | role=radiogroup + aria-checked; DialogDescription actually describes sections; save indicator aria-live=polite |

## Sections

- **01 Appearance** — palette, code font, code theme
- **02 Review** — web search, parallel review
- **03 Proactive** — proactive mode, watched repos, max PRs, override block (gated + visually anchored when shown)
- **04 System** — notifications, menu bar, analytics
- **05 Advanced** — CLI paths, replay onboarding, open logs

## Test plan

- [ ] Open Settings — dialog is wider, TOC rail visible on left, content on right
- [ ] Click each TOC item — content scrolls smoothly to that section
- [ ] Scroll manually — active TOC item updates as you pass each section's top edge
- [ ] Toggle any setting — \"Saved.\" fades in briefly at bottom-right
- [ ] Open Analytics \"What we send\" — expanded copy with linked Aptabase reference
- [ ] Enable Proactive, enable override — current manual model shown in description; background block has visible left rail with caption
- [ ] Change Max PRs via chips — persists; chips reflect value on reload
- [ ] Screen reader — chip groups announce as radiogroups; saved announcements are polite
- [ ] Light ↔ dark both readable

## Files
- \`components/SettingsDialog.tsx\` (rewrite)
- \`src/globals.css\` (adds \`.saved-flash\` keyframes under reduced-motion-aware media query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)