### PR TITLE
feat: make review-check anchoring work across every diff renderer

### DIFF
--- a/components/DiffHunk.tsx
+++ b/components/DiffHunk.tsx
@@ -1,4 +1,11 @@
+import { useMemo } from 'react';
+import { parseDiffLines } from '@/lib/diff-lines';
 import { FilePathLink } from '@/components/FilePathLink';
+import {
+  parseShikiLines,
+  extractShikiStyles,
+  lineAnchorAttrs,
+} from '@/components/shared-diff-utils';
 import type { DiffHunk as DiffHunkType } from '@/lib/types';
 
 interface Props {
@@ -18,7 +25,7 @@ export function DiffHunk({ hunk, showFileHeader = true, gitFileUrlBase }: Props)
       {hunk.hunkHeader && (
         <div className="bg-muted/30 px-3 py-1 font-mono text-xs text-muted-foreground border-b">{hunk.hunkHeader}</div>
       )}
-      <div className="select-text" dangerouslySetInnerHTML={{ __html: hunk.renderedHtml }} />
+      <PlainHunk hunk={hunk} filePath={hunk.filePath} />
     </div>
   );
 }
@@ -43,9 +50,82 @@ export function DiffHunkGroup({ filePath, hunks, gitFileUrlBase }: GroupedProps)
               {hunk.hunkHeader}
             </div>
           )}
-          <div className="select-text" dangerouslySetInnerHTML={{ __html: hunk.renderedHtml }} />
+          <PlainHunk hunk={hunk} filePath={filePath} />
         </div>
       ))}
     </div>
+  );
+}
+
+// Non-interactive unified hunk. Same per-line structure as
+// InteractiveDiffHunk so review-check anchoring (data-file-path +
+// data-line-number / data-base-line) works in read-only mode too.
+// Falls back to raw innerHTML if the Shiki HTML can't be parsed line
+// by line (extremely rare — defensive only).
+function PlainHunk({ hunk, filePath }: { hunk: DiffHunkType; filePath: string }) {
+  const lineInfos = useMemo(() => parseDiffLines(hunk.hunkHeader, hunk.content), [hunk.hunkHeader, hunk.content]);
+  const lineHtmls = useMemo(() => parseShikiLines(hunk.renderedHtml), [hunk.renderedHtml]);
+  const shikiStyles = useMemo(() => extractShikiStyles(hunk.renderedHtml), [hunk.renderedHtml]);
+
+  if (!lineHtmls || lineInfos.length === 0 || lineHtmls.length < lineInfos.length) {
+    return <div className="select-text" dangerouslySetInnerHTML={{ __html: hunk.renderedHtml }} />;
+  }
+
+  const hasDiff = lineInfos.some((l) => l.type !== 'context');
+
+  return (
+    <pre className={`${shikiStyles.preClass} select-text`} style={shikiStyles.preStyle}>
+      <code style={{ display: 'block', fontSize: 0, minWidth: '100%', width: 'max-content' }}>
+        {lineInfos.map((info, idx) => {
+          const diffClass = info.type === 'add' ? 'diff add' : info.type === 'remove' ? 'diff remove' : '';
+          return (
+            <span
+              key={idx}
+              className={`line ${diffClass}`}
+              {...lineAnchorAttrs(filePath, info)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                fontSize: '0.8125rem',
+                lineHeight: '1.5',
+                paddingRight: '1.25rem',
+              }}
+            >
+              <span
+                className="line-number-gutter"
+                style={{
+                  display: 'inline-block',
+                  width: '3.5ch',
+                  textAlign: 'right',
+                  paddingRight: '0.5ch',
+                  color: 'var(--muted-foreground)',
+                  userSelect: 'none',
+                  flexShrink: 0,
+                  fontSize: '0.75rem',
+                }}
+              >
+                {info.lineNumber}
+              </span>
+              {hasDiff && (
+                <span
+                  style={{
+                    display: 'inline-block',
+                    width: '1ch',
+                    marginRight: '1ch',
+                    userSelect: 'none',
+                    flexShrink: 0,
+                    color:
+                      info.type === 'add' ? '#3fb950' : info.type === 'remove' ? '#f85149' : 'transparent',
+                  }}
+                >
+                  {info.type === 'add' ? '+' : info.type === 'remove' ? '-' : ' '}
+                </span>
+              )}
+              <span dangerouslySetInnerHTML={{ __html: lineHtmls[idx] }} style={{ flex: 1, minWidth: 0 }} />
+            </span>
+          );
+        })}
+      </code>
+    </pre>
   );
 }

--- a/components/InteractiveDiffHunk.tsx
+++ b/components/InteractiveDiffHunk.tsx
@@ -7,6 +7,7 @@ import {
   type CommentCallbacks,
   parseShikiLines,
   extractShikiStyles,
+  lineAnchorAttrs,
   InlineCommentForm,
   CommentBubble,
 } from '@/components/shared-diff-utils';
@@ -97,8 +98,7 @@ function InteractiveHunk({
             <span key={idx}>
               <span
                 className={`line ${diffClass} interactive-line`}
-                data-file-path={filePath}
-                data-line-number={line.info.lineNumber}
+                {...lineAnchorAttrs(filePath, line.info)}
                 style={{
                   display: 'flex',
                   alignItems: 'center',

--- a/components/SlideView.tsx
+++ b/components/SlideView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback } from 'react';
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { Group as PanelGroup, Panel, Separator as PanelResizeHandle } from 'react-resizable-panels';
 import { MessageCircle, MessageSquarePlus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -42,6 +42,29 @@ function formatFileAge(lastModified: string | null | undefined): string | null {
   if (days >= 30) return `${Math.floor(days / 30)}mo old`;
   if (days >= 1) return `${days}d old`;
   return null; // modified today — not worth showing
+}
+
+// Build the set of `{filePath}:{newFileLine}` + `{filePath}:{oldFileLine}`
+// keys that any review check could resolve to inside this slide's
+// hunks. Used to pre-filter clickable anchors at render time so the
+// callout never shows a link that would silently do nothing. Parses
+// hunk headers directly (`@@ -baseStart,baseCount +headStart,headCount @@`)
+// rather than walking rendered lines — much cheaper.
+function buildAnchorableSet(hunks: DiffHunk[]): Set<string> {
+  const keys = new Set<string>();
+  for (const hunk of hunks) {
+    const m = hunk.hunkHeader.match(/@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+    if (!m) continue;
+    const baseStart = parseInt(m[1], 10);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- regex optional groups can be undefined at runtime
+    const baseCount = m[2] !== undefined ? parseInt(m[2], 10) : 1;
+    const headStart = parseInt(m[3], 10);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- regex optional groups can be undefined at runtime
+    const headCount = m[4] !== undefined ? parseInt(m[4], 10) : 1;
+    for (let i = 0; i < headCount; i++) keys.add(`${hunk.filePath}:${headStart + i}`);
+    for (let i = 0; i < baseCount; i++) keys.add(`${hunk.filePath}:${baseStart + i}`);
+  }
+  return keys;
 }
 
 // Group hunks by filePath so we can render them under a single file header
@@ -153,14 +176,44 @@ export function SlideView({
   const fileCount = slide.affectedFiles.length;
   const fileCountLabel = fileCount === 0 ? 'no files' : `${fileCount} ${fileCount === 1 ? 'file' : 'files'}`;
 
+  // When a review-check click can't be resolved to a visible diff line
+  // (rare, because we also pre-filter at render time), surface a brief
+  // muted note below the callout so the user isn't left guessing why
+  // the click did nothing. Cleared after ~3s.
+  const [anchorMiss, setAnchorMiss] = useState<{ filePath: string; line: number; at: number } | null>(null);
+
+  // Auto-clear the miss notice so it doesn't linger past the moment
+  // the user expects feedback.
+  useEffect(() => {
+    if (!anchorMiss) return;
+    const t = setTimeout(() => {
+      setAnchorMiss((current) => (current && current.at === anchorMiss.at ? null : current));
+    }, 3000);
+    return () => clearTimeout(t);
+  }, [anchorMiss]);
+
+  // Which `{filePath, line}` anchors can actually resolve inside THIS
+  // slide's diff hunks. Used to pre-filter click affordances so we
+  // never render a clickable-looking check that will silently fail.
+  const anchorable = useMemo(() => buildAnchorableSet(slide.diffHunks), [slide.diffHunks]);
+
   const handleCheckClick = useCallback((check: ReviewCheck) => {
     if (!check.filePath || !check.startLine) return;
     const container = rightPanelRef.current;
     if (!container) return;
 
-    const selector = `[data-file-path="${CSS.escape(check.filePath)}"][data-line-number="${check.startLine}"]`;
-    const target = container.querySelector(selector);
-    if (!target) return;
+    const escapedPath = CSS.escape(check.filePath);
+    // Primary: new-file line number (matches what the AI is told to emit).
+    // Fallback: old-file line number, in case the AI anchored at a
+    // removed line.
+    const target =
+      container.querySelector(`[data-file-path="${escapedPath}"][data-line-number="${check.startLine}"]`) ??
+      container.querySelector(`[data-file-path="${escapedPath}"][data-base-line="${check.startLine}"]`);
+
+    if (!target) {
+      setAnchorMiss({ filePath: check.filePath, line: check.startLine, at: Date.now() });
+      return;
+    }
 
     target.scrollIntoView({ behavior: 'smooth', block: 'center' });
     target.classList.remove('check-highlight');
@@ -213,7 +266,14 @@ export function SlideView({
                 <span className="editorial-label">What to check.</span>{' '}
                 <span className="review-focus-content">
                   {checks.map((check, i) => {
-                    const isClickable = !!(check.filePath && check.startLine != null && check.startLine > 0);
+                    // Only render as a clickable anchor when the
+                    // `{filePath, line}` actually resolves to a line
+                    // inside this slide's hunks. Prevents silent
+                    // no-op clicks on hallucinated or out-of-context
+                    // anchors.
+                    const isClickable =
+                      !!(check.filePath && check.startLine != null && check.startLine > 0) &&
+                      anchorable.has(`${check.filePath}:${check.startLine}`);
                     return (
                       <span
                         key={i}
@@ -237,6 +297,12 @@ export function SlideView({
           <p className="slide-prose">
             <span className="editorial-label">What to check.</span>{' '}
             <span className="review-focus-content">{slide.reviewFocus ?? ''}</span>
+          </p>
+        )}
+        {anchorMiss && (
+          <p className="slide-meta mt-2" role="status" aria-live="polite">
+            Line {anchorMiss.line} in <span className="font-mono">{anchorMiss.filePath}</span> isn't in this slide's
+            visible diff.
           </p>
         )}
       </div>

--- a/components/SplitDiffHunk.tsx
+++ b/components/SplitDiffHunk.tsx
@@ -1,12 +1,13 @@
 import { useState, useMemo } from 'react';
 import { MessageSquarePlus } from 'lucide-react';
 import { parseDiffLines, buildSplitRows, type DiffLineInfo, type SplitRow } from '@/lib/diff-lines';
-import type { DiffHunk, PendingReviewComment } from '@/lib/types';
+import type { DiffHunk, DiffSide, PendingReviewComment } from '@/lib/types';
 import { FilePathLink } from '@/components/FilePathLink';
 import {
   type CommentCallbacks,
   parseShikiLines,
   extractShikiStyles,
+  lineAnchorAttrs,
   InlineCommentForm,
   CommentBubble,
 } from '@/components/shared-diff-utils';
@@ -21,20 +22,27 @@ interface SplitDiffHunkGroupProps {
 }
 
 function SplitDiffCell({
+  filePath,
   info,
   html,
   cellClass,
+  side,
   isInteractive,
   onClickLine,
 }: {
+  filePath: string;
   info: DiffLineInfo | null;
   html: string | null;
   cellClass: string;
+  side: DiffSide;
   isInteractive: boolean;
   onClickLine: (info: DiffLineInfo) => void;
 }) {
   const lineNum =
     info?.type === 'context' ? info.lineNumber : info?.type === 'remove' ? info.baseLineNumber : info?.headLineNumber;
+  // Anchor attrs on the code cell — that's the widest hit area and the
+  // natural visual target for "where does this check point to."
+  const anchorAttrs = info ? lineAnchorAttrs(filePath, info, side) : undefined;
 
   return (
     <>
@@ -73,6 +81,7 @@ function SplitDiffCell({
       </span>
       <span
         className={`split-diff-code select-text ${cellClass}`}
+        {...anchorAttrs}
         style={{ paddingLeft: '0.5ch', paddingRight: '1ch', whiteSpace: 'pre' }}
       >
         {html ? <span dangerouslySetInnerHTML={{ __html: html }} /> : null}
@@ -178,6 +187,7 @@ function SplitHunk({
           return (
             <SplitDiffRowFragment
               key={rowIdx}
+              filePath={filePath}
               row={row}
               leftCellClass={leftCellClass}
               rightCellClass={rightCellClass}
@@ -202,6 +212,7 @@ function SplitHunk({
 }
 
 function SplitDiffRowFragment({
+  filePath,
   row,
   leftCellClass,
   rightCellClass,
@@ -218,6 +229,7 @@ function SplitDiffRowFragment({
   onCancelForm,
   commentCallbacks,
 }: {
+  filePath: string;
   row: SplitRow;
   leftCellClass: string;
   rightCellClass: string;
@@ -237,9 +249,11 @@ function SplitDiffRowFragment({
   return (
     <>
       <SplitDiffCell
+        filePath={filePath}
         info={row.left?.info ?? null}
         html={row.left?.html ?? null}
         cellClass={leftCellClass}
+        side="LEFT"
         isInteractive={isInteractive}
         onClickLine={onClickLine}
       />
@@ -247,9 +261,11 @@ function SplitDiffRowFragment({
       <span className="split-diff-separator" />
 
       <SplitDiffCell
+        filePath={filePath}
         info={row.right?.info ?? null}
         html={row.right?.html ?? null}
         cellClass={rightCellClass}
+        side="RIGHT"
         isInteractive={isInteractive}
         onClickLine={onClickLine}
       />

--- a/components/shared-diff-utils.tsx
+++ b/components/shared-diff-utils.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { Pencil, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import type { DiffLineInfo } from '@/lib/diff-lines';
 import type { PendingReviewComment, DiffSide } from '@/lib/types';
 
 export interface CommentCallbacks {
@@ -37,6 +38,53 @@ export function parseShikiLines(renderedHtml: string): string[] | null {
  * Extract the Shiki theme styles from the rendered <pre> element so we can
  * re-apply them when rendering individual lines outside the original tree.
  */
+/**
+ * Data attributes used by review-check anchoring ("What to check" click
+ * jumps to a diff line). Emitted on every visible diff-line wrapper across
+ * all three renderers so click resolution works regardless of layout.
+ *
+ * Contract:
+ * - `data-file-path`: exact filePath string (matches what the AI emits).
+ * - `data-line-number`: NEW-FILE line number when the line exists in the
+ *   new file (adds and context). This is the primary attribute the click
+ *   handler looks for — the AI is instructed to emit new-file line numbers.
+ * - `data-base-line`: OLD-FILE line number when the line exists in the old
+ *   file (removes and context). Fallback attribute for when the AI
+ *   accidentally anchors to a removed line.
+ *
+ * `side` is the side this wrapper is RENDERED ON (LEFT/RIGHT in split
+ * layout, always RIGHT for unified). For split-layout cells, a context
+ * line's two halves each emit only the side-appropriate attribute, so the
+ * click targets the right visual cell.
+ */
+export interface LineAnchorAttrs {
+  'data-file-path': string;
+  'data-line-number'?: number;
+  'data-base-line'?: number;
+}
+
+export function lineAnchorAttrs(
+  filePath: string,
+  info: DiffLineInfo,
+  // undefined = unified row; defined = split-layout cell on that side
+  side?: DiffSide
+): LineAnchorAttrs {
+  const attrs: LineAnchorAttrs = { 'data-file-path': filePath };
+  if (side === undefined) {
+    // Unified — a single row represents the line from whichever file(s)
+    // it exists in, so expose both line numbers when available.
+    if (info.headLineNumber != null) attrs['data-line-number'] = info.headLineNumber;
+    if (info.baseLineNumber != null) attrs['data-base-line'] = info.baseLineNumber;
+  } else if (side === 'RIGHT') {
+    // Right-side (new-file) cell in split — only the head line applies.
+    if (info.headLineNumber != null) attrs['data-line-number'] = info.headLineNumber;
+  } else {
+    // Left-side (old-file) cell in split — only the base line applies.
+    if (info.baseLineNumber != null) attrs['data-base-line'] = info.baseLineNumber;
+  }
+  return attrs;
+}
+
 export function extractShikiStyles(renderedHtml: string): { preStyle: Record<string, string>; preClass: string } {
   try {
     const parser = new DOMParser();

--- a/src/globals.css
+++ b/src/globals.css
@@ -632,18 +632,28 @@
 
 /* ─── Check suggestion jump highlight ────────────────────────── */
 
+/* When a reviewer clicks a "What to check" hint, the target diff
+   line gets this class briefly. The ::after overlays the line with a
+   claret wash that fades to zero — a page-turning blink rather than
+   a pulsing highlight. isolation:isolate keeps the overlay contained
+   if the target happens to be inside another stacking context. */
 .check-highlight {
   position: relative;
+  isolation: isolate;
 }
 .check-highlight::after {
   content: '';
   position: absolute;
   inset: 0;
   pointer-events: none;
-  /* Claret flash — same hue as the brand --ring, just briefly
-     visible to show the user where the check landed. */
+  z-index: 0;
   background-color: oklch(0.55 0.14 15 / 22%);
   animation: check-highlight-fade 1.5s ease-out forwards;
+  will-change: opacity;
+}
+.check-highlight > * {
+  position: relative;
+  z-index: 1;
 }
 @keyframes check-highlight-fade {
   from {


### PR DESCRIPTION
Fixes the P0 where clicking a "What to check" hint silently did nothing in every mode except *unified + editable*. Also hardens the edge cases.

## Why
A review of the hint→diff linking logic found that only \`InteractiveDiffHunk\` emitted the \`data-file-path\` + \`data-line-number\` attributes the click handler looks for. \`DiffHunk\` (read-only) and \`SplitDiffHunk\` (the default split layout) did not, so clicking a hint was a silent no-op in both. On top of that, the click handler couldn't resolve anchors to *removed* lines, and when an anchor didn't resolve there was no user feedback.

## What changed

### Renderer parity (P0)
- New helper \`lineAnchorAttrs(filePath, info, side?)\` in \`shared-diff-utils.tsx\` emits anchor attributes consistently, side-aware:
  - Unified row → both \`data-line-number\` (new-file) and \`data-base-line\` (old-file) when available.
  - Split-RIGHT cell → \`data-line-number\` only.
  - Split-LEFT cell → \`data-base-line\` only.
- \`DiffHunk.tsx\` rewritten to render per-line JSX like the other two renderers, so every line carries the attrs. Previously dumped raw \`renderedHtml\` via \`dangerouslySetInnerHTML\`.
- \`SplitDiffHunk.tsx\`: each \`SplitDiffCell\`'s code cell now carries side-appropriate attrs.
- \`InteractiveDiffHunk.tsx\`: switched to the same helper so the contract is centralised.

### Contract fix for removals (P1)
- Click handler tries \`data-line-number="N"\` first (the AI's "new-file line number" contract), then falls back to \`data-base-line="N"\` so a check that anchors at a removed line still resolves.

### Off-view fallback (P1)
- \`buildAnchorableSet(hunks)\` parses hunk headers (\`@@ -b,bc +h,hc @@\`) to compute every resolvable line number for this slide. SlideView pre-filters \`isClickable\` — hallucinated or out-of-slide anchors don't render as clickable in the first place.
- Defensive miss notice: if a click still doesn't resolve, an \`aria-live="polite"\` note ("Line N in \`<path>\` isn't in this slide's visible diff") appears below the callout and auto-clears after 3s.

### Highlight robustness (P2)
- \`.check-highlight\` now uses \`isolation: isolate\`, \`z-index\` on the \`::after\`, and a positioned-children rule so the flash layers correctly regardless of surrounding stacking context.

## Files
- \`components/shared-diff-utils.tsx\` — \`lineAnchorAttrs\` helper
- \`components/DiffHunk.tsx\` — rewrite to per-line JSX
- \`components/InteractiveDiffHunk.tsx\` — use shared helper
- \`components/SplitDiffHunk.tsx\` — side-aware attrs on each cell
- \`components/SlideView.tsx\` — pre-validator, fallback selector, miss notice
- \`src/globals.css\` — \`.check-highlight\` tightening

## Test plan
- [ ] Click a "What to check" hint in split layout → scrolls + flashes the matching line (was silently dead before).
- [ ] Click a hint in unified read-only mode (no comment callbacks) → scrolls + flashes.
- [ ] Click a hint anchored to a removed line → falls back to \`data-base-line\`, still scrolls.
- [ ] Force an out-of-slide anchor (edit review JSON for a check pointing at a line not in the hunks) → the check renders non-clickable (no dotted underline).
- [ ] Fabricate a passing \`canAnchor\` but missing DOM target (rare) → miss notice appears for ~3s.
- [ ] Light ↔ dark, prefers-reduced-motion on → flash behaves (instant in reduced mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)