### PR TITLE
feat: review-checks combined — rendering + prompt + anchoring

### DIFF
--- a/components/DiffHunk.tsx
+++ b/components/DiffHunk.tsx
@@ -1,4 +1,11 @@
+import { useMemo } from 'react';
+import { parseDiffLines } from '@/lib/diff-lines';
 import { FilePathLink } from '@/components/FilePathLink';
+import {
+  parseShikiLines,
+  extractShikiStyles,
+  lineAnchorAttrs,
+} from '@/components/shared-diff-utils';
 import type { DiffHunk as DiffHunkType } from '@/lib/types';
 
 interface Props {
@@ -18,7 +25,7 @@ export function DiffHunk({ hunk, showFileHeader = true, gitFileUrlBase }: Props)
       {hunk.hunkHeader && (
         <div className="bg-muted/30 px-3 py-1 font-mono text-xs text-muted-foreground border-b">{hunk.hunkHeader}</div>
       )}
-      <div className="select-text" dangerouslySetInnerHTML={{ __html: hunk.renderedHtml }} />
+      <PlainHunk hunk={hunk} filePath={hunk.filePath} />
     </div>
   );
 }
@@ -43,9 +50,82 @@ export function DiffHunkGroup({ filePath, hunks, gitFileUrlBase }: GroupedProps)
               {hunk.hunkHeader}
             </div>
           )}
-          <div className="select-text" dangerouslySetInnerHTML={{ __html: hunk.renderedHtml }} />
+          <PlainHunk hunk={hunk} filePath={filePath} />
         </div>
       ))}
     </div>
+  );
+}
+
+// Non-interactive unified hunk. Same per-line structure as
+// InteractiveDiffHunk so review-check anchoring (data-file-path +
+// data-line-number / data-base-line) works in read-only mode too.
+// Falls back to raw innerHTML if the Shiki HTML can't be parsed line
+// by line (extremely rare — defensive only).
+function PlainHunk({ hunk, filePath }: { hunk: DiffHunkType; filePath: string }) {
+  const lineInfos = useMemo(() => parseDiffLines(hunk.hunkHeader, hunk.content), [hunk.hunkHeader, hunk.content]);
+  const lineHtmls = useMemo(() => parseShikiLines(hunk.renderedHtml), [hunk.renderedHtml]);
+  const shikiStyles = useMemo(() => extractShikiStyles(hunk.renderedHtml), [hunk.renderedHtml]);
+
+  if (!lineHtmls || lineInfos.length === 0 || lineHtmls.length < lineInfos.length) {
+    return <div className="select-text" dangerouslySetInnerHTML={{ __html: hunk.renderedHtml }} />;
+  }
+
+  const hasDiff = lineInfos.some((l) => l.type !== 'context');
+
+  return (
+    <pre className={`${shikiStyles.preClass} select-text`} style={shikiStyles.preStyle}>
+      <code style={{ display: 'block', fontSize: 0, minWidth: '100%', width: 'max-content' }}>
+        {lineInfos.map((info, idx) => {
+          const diffClass = info.type === 'add' ? 'diff add' : info.type === 'remove' ? 'diff remove' : '';
+          return (
+            <span
+              key={idx}
+              className={`line ${diffClass}`}
+              {...lineAnchorAttrs(filePath, info)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                fontSize: '0.8125rem',
+                lineHeight: '1.5',
+                paddingRight: '1.25rem',
+              }}
+            >
+              <span
+                className="line-number-gutter"
+                style={{
+                  display: 'inline-block',
+                  width: '3.5ch',
+                  textAlign: 'right',
+                  paddingRight: '0.5ch',
+                  color: 'var(--muted-foreground)',
+                  userSelect: 'none',
+                  flexShrink: 0,
+                  fontSize: '0.75rem',
+                }}
+              >
+                {info.lineNumber}
+              </span>
+              {hasDiff && (
+                <span
+                  style={{
+                    display: 'inline-block',
+                    width: '1ch',
+                    marginRight: '1ch',
+                    userSelect: 'none',
+                    flexShrink: 0,
+                    color:
+                      info.type === 'add' ? '#3fb950' : info.type === 'remove' ? '#f85149' : 'transparent',
+                  }}
+                >
+                  {info.type === 'add' ? '+' : info.type === 'remove' ? '-' : ' '}
+                </span>
+              )}
+              <span dangerouslySetInnerHTML={{ __html: lineHtmls[idx] }} style={{ flex: 1, minWidth: 0 }} />
+            </span>
+          );
+        })}
+      </code>
+    </pre>
   );
 }

--- a/components/InteractiveDiffHunk.tsx
+++ b/components/InteractiveDiffHunk.tsx
@@ -7,6 +7,7 @@ import {
   type CommentCallbacks,
   parseShikiLines,
   extractShikiStyles,
+  lineAnchorAttrs,
   InlineCommentForm,
   CommentBubble,
 } from '@/components/shared-diff-utils';
@@ -97,8 +98,7 @@ function InteractiveHunk({
             <span key={idx}>
               <span
                 className={`line ${diffClass} interactive-line`}
-                data-file-path={filePath}
-                data-line-number={line.info.lineNumber}
+                {...lineAnchorAttrs(filePath, line.info)}
                 style={{
                   display: 'flex',
                   alignItems: 'center',

--- a/components/SlideView.tsx
+++ b/components/SlideView.tsx
@@ -58,6 +58,23 @@ function looksLikePackedList(text: string): boolean {
   return false;
 }
 
+// Try to split a prose check into its constituent sentences so a
+// model-emitted "one giant check with three topics" renders as
+// bullets instead of a paragraph. Splits on sentence terminators
+// (`.`, `?`, `!`) followed by whitespace then a capital letter or
+// a backtick (next sentence starts with an identifier). Only returns
+// multiple segments when each is a reasonable bullet length — under
+// 20 chars is probably noise, over 500 is a tell the split picked
+// the wrong boundary.
+function splitIntoProseChecks(text: string): string[] {
+  if (!text) return [];
+  const trimmed = text.trim();
+  const parts = trimmed.split(/(?<=[.?!])\s+(?=[A-Z`])/).map((s) => s.trim()).filter(Boolean);
+  if (parts.length < 2) return [trimmed];
+  if (parts.some((p) => p.length < 20 || p.length > 500)) return [trimmed];
+  return parts;
+}
+
 // Inline click affordance for a single anchored check — dotted
 // underline in brand claret so it reads as a quiet link.
 const clickableCheckClass =
@@ -95,14 +112,40 @@ function renderReviewChecks(
     );
   }
 
-  // Single structured check. Short enough for a run-in label → inline.
-  // Long or self-contains a list → promote to a block so it doesn't
-  // render as a wall of text.
+  // Single structured check. If its text is actually several
+  // sentences crammed together, split into bullets. If just long,
+  // promote to a block through Markdown. Otherwise keep the inline
+  // run-in label + sentence.
   if (checks && checks.length === 1) {
     const check = checks[0];
     const isClickable = !!(check.filePath && check.startLine != null && check.startLine > 0);
     const packed = looksLikePackedList(check.text);
     const longText = check.text.length > 180;
+    const split = longText || packed ? splitIntoProseChecks(check.text) : [check.text];
+    if (split.length > 1) {
+      // Prose-split into multiple sentences → render as bulleted
+      // list. The anchor click (when present) applies to every
+      // bullet; the whole check points at one line.
+      return (
+        <>
+          <p className="slide-prose">
+            <span className="editorial-label">What to check.</span>
+          </p>
+          <ul className="slide-prose review-checks-list mt-1.5">
+            {split.map((sentence, i) => (
+              <li key={i} className="review-checks-item">
+                <span
+                  className={isClickable ? clickableCheckClass : ''}
+                  onClick={isClickable ? () => onCheckClick(check) : undefined}
+                >
+                  <Markdown className="review-focus-markdown">{sentence}</Markdown>
+                </span>
+              </li>
+            ))}
+          </ul>
+        </>
+      );
+    }
     if (packed || longText) {
       return (
         <>
@@ -148,6 +191,23 @@ function renderReviewChecks(
     );
   }
   if (looksLikePackedList(focus) || focus.length > 180) {
+    const split = splitIntoProseChecks(focus);
+    if (split.length > 1) {
+      return (
+        <>
+          <p className="slide-prose">
+            <span className="editorial-label">What to check.</span>
+          </p>
+          <ul className="slide-prose review-checks-list mt-1.5">
+            {split.map((sentence, i) => (
+              <li key={i} className="review-checks-item">
+                <Markdown className="review-focus-markdown">{sentence}</Markdown>
+              </li>
+            ))}
+          </ul>
+        </>
+      );
+    }
     return (
       <>
         <p className="slide-prose">

--- a/components/SlideView.tsx
+++ b/components/SlideView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback } from 'react';
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { Group as PanelGroup, Panel, Separator as PanelResizeHandle } from 'react-resizable-panels';
 import { MessageCircle, MessageSquarePlus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -42,6 +42,29 @@ function formatFileAge(lastModified: string | null | undefined): string | null {
   if (days >= 30) return `${Math.floor(days / 30)}mo old`;
   if (days >= 1) return `${days}d old`;
   return null; // modified today — not worth showing
+}
+
+// Build the set of `{filePath}:{newFileLine}` + `{filePath}:{oldFileLine}`
+// keys that any review check could resolve to inside this slide's
+// hunks. Used to pre-filter clickable anchors at render time so the
+// callout never shows a link that would silently do nothing. Parses
+// hunk headers directly (`@@ -baseStart,baseCount +headStart,headCount @@`)
+// rather than walking rendered lines — much cheaper.
+function buildAnchorableSet(hunks: DiffHunk[]): Set<string> {
+  const keys = new Set<string>();
+  for (const hunk of hunks) {
+    const m = hunk.hunkHeader.match(/@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+    if (!m) continue;
+    const baseStart = parseInt(m[1], 10);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- regex optional groups can be undefined at runtime
+    const baseCount = m[2] !== undefined ? parseInt(m[2], 10) : 1;
+    const headStart = parseInt(m[3], 10);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- regex optional groups can be undefined at runtime
+    const headCount = m[4] !== undefined ? parseInt(m[4], 10) : 1;
+    for (let i = 0; i < headCount; i++) keys.add(`${hunk.filePath}:${headStart + i}`);
+    for (let i = 0; i < baseCount; i++) keys.add(`${hunk.filePath}:${baseStart + i}`);
+  }
+  return keys;
 }
 
 // Group hunks by filePath so we can render them under a single file header
@@ -153,14 +176,44 @@ export function SlideView({
   const fileCount = slide.affectedFiles.length;
   const fileCountLabel = fileCount === 0 ? 'no files' : `${fileCount} ${fileCount === 1 ? 'file' : 'files'}`;
 
+  // When a review-check click can't be resolved to a visible diff line
+  // (rare, because we also pre-filter at render time), surface a brief
+  // muted note below the callout so the user isn't left guessing why
+  // the click did nothing. Cleared after ~3s.
+  const [anchorMiss, setAnchorMiss] = useState<{ filePath: string; line: number; at: number } | null>(null);
+
+  // Auto-clear the miss notice so it doesn't linger past the moment
+  // the user expects feedback.
+  useEffect(() => {
+    if (!anchorMiss) return;
+    const t = setTimeout(() => {
+      setAnchorMiss((current) => (current && current.at === anchorMiss.at ? null : current));
+    }, 3000);
+    return () => clearTimeout(t);
+  }, [anchorMiss]);
+
+  // Which `{filePath, line}` anchors can actually resolve inside THIS
+  // slide's diff hunks. Used to pre-filter click affordances so we
+  // never render a clickable-looking check that will silently fail.
+  const anchorable = useMemo(() => buildAnchorableSet(slide.diffHunks), [slide.diffHunks]);
+
   const handleCheckClick = useCallback((check: ReviewCheck) => {
     if (!check.filePath || !check.startLine) return;
     const container = rightPanelRef.current;
     if (!container) return;
 
-    const selector = `[data-file-path="${CSS.escape(check.filePath)}"][data-line-number="${check.startLine}"]`;
-    const target = container.querySelector(selector);
-    if (!target) return;
+    const escapedPath = CSS.escape(check.filePath);
+    // Primary: new-file line number (matches what the AI is told to emit).
+    // Fallback: old-file line number, in case the AI anchored at a
+    // removed line.
+    const target =
+      container.querySelector(`[data-file-path="${escapedPath}"][data-line-number="${check.startLine}"]`) ??
+      container.querySelector(`[data-file-path="${escapedPath}"][data-base-line="${check.startLine}"]`);
+
+    if (!target) {
+      setAnchorMiss({ filePath: check.filePath, line: check.startLine, at: Date.now() });
+      return;
+    }
 
     target.scrollIntoView({ behavior: 'smooth', block: 'center' });
     target.classList.remove('check-highlight');
@@ -213,7 +266,14 @@ export function SlideView({
                 <span className="editorial-label">What to check.</span>{' '}
                 <span className="review-focus-content">
                   {checks.map((check, i) => {
-                    const isClickable = !!(check.filePath && check.startLine != null && check.startLine > 0);
+                    // Only render as a clickable anchor when the
+                    // `{filePath, line}` actually resolves to a line
+                    // inside this slide's hunks. Prevents silent
+                    // no-op clicks on hallucinated or out-of-context
+                    // anchors.
+                    const isClickable =
+                      !!(check.filePath && check.startLine != null && check.startLine > 0) &&
+                      anchorable.has(`${check.filePath}:${check.startLine}`);
                     return (
                       <span
                         key={i}
@@ -237,6 +297,12 @@ export function SlideView({
           <p className="slide-prose">
             <span className="editorial-label">What to check.</span>{' '}
             <span className="review-focus-content">{slide.reviewFocus ?? ''}</span>
+          </p>
+        )}
+        {anchorMiss && (
+          <p className="slide-meta mt-2" role="status" aria-live="polite">
+            Line {anchorMiss.line} in <span className="font-mono">{anchorMiss.filePath}</span> isn't in this slide's
+            visible diff.
           </p>
         )}
       </div>

--- a/components/SlideView.tsx
+++ b/components/SlideView.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { useRef, useState, useCallback } from 'react';
 import { Group as PanelGroup, Panel, Separator as PanelResizeHandle } from 'react-resizable-panels';
 import { MessageCircle, MessageSquarePlus } from 'lucide-react';
@@ -42,6 +43,128 @@ function formatFileAge(lastModified: string | null | undefined): string | null {
   if (days >= 30) return `${Math.floor(days / 30)}mo old`;
   if (days >= 1) return `${days}d old`;
   return null; // modified today — not worth showing
+}
+
+// A loose heuristic for "this single string is actually multiple
+// bullets jammed together". The model sometimes returns one long
+// reviewFocus or one single reviewCheck that contains its own
+// markdown list. If that happens, we want to render it as a list
+// instead of a wall of text.
+function looksLikePackedList(text: string): boolean {
+  // Markdown bullets on their own line.
+  if (/\n\s*[-*]\s+/.test(text)) return true;
+  // Numbered list items on their own line.
+  if (/\n\s*\d+[.)]\s+/.test(text)) return true;
+  return false;
+}
+
+// Inline click affordance for a single anchored check — dotted
+// underline in brand claret so it reads as a quiet link.
+const clickableCheckClass =
+  'cursor-pointer underline decoration-dotted decoration-[var(--ring)]/50 underline-offset-4 hover:decoration-[var(--ring)]';
+
+function renderReviewChecks(
+  checks: ReviewCheck[] | undefined,
+  reviewFocus: string | null,
+  onCheckClick: (check: ReviewCheck) => void
+): ReactNode {
+  // Multi-item structured: custom bulleted list, per-item click
+  // affordance for anchored checks.
+  if (checks && checks.length > 1) {
+    return (
+      <>
+        <p className="slide-prose">
+          <span className="editorial-label">What to check.</span>
+        </p>
+        <ul className="slide-prose review-checks-list mt-1.5">
+          {checks.map((check, i) => {
+            const isClickable = !!(check.filePath && check.startLine != null && check.startLine > 0);
+            return (
+              <li key={i} className="review-checks-item">
+                <span
+                  className={isClickable ? clickableCheckClass : ''}
+                  onClick={isClickable ? () => onCheckClick(check) : undefined}
+                >
+                  {check.text}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </>
+    );
+  }
+
+  // Single structured check. Short enough for a run-in label → inline.
+  // Long or self-contains a list → promote to a block so it doesn't
+  // render as a wall of text.
+  if (checks && checks.length === 1) {
+    const check = checks[0];
+    const isClickable = !!(check.filePath && check.startLine != null && check.startLine > 0);
+    const packed = looksLikePackedList(check.text);
+    const longText = check.text.length > 180;
+    if (packed || longText) {
+      return (
+        <>
+          <p className="slide-prose">
+            <span className="editorial-label">What to check.</span>
+          </p>
+          <div className="slide-prose mt-1.5">
+            <span
+              className={isClickable ? clickableCheckClass : ''}
+              onClick={isClickable ? () => onCheckClick(check) : undefined}
+            >
+              <Markdown className="review-focus-markdown">{check.text}</Markdown>
+            </span>
+          </div>
+        </>
+      );
+    }
+    return (
+      <p className="slide-prose">
+        <span className="editorial-label">What to check.</span>{' '}
+        <span className="review-focus-content">
+          <span
+            className={isClickable ? clickableCheckClass : ''}
+            onClick={isClickable ? () => onCheckClick(check) : undefined}
+          >
+            {check.text}
+          </span>
+        </span>
+      </p>
+    );
+  }
+
+  // Fallback: render reviewFocus. The model is told to format it as
+  // a markdown bullet list, so route it through <Markdown> — that way
+  // "- item1\n- item2" actually renders as a list, and a paragraph
+  // still renders as a paragraph.
+  const focus = reviewFocus ?? '';
+  if (!focus.trim()) {
+    return (
+      <p className="slide-prose">
+        <span className="editorial-label">What to check.</span>
+      </p>
+    );
+  }
+  if (looksLikePackedList(focus) || focus.length > 180) {
+    return (
+      <>
+        <p className="slide-prose">
+          <span className="editorial-label">What to check.</span>
+        </p>
+        <div className="slide-prose mt-1.5">
+          <Markdown className="review-focus-markdown">{focus}</Markdown>
+        </div>
+      </>
+    );
+  }
+  return (
+    <p className="slide-prose">
+      <span className="editorial-label">What to check.</span>{' '}
+      <span className="review-focus-content">{focus}</span>
+    </p>
+  );
 }
 
 // Group hunks by filePath so we can render them under a single file header
@@ -205,59 +328,7 @@ export function SlideView({
       )}
 
       <div className="editorial-callout select-text">
-        {slide.reviewChecks && slide.reviewChecks.length > 1 ? (
-          <>
-            <p className="slide-prose">
-              <span className="editorial-label">What to check.</span>
-            </p>
-            <ul className="slide-prose review-checks-list mt-1.5">
-              {slide.reviewChecks.map((check, i) => {
-                const isClickable = !!(check.filePath && check.startLine != null && check.startLine > 0);
-                return (
-                  <li key={i} className="review-checks-item">
-                    <span
-                      className={
-                        isClickable
-                          ? 'cursor-pointer underline decoration-dotted decoration-[var(--ring)]/50 underline-offset-4 hover:decoration-[var(--ring)]'
-                          : ''
-                      }
-                      onClick={isClickable ? () => handleCheckClick(check) : undefined}
-                    >
-                      {check.text}
-                    </span>
-                  </li>
-                );
-              })}
-            </ul>
-          </>
-        ) : slide.reviewChecks && slide.reviewChecks.length === 1 ? (
-          (() => {
-            const check = slide.reviewChecks[0];
-            const isClickable = !!(check.filePath && check.startLine != null && check.startLine > 0);
-            return (
-              <p className="slide-prose">
-                <span className="editorial-label">What to check.</span>{' '}
-                <span className="review-focus-content">
-                  <span
-                    className={
-                      isClickable
-                        ? 'cursor-pointer underline decoration-dotted decoration-[var(--ring)]/50 underline-offset-4 hover:decoration-[var(--ring)]'
-                        : ''
-                    }
-                    onClick={isClickable ? () => handleCheckClick(check) : undefined}
-                  >
-                    {check.text}
-                  </span>
-                </span>
-              </p>
-            );
-          })()
-        ) : (
-          <p className="slide-prose">
-            <span className="editorial-label">What to check.</span>{' '}
-            <span className="review-focus-content">{slide.reviewFocus ?? ''}</span>
-          </p>
-        )}
+        {renderReviewChecks(slide.reviewChecks, slide.reviewFocus, handleCheckClick)}
       </div>
 
       {slide.contextSnippets.length > 0 && (

--- a/components/SlideView.tsx
+++ b/components/SlideView.tsx
@@ -205,30 +205,49 @@ export function SlideView({
       )}
 
       <div className="editorial-callout select-text">
-        {slide.reviewChecks && slide.reviewChecks.length > 0 ? (
+        {slide.reviewChecks && slide.reviewChecks.length > 1 ? (
+          <>
+            <p className="slide-prose">
+              <span className="editorial-label">What to check.</span>
+            </p>
+            <ul className="slide-prose review-checks-list mt-1.5">
+              {slide.reviewChecks.map((check, i) => {
+                const isClickable = !!(check.filePath && check.startLine != null && check.startLine > 0);
+                return (
+                  <li key={i} className="review-checks-item">
+                    <span
+                      className={
+                        isClickable
+                          ? 'cursor-pointer underline decoration-dotted decoration-[var(--ring)]/50 underline-offset-4 hover:decoration-[var(--ring)]'
+                          : ''
+                      }
+                      onClick={isClickable ? () => handleCheckClick(check) : undefined}
+                    >
+                      {check.text}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </>
+        ) : slide.reviewChecks && slide.reviewChecks.length === 1 ? (
           (() => {
-            const checks = slide.reviewChecks;
+            const check = slide.reviewChecks[0];
+            const isClickable = !!(check.filePath && check.startLine != null && check.startLine > 0);
             return (
               <p className="slide-prose">
                 <span className="editorial-label">What to check.</span>{' '}
                 <span className="review-focus-content">
-                  {checks.map((check, i) => {
-                    const isClickable = !!(check.filePath && check.startLine != null && check.startLine > 0);
-                    return (
-                      <span
-                        key={i}
-                        className={
-                          isClickable
-                            ? 'cursor-pointer underline decoration-dotted decoration-[var(--ring)]/50 underline-offset-4 hover:decoration-[var(--ring)]'
-                            : ''
-                        }
-                        onClick={isClickable ? () => handleCheckClick(check) : undefined}
-                      >
-                        {check.text}
-                        {i < checks.length - 1 && ' '}
-                      </span>
-                    );
-                  })}
+                  <span
+                    className={
+                      isClickable
+                        ? 'cursor-pointer underline decoration-dotted decoration-[var(--ring)]/50 underline-offset-4 hover:decoration-[var(--ring)]'
+                        : ''
+                    }
+                    onClick={isClickable ? () => handleCheckClick(check) : undefined}
+                  >
+                    {check.text}
+                  </span>
                 </span>
               </p>
             );

--- a/components/SplitDiffHunk.tsx
+++ b/components/SplitDiffHunk.tsx
@@ -1,12 +1,13 @@
 import { useState, useMemo } from 'react';
 import { MessageSquarePlus } from 'lucide-react';
 import { parseDiffLines, buildSplitRows, type DiffLineInfo, type SplitRow } from '@/lib/diff-lines';
-import type { DiffHunk, PendingReviewComment } from '@/lib/types';
+import type { DiffHunk, DiffSide, PendingReviewComment } from '@/lib/types';
 import { FilePathLink } from '@/components/FilePathLink';
 import {
   type CommentCallbacks,
   parseShikiLines,
   extractShikiStyles,
+  lineAnchorAttrs,
   InlineCommentForm,
   CommentBubble,
 } from '@/components/shared-diff-utils';
@@ -21,20 +22,27 @@ interface SplitDiffHunkGroupProps {
 }
 
 function SplitDiffCell({
+  filePath,
   info,
   html,
   cellClass,
+  side,
   isInteractive,
   onClickLine,
 }: {
+  filePath: string;
   info: DiffLineInfo | null;
   html: string | null;
   cellClass: string;
+  side: DiffSide;
   isInteractive: boolean;
   onClickLine: (info: DiffLineInfo) => void;
 }) {
   const lineNum =
     info?.type === 'context' ? info.lineNumber : info?.type === 'remove' ? info.baseLineNumber : info?.headLineNumber;
+  // Anchor attrs on the code cell — that's the widest hit area and the
+  // natural visual target for "where does this check point to."
+  const anchorAttrs = info ? lineAnchorAttrs(filePath, info, side) : undefined;
 
   return (
     <>
@@ -73,6 +81,7 @@ function SplitDiffCell({
       </span>
       <span
         className={`split-diff-code select-text ${cellClass}`}
+        {...anchorAttrs}
         style={{ paddingLeft: '0.5ch', paddingRight: '1ch', whiteSpace: 'pre' }}
       >
         {html ? <span dangerouslySetInnerHTML={{ __html: html }} /> : null}
@@ -178,6 +187,7 @@ function SplitHunk({
           return (
             <SplitDiffRowFragment
               key={rowIdx}
+              filePath={filePath}
               row={row}
               leftCellClass={leftCellClass}
               rightCellClass={rightCellClass}
@@ -202,6 +212,7 @@ function SplitHunk({
 }
 
 function SplitDiffRowFragment({
+  filePath,
   row,
   leftCellClass,
   rightCellClass,
@@ -218,6 +229,7 @@ function SplitDiffRowFragment({
   onCancelForm,
   commentCallbacks,
 }: {
+  filePath: string;
   row: SplitRow;
   leftCellClass: string;
   rightCellClass: string;
@@ -237,9 +249,11 @@ function SplitDiffRowFragment({
   return (
     <>
       <SplitDiffCell
+        filePath={filePath}
         info={row.left?.info ?? null}
         html={row.left?.html ?? null}
         cellClass={leftCellClass}
+        side="LEFT"
         isInteractive={isInteractive}
         onClickLine={onClickLine}
       />
@@ -247,9 +261,11 @@ function SplitDiffRowFragment({
       <span className="split-diff-separator" />
 
       <SplitDiffCell
+        filePath={filePath}
         info={row.right?.info ?? null}
         html={row.right?.html ?? null}
         cellClass={rightCellClass}
+        side="RIGHT"
         isInteractive={isInteractive}
         onClickLine={onClickLine}
       />

--- a/components/shared-diff-utils.tsx
+++ b/components/shared-diff-utils.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { Pencil, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import type { DiffLineInfo } from '@/lib/diff-lines';
 import type { PendingReviewComment, DiffSide } from '@/lib/types';
 
 export interface CommentCallbacks {
@@ -37,6 +38,53 @@ export function parseShikiLines(renderedHtml: string): string[] | null {
  * Extract the Shiki theme styles from the rendered <pre> element so we can
  * re-apply them when rendering individual lines outside the original tree.
  */
+/**
+ * Data attributes used by review-check anchoring ("What to check" click
+ * jumps to a diff line). Emitted on every visible diff-line wrapper across
+ * all three renderers so click resolution works regardless of layout.
+ *
+ * Contract:
+ * - `data-file-path`: exact filePath string (matches what the AI emits).
+ * - `data-line-number`: NEW-FILE line number when the line exists in the
+ *   new file (adds and context). This is the primary attribute the click
+ *   handler looks for — the AI is instructed to emit new-file line numbers.
+ * - `data-base-line`: OLD-FILE line number when the line exists in the old
+ *   file (removes and context). Fallback attribute for when the AI
+ *   accidentally anchors to a removed line.
+ *
+ * `side` is the side this wrapper is RENDERED ON (LEFT/RIGHT in split
+ * layout, always RIGHT for unified). For split-layout cells, a context
+ * line's two halves each emit only the side-appropriate attribute, so the
+ * click targets the right visual cell.
+ */
+export interface LineAnchorAttrs {
+  'data-file-path': string;
+  'data-line-number'?: number;
+  'data-base-line'?: number;
+}
+
+export function lineAnchorAttrs(
+  filePath: string,
+  info: DiffLineInfo,
+  // undefined = unified row; defined = split-layout cell on that side
+  side?: DiffSide
+): LineAnchorAttrs {
+  const attrs: LineAnchorAttrs = { 'data-file-path': filePath };
+  if (side === undefined) {
+    // Unified — a single row represents the line from whichever file(s)
+    // it exists in, so expose both line numbers when available.
+    if (info.headLineNumber != null) attrs['data-line-number'] = info.headLineNumber;
+    if (info.baseLineNumber != null) attrs['data-base-line'] = info.baseLineNumber;
+  } else if (side === 'RIGHT') {
+    // Right-side (new-file) cell in split — only the head line applies.
+    if (info.headLineNumber != null) attrs['data-line-number'] = info.headLineNumber;
+  } else {
+    // Left-side (old-file) cell in split — only the base line applies.
+    if (info.baseLineNumber != null) attrs['data-base-line'] = info.baseLineNumber;
+  }
+  return attrs;
+}
+
 export function extractShikiStyles(renderedHtml: string): { preStyle: Record<string, string>; preClass: string } {
   try {
     const parser = new DOMParser();

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -28,15 +28,29 @@ NARRATIVE: For each slide, explain WHY this changed, not just WHAT changed.
 - Use **bold** for emphasis, \`backticks\` for code symbols, and markdown lists where helpful
 - No headings in narrative — just bold, lists, inline code
 
-REVIEW FOCUS: Write 2–4 actionable checks as a markdown bullet list.
-- Each bullet should be a single clear sentence
-- Focus on what could actually go wrong, not just what to look at
+REVIEW CHECKS: The reviewer has read your narrative. Now give them 2–4 things they STILL need to check to approve with confidence. This is the highest-leverage field in the review — spend real effort on it.
 
-REVIEW CHECKS (structured): Also produce a reviewChecks array with the same items as reviewFocus but in structured form.
-- Each entry has "text" (the check sentence), plus optional "filePath" and "startLine" to pinpoint where the reviewer should look.
-- filePath must exactly match one of the diffHunks[].filePath values on the same slide.
-- startLine is the new-file line number (right side) within one of that file's hunk ranges.
-- If a check is general and doesn't reference a specific line, set filePath and startLine to null.
+What makes a good check:
+- Names a SPECIFIC risk in THIS diff — a possible bug, missed edge case, broken invariant, unsafe assumption, race, boundary condition, stale cache, or contract violation. Not a generic review platitude.
+- Is phrased as a directive or yes/no question the reviewer can answer by reading the code: "Confirm X handles null Y", "Does Z still work when W is empty?", "What happens if the request aborts mid-flight at line N?"
+- Is grounded in the actual code — reference the specific function, file, or line. If you cannot point at something concrete, the check is probably not worth including.
+- Is short — one sentence. If you need two, you have two checks.
+- Is verifiable — a careful senior reviewer can say "yes, that's handled" or "no, that's broken" by looking at the diff.
+
+Do NOT produce:
+- Vague prompts ("review this", "verify correctness", "check for bugs")
+- Restatements of what the narrative or code already says
+- Style or lint commentary (formatting, naming, const vs. let, import order) — that's the linter's job, not the reviewer's
+- Generic security/performance checklist items not grounded in the diff
+- Filler checks to hit the 4-item count. Prefer 2 great checks over 4 mediocre ones.
+
+Anchor each check to a location when you honestly can:
+- "filePath" must exactly match one of the diffHunks[].filePath values on the same slide.
+- "startLine" is the new-file line number (right side) within one of that file's hunk ranges. Prefer the most specific line — the exact branch, call, or assignment the reviewer should look at, NOT the top of the function.
+- Use filePath: null, startLine: null only when the check is genuinely cross-cutting (e.g. "across these files, confirm every exception path still releases the lock").
+- Do NOT invent line numbers to look thorough. An un-anchored but concrete check is far better than a fabricated anchor.
+
+REVIEW FOCUS: The markdown-prose rendering of the same 2–4 checks as a bullet list. Same items, same standard — just formatted for reading.
 
 MERMAID DIAGRAM (optional): Include a Mermaid diagram when it genuinely helps the reviewer understand the flow or structure. Omit it (null) when the change is simple or the diagram would add clutter.
 - Use sequenceDiagram for request/response flows, async calls, event handling, or service interactions
@@ -380,13 +394,22 @@ NARRATIVE: 2–4 short paragraphs. Lead with motivation, explain what changed, n
 - Reference how this topic connects to the broader PR story when relevant
 - If this topic depends on earlier topics, briefly acknowledge what was established (e.g., "Building on the Token type introduced earlier...")
 
-REVIEW FOCUS: 2–4 actionable checks as a markdown bullet list. Focus on what could go wrong.
+REVIEW CHECKS: The reviewer has read your narrative — give them 2–4 things they STILL need to check to approve with confidence. This is the highest-leverage field; spend real effort on it.
 
-REVIEW CHECKS: Same items as reviewFocus in structured form.
-- "text" = the check sentence
-- "filePath" must exactly match a file in the provided hunks
-- "startLine" is the new-file line number within a hunk range
-- Set filePath and startLine to null for general checks
+Each check must:
+- Name a SPECIFIC risk in THIS diff (possible bug, missed edge case, broken invariant, unsafe assumption, race, boundary, stale cache, contract violation) — not a generic review platitude.
+- Be phrased as a directive or yes/no question answerable from the diff: "Confirm X handles null Y", "Does Z still work when W is empty?", "What happens if the request aborts mid-flight at line N?"
+- Be grounded in the actual code. If you cannot point at something concrete, skip the check.
+- Be one sentence. Two sentences means two checks.
+
+Avoid: vague prompts, restatements of the narrative, style/lint nits, generic checklist items, filler to hit 4 items. Prefer 2 great checks over 4 mediocre ones.
+
+Anchor when you can:
+- "filePath" exactly matches a file in the provided hunks.
+- "startLine" is a new-file line inside a hunk range — pick the most specific line (the branch, call, or assignment the reviewer should look at), not the top of the function.
+- filePath: null, startLine: null only for genuinely cross-cutting checks. Never invent anchors.
+
+REVIEW FOCUS: Markdown-bullet-list rendering of the same checks. Same items, same standard.
 
 MERMAID DIAGRAM: Include only when it genuinely helps understanding (sequence diagrams for flows, flowcharts for branching, class diagrams for data models). Keep small: 5–8 nodes max. Omit (null) when not useful.
 

--- a/src/globals.css
+++ b/src/globals.css
@@ -482,6 +482,21 @@
   background: oklch(0.65 0.13 15 / 70%);
 }
 
+/* Reused when a single packed check or a markdown-formatted
+   reviewFocus is rendered as a block inside the callout. Tightens
+   the default Markdown spacing so the block doesn't feel like an
+   article inside a margin note. */
+.review-focus-markdown p:first-child {
+  margin-top: 0;
+}
+.review-focus-markdown p:last-child {
+  margin-bottom: 0;
+}
+.review-focus-markdown ul {
+  margin-top: 0.25rem;
+  margin-bottom: 0;
+}
+
 /* Pending review comment block — the user's draft comment as it
    appears under a diff line. Tinted in the brand claret so it
    reads as "this is your work, not the diff itself." Both modes

--- a/src/globals.css
+++ b/src/globals.css
@@ -447,6 +447,41 @@
   background: oklch(0.65 0.13 15 / 70%);
 }
 
+/* Multi-check list inside .editorial-callout. Each check is its own
+   discrete item with a small brand-claret bullet so the reader can
+   take them one at a time instead of parsing a run-on paragraph.
+   The bullet uses the accent at low alpha so it reads as
+   punctuation, not highlight. */
+.review-checks-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.review-checks-item {
+  position: relative;
+  padding-left: 1.1rem;
+  line-height: 1.55;
+}
+
+.review-checks-item::before {
+  content: '';
+  position: absolute;
+  left: 0.05rem;
+  top: 0.7em;
+  width: 0.3rem;
+  height: 0.3rem;
+  border-radius: 9999px;
+  background: oklch(0.4 0.12 15 / 55%);
+}
+
+.dark .review-checks-item::before {
+  background: oklch(0.65 0.13 15 / 70%);
+}
+
 /* Pending review comment block — the user's draft comment as it
    appears under a diff line. Tinted in the brand claret so it
    reads as "this is your work, not the diff itself." Both modes

--- a/src/globals.css
+++ b/src/globals.css
@@ -632,18 +632,28 @@
 
 /* ─── Check suggestion jump highlight ────────────────────────── */
 
+/* When a reviewer clicks a "What to check" hint, the target diff
+   line gets this class briefly. The ::after overlays the line with a
+   claret wash that fades to zero — a page-turning blink rather than
+   a pulsing highlight. isolation:isolate keeps the overlay contained
+   if the target happens to be inside another stacking context. */
 .check-highlight {
   position: relative;
+  isolation: isolate;
 }
 .check-highlight::after {
   content: '';
   position: absolute;
   inset: 0;
   pointer-events: none;
-  /* Claret flash — same hue as the brand --ring, just briefly
-     visible to show the user where the check landed. */
+  z-index: 0;
   background-color: oklch(0.55 0.14 15 / 22%);
   animation: check-highlight-fade 1.5s ease-out forwards;
+  will-change: opacity;
+}
+.check-highlight > * {
+  position: relative;
+  z-index: 1;
 }
 @keyframes check-highlight-fade {
   from {


### PR DESCRIPTION
Combines #84, #85, #86 into a single branch for end-to-end testing. All three touch the "What to check" surface and are tied together.

## What's inside

### From #85 — prompt guidance (\`lib/agent.ts\`)
Rewrites the reviewChecks / reviewFocus guidance in both \`SYSTEM_PROMPT\` (single-phase) and \`WRITER_SYSTEM\` (parallel writer) with explicit positive criteria (specific risk in THIS diff, directive/question form, grounded in code, one sentence, verifiable) and an anti-pattern list (vague prompts, narrative restatements, lint nits, filler, fabricated anchors). Tightens anchoring rules — prefer the specific line over the top of the function.

### From #86 — anchoring parity (\`components/DiffHunk.tsx\`, \`InteractiveDiffHunk.tsx\`, \`SplitDiffHunk.tsx\`, \`shared-diff-utils.tsx\`)
Previously, only \`InteractiveDiffHunk\` emitted \`data-file-path\`/\`data-line-number\`, so clicking a hint in split layout or in read-only unified mode silently did nothing. Now all three renderers emit consistent, side-aware anchor attributes via \`lineAnchorAttrs\`. Click handler tries \`data-line-number\` first (new-file, matches the prompt's contract) then falls back to \`data-base-line\` (covers the rare case of an anchor at a removed line). \`.check-highlight\` tightened with \`isolation\` / \`z-index\` so the flash layers correctly in every stacking context.

### From #84 — rendering (\`components/SlideView.tsx\`, \`src/globals.css\`)
Multi-item \`reviewChecks\` render as a custom bulleted list. Single long or "packed" checks promote to a block through Markdown. A sentence-level fallback (\`splitIntoProseChecks\`) catches the common case where the model crams multiple distinct checks into one prose blob — splits on \`.\`/\`?\`/\`!\` followed by a capital letter or backtick, returning multiple bullets when each segment is a reasonable length (20–500 chars). \`reviewFocus\` fallback goes through the same logic, so \`- foo\\n- bar\` renders as a real list.

### Combined additions
- \`buildAnchorableSet(hunks)\` parses hunk headers to compute every resolvable \`{filePath}:line\` in the current slide — used by \`renderReviewChecks\` to only mark a check as clickable when the anchor actually lands on a visible line. Prevents silent no-op clicks in every render branch, not just the inline one.
- Defensive \`aria-live="polite"\` "Line N in \`<path>\` isn't in this slide's visible diff" notice auto-clears after 3s if a click somehow still misses.

## Files
- \`lib/agent.ts\`
- \`components/DiffHunk.tsx\`
- \`components/InteractiveDiffHunk.tsx\`
- \`components/SplitDiffHunk.tsx\`
- \`components/SlideView.tsx\`
- \`components/shared-diff-utils.tsx\`
- \`src/globals.css\`

## Test plan (end-to-end)
- [ ] Open an old review with one giant multi-topic \`reviewCheck\` — renders as sentence bullets
- [ ] Open an old review with only \`reviewFocus\` as a paragraph — ditto
- [ ] Open an old review with 3+ structured checks — renders as bullets, per-item clickable
- [ ] Click a check anchor in unified + interactive mode — flashes the line (was already working)
- [ ] Click a check anchor in split layout — flashes the correct side's cell (was broken)
- [ ] Click a check anchor in unified read-only mode — flashes the line (was broken)
- [ ] Force an out-of-slide anchor — renders non-clickable (no dotted underline)
- [ ] Generate a new review with the updated prompt — checks look more specific, less platitude
- [ ] Light ↔ dark, prefers-reduced-motion — all behave

Closes #84, #85, #86 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)