### PR TITLE
feat: Education Mode — inline explainers for assumed concepts

### DIFF
--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -141,6 +141,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
   const [trayEnabled, setTrayEnabled] = useState(true);
   const [maxPrsPerRepo, setMaxPrsPerRepo] = useState(10);
   const [parallelReview, setParallelReview] = useState(false);
+  const [educationMode, setEducationMode] = useState(true);
   const [analytics, setAnalytics] = useState(true);
   const [proactiveReviewOverrides, setProactiveReviewOverrides] = useState(false);
   const [proactiveProvider, setProactiveProvider] = useState<Provider>('claude');
@@ -167,6 +168,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
       setTrayEnabled(prefs.trayEnabled);
       setMaxPrsPerRepo(prefs.maxPrsPerRepo);
       setParallelReview(prefs.parallelReview);
+      setEducationMode(prefs.educationMode);
       setAnalytics(prefs.analytics);
       setProactiveReviewOverrides(prefs.proactiveReviewOverrides);
       setProactiveProvider(prefs.proactiveProvider);
@@ -286,6 +288,21 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
                   const next = !parallelReview;
                   setParallelReview(next);
                   saveField({ parallelReview: next });
+                }}
+              />
+            </SettingRow>
+
+            <SettingRow
+              label="Education mode"
+              description="Add short explainer notes inside slides for concepts the code assumes knowledge of (e.g. Unit of Work). Helpful for reviewers less familiar with the area."
+            >
+              <Toggle
+                checked={educationMode}
+                ariaLabel="Education mode"
+                onChange={() => {
+                  const next = !educationMode;
+                  setEducationMode(next);
+                  saveField({ educationMode: next });
                 }}
               />
             </SettingRow>

--- a/components/SlideView.tsx
+++ b/components/SlideView.tsx
@@ -440,10 +440,12 @@ export function SlideView({
       {slide.educationNotes && slide.educationNotes.length > 0 && (
         <aside className="education-notes select-text" aria-label="Background concepts">
           {slide.educationNotes.map((note, i) => (
-            <div key={i} className="education-note">
-              <span className="education-note-label">Background</span>
-              <span className="education-note-concept">{note.concept}</span>
-              <Markdown className="education-note-explanation">{note.explanation}</Markdown>
+            <div key={i} className="flex flex-col gap-1">
+              <span className="slide-meta">Background</span>
+              <p className="slide-prose">
+                <span className="editorial-label">{note.concept}.</span>{' '}
+                {note.explanation}
+              </p>
             </div>
           ))}
         </aside>

--- a/components/SlideView.tsx
+++ b/components/SlideView.tsx
@@ -437,6 +437,18 @@ export function SlideView({
 
       <Markdown className="slide-prose select-text">{slide.narrative}</Markdown>
 
+      {slide.educationNotes && slide.educationNotes.length > 0 && (
+        <aside className="education-notes select-text" aria-label="Background concepts">
+          {slide.educationNotes.map((note, i) => (
+            <div key={i} className="education-note">
+              <span className="education-note-label">Background</span>
+              <span className="education-note-concept">{note.concept}</span>
+              <Markdown className="education-note-explanation">{note.explanation}</Markdown>
+            </div>
+          ))}
+        </aside>
+      )}
+
       {slide.affectedFiles.length > 0 && (
         <ul className="slide-meta flex flex-col gap-1 select-text">
           {slide.affectedFiles.map((f) => (

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -131,9 +131,6 @@ The JSON must match this schema exactly:
           "filePath": string | null,
           "startLine": number | null
         }
-      ],
-      "educationNotes": [
-        { "concept": string, "explanation": string }
       ]
     }
   ]
@@ -199,34 +196,59 @@ function validateAIReviewGuide(obj: unknown): obj is AIReviewGuide {
 
 // ── Main entry point ─────────────────────────────────────────────
 
-export async function generateReviewGuide(
-  contextPackage: string,
-  prUrl: string,
-  providerName: Provider,
-  model: ModelId,
-  instructions?: string,
-  onChunk?: (chunk: string, isThinking: boolean) => void,
-  thinking: boolean = false,
-  mcpConfigPath?: string,
-  allowedTools?: string[],
-  reviewSuggestions: boolean = true,
-  webResearch: boolean = false,
-  onToolUse?: (toolName: string) => void,
-  onPromptReady?: (system: string, userMessage: string) => void,
-  signal?: AbortSignal,
-  educationMode: boolean = false
-): Promise<AIReviewGuide> {
+export interface GenerateReviewGuideOptions {
+  contextPackage: string;
+  prUrl: string;
+  providerName: Provider;
+  model: ModelId;
+  instructions?: string;
+  thinking?: boolean;
+  reviewSuggestions?: boolean;
+  webResearch?: boolean;
+  educationMode?: boolean;
+  mcpConfigPath?: string;
+  allowedTools?: string[];
+  onChunk?: (chunk: string, isThinking: boolean) => void;
+  onToolUse?: (toolName: string) => void;
+  onPromptReady?: (system: string, userMessage: string) => void;
+  signal?: AbortSignal;
+}
+
+export async function generateReviewGuide(opts: GenerateReviewGuideOptions): Promise<AIReviewGuide> {
+  const {
+    contextPackage,
+    prUrl,
+    providerName,
+    model,
+    instructions,
+    thinking = false,
+    reviewSuggestions = true,
+    webResearch = false,
+    educationMode = false,
+    mcpConfigPath,
+    allowedTools,
+    onChunk,
+    onToolUse,
+    onPromptReady,
+    signal,
+  } = opts;
   const provider = getProvider(providerName);
 
   async function attempt(extraInstruction: string = ''): Promise<AIReviewGuide> {
     const customInstructions = instructions?.trim();
     const webSourcesSchema = webResearch ? `,\n  "webSources": [{ "url": string, "title": string }, ...]` : '';
+    const educationNotesSchema = educationMode
+      ? `,\n      "educationNotes": [{ "concept": string, "explanation": string }]`
+      : '';
+    const slideSchema = USER_SUFFIX
+      .replace(/\n {4}}\n/, `${educationNotesSchema}\n    }\n`)
+      .replace('\n}', `${webSourcesSchema}\n}`);
     const userMessage = customInstructions
       ? contextPackage +
-        USER_SUFFIX.replace('\n}', `${webSourcesSchema}\n}`) +
+        slideSchema +
         extraInstruction +
         `\n\n<reviewer_instructions>\nThe reviewer has provided custom instructions that MUST take priority over default style guidelines.\n${customInstructions}\n</reviewer_instructions>`
-      : contextPackage + USER_SUFFIX.replace('\n}', `${webSourcesSchema}\n}`) + extraInstruction;
+      : contextPackage + slideSchema + extraInstruction;
 
     const reviewSuggestionsDirective = reviewSuggestions
       ? ''
@@ -446,9 +468,6 @@ Write the slide content for this topic. Respond with JSON matching this schema e
       "filePath": string | null,
       "startLine": number | null
     }
-  ],
-  "educationNotes": [
-    { "concept": string, "explanation": string }
   ]
 }`;
 
@@ -458,17 +477,30 @@ function validateWriterOutput(obj: unknown): obj is WriterSlideOutput {
   return typeof o.narrative === 'string';
 }
 
-export async function generateSlide(
-  topicContext: string,
-  providerName: Provider,
-  model: ModelId,
-  instructions?: string,
-  reviewSuggestions: boolean = true,
-  onChunk?: (chunk: string, isThinking: boolean) => void,
-  thinking: boolean = false,
-  signal?: AbortSignal,
-  educationMode: boolean = false
-): Promise<WriterSlideOutput> {
+export interface GenerateSlideOptions {
+  topicContext: string;
+  providerName: Provider;
+  model: ModelId;
+  instructions?: string;
+  reviewSuggestions?: boolean;
+  thinking?: boolean;
+  educationMode?: boolean;
+  onChunk?: (chunk: string, isThinking: boolean) => void;
+  signal?: AbortSignal;
+}
+
+export async function generateSlide(opts: GenerateSlideOptions): Promise<WriterSlideOutput> {
+  const {
+    topicContext,
+    providerName,
+    model,
+    instructions,
+    reviewSuggestions = true,
+    thinking = false,
+    educationMode = false,
+    onChunk,
+    signal,
+  } = opts;
   const provider = getProvider(providerName);
 
   const reviewSuggestionsDirective = reviewSuggestions
@@ -481,7 +513,10 @@ export async function generateSlide(
     system += `\n\nCUSTOM REVIEWER INSTRUCTIONS (take precedence over style guidelines):\n${instructions.trim()}`;
   }
 
-  const userMessage = topicContext + WRITER_USER_SUFFIX;
+  const educationNotesSchema = educationMode
+    ? `,\n  "educationNotes": [{ "concept": string, "explanation": string }]`
+    : '';
+  const userMessage = topicContext + WRITER_USER_SUFFIX.replace('\n}', `${educationNotesSchema}\n}`);
   console.log(`[writer] Starting ${providerName} (${model}) with ${userMessage.length} chars`);
 
   async function attempt(extra: string = ''): Promise<WriterSlideOutput> {

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -131,6 +131,9 @@ The JSON must match this schema exactly:
           "filePath": string | null,
           "startLine": number | null
         }
+      ],
+      "educationNotes": [
+        { "concept": string, "explanation": string }
       ]
     }
   ]
@@ -139,6 +142,18 @@ The JSON must match this schema exactly:
 const CONCISE_SUFFIX = `
 
 IMPORTANT: Be concise. Keep narrative and reviewFocus under 2 sentences each. Omit contextSnippets entirely (use empty arrays). Limit diffHunkIds to the 5 most important hunk IDs per slide. Return only raw JSON starting with { and ending with }.`;
+
+const EDUCATION_DIRECTIVE = `
+EDUCATION MODE — ACTIVE
+The reviewer may not be familiar with every concept the code assumes knowledge of. Where a slide's narrative references a named pattern, domain concept, or non-obvious library primitive, include a short entry in "educationNotes" for that slide explaining it.
+
+Rules for educationNotes:
+- Include a note ONLY when a concept is genuinely referenced AND would not be obvious to a competent developer new to this area (e.g. "Unit of Work", "CORS preflight", "idempotency key", "backpressure", "tombstone row"). Skip the obvious (variable, for-loop, HTTP 404).
+- "concept" is the term itself, as it would appear in a glossary. 1–4 words. Sentence case.
+- "explanation" is 1–2 plain-English sentences. No prerequisites, no code, no jargon. Tell the reviewer WHAT it is and WHY it matters in this context.
+- At most 3 notes per slide. Prefer 0–1 unless the slide genuinely leans on multiple concepts.
+- Do NOT pad: if nothing in the slide assumes outside knowledge, omit the field (or return an empty array).
+`;
 
 const WEB_RESEARCH_DIRECTIVE = `
 WEB RESEARCH MODE — ACTIVE
@@ -198,7 +213,8 @@ export async function generateReviewGuide(
   webResearch: boolean = false,
   onToolUse?: (toolName: string) => void,
   onPromptReady?: (system: string, userMessage: string) => void,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  educationMode: boolean = false
 ): Promise<AIReviewGuide> {
   const provider = getProvider(providerName);
 
@@ -217,10 +233,11 @@ export async function generateReviewGuide(
       : `\nREVIEW SUGGESTIONS DISABLED: The reviewer has turned off review suggestions. Set "reviewFocus" to null for every slide. Do not generate any review focus content.\n`;
 
     const webResearchDirective = webResearch ? WEB_RESEARCH_DIRECTIVE : '';
+    const educationDirective = educationMode ? EDUCATION_DIRECTIVE : '';
 
     // Signal boost is always on — deprioritize formatting and
     // import-only changes, emphasize design decisions.
-    const baseSystem = `${FOCUS_DIRECTIVE}\n${webResearchDirective}${SYSTEM_PROMPT}${reviewSuggestionsDirective}`;
+    const baseSystem = `${FOCUS_DIRECTIVE}\n${webResearchDirective}${educationDirective}${SYSTEM_PROMPT}${reviewSuggestionsDirective}`;
 
     const system = customInstructions
       ? `${baseSystem}\n\nIMPORTANT — CUSTOM REVIEWER INSTRUCTIONS:\nThe reviewer has provided the following instructions. These take precedence over the default writing style and tone guidelines above. Adapt your narrative, reviewFocus, summary, and all prose fields accordingly.\n\n<instructions>\n${customInstructions}\n</instructions>`
@@ -429,6 +446,9 @@ Write the slide content for this topic. Respond with JSON matching this schema e
       "filePath": string | null,
       "startLine": number | null
     }
+  ],
+  "educationNotes": [
+    { "concept": string, "explanation": string }
   ]
 }`;
 
@@ -446,15 +466,17 @@ export async function generateSlide(
   reviewSuggestions: boolean = true,
   onChunk?: (chunk: string, isThinking: boolean) => void,
   thinking: boolean = false,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  educationMode: boolean = false
 ): Promise<WriterSlideOutput> {
   const provider = getProvider(providerName);
 
   const reviewSuggestionsDirective = reviewSuggestions
     ? ''
     : '\nSet "reviewFocus" to null. Do not generate review focus content.\n';
+  const educationDirective = educationMode ? EDUCATION_DIRECTIVE : '';
 
-  let system = WRITER_SYSTEM + reviewSuggestionsDirective;
+  let system = WRITER_SYSTEM + reviewSuggestionsDirective + educationDirective;
   if (instructions?.trim()) {
     system += `\n\nCUSTOM REVIEWER INSTRUCTIONS (take precedence over style guidelines):\n${instructions.trim()}`;
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -27,6 +27,17 @@ export interface ReviewCheck {
   startLine?: number;
 }
 
+// A short "here's what this term means" callout rendered inline in a
+// slide when Education Mode is on. Populated by the AI when the slide
+// references a concept the reviewer might not already know — e.g.
+// "Unit of Work", "CORS preflight", "idempotency key".
+export interface EducationNote {
+  /** The concept or pattern (short, headline-style). */
+  concept: string;
+  /** 1-2 sentences, plain English, no prerequisites. */
+  explanation: string;
+}
+
 export type SlideImportance = 'critical' | 'important' | 'minor';
 
 export interface Slide {
@@ -42,6 +53,7 @@ export interface Slide {
   dependsOn: string[];
   mermaidDiagram?: string | null;
   reviewChecks?: ReviewCheck[];
+  educationNotes?: EducationNote[];
   // AI-assigned importance. "critical" = auth, data integrity, API
   // contract changes. "important" = core logic, new features.
   // "minor" = config, docs, test boilerplate, import reordering.
@@ -62,6 +74,7 @@ export interface AISlide {
   dependsOn: string[];
   mermaidDiagram?: string | null;
   reviewChecks?: ReviewCheck[];
+  educationNotes?: EducationNote[];
   importance?: SlideImportance;
 }
 
@@ -110,6 +123,7 @@ export interface WriterSlideOutput {
   contextSnippets: string[];
   mermaidDiagram?: string | null;
   reviewChecks?: ReviewCheck[];
+  educationNotes?: EducationNote[];
 }
 
 export interface FileMetadata {
@@ -257,6 +271,10 @@ export interface Preferences {
   proactiveProvider: Provider;
   proactiveModel: ModelId;
   proactiveThinking: boolean;
+  /** Education Mode — when on, each slide can include short explanatory
+   *  callouts ("educationNotes") for concepts the code assumes knowledge
+   *  of, so reviewers less familiar with the area still have context. */
+  educationMode: boolean;
 }
 
 export interface SendSlideChatRequest {
@@ -283,6 +301,7 @@ export interface GenerateReviewRequest {
   smartImports?: boolean;
   reviewSuggestions?: boolean;
   webResearch?: boolean;
+  educationMode?: boolean;
   excludedFiles?: string[];
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -27,14 +27,8 @@ export interface ReviewCheck {
   startLine?: number;
 }
 
-// A short "here's what this term means" callout rendered inline in a
-// slide when Education Mode is on. Populated by the AI when the slide
-// references a concept the reviewer might not already know — e.g.
-// "Unit of Work", "CORS preflight", "idempotency key".
 export interface EducationNote {
-  /** The concept or pattern (short, headline-style). */
   concept: string;
-  /** 1-2 sentences, plain English, no prerequisites. */
   explanation: string;
 }
 
@@ -271,9 +265,6 @@ export interface Preferences {
   proactiveProvider: Provider;
   proactiveModel: ModelId;
   proactiveThinking: boolean;
-  /** Education Mode — when on, each slide can include short explanatory
-   *  callouts ("educationNotes") for concepts the code assumes knowledge
-   *  of, so reviewers less familiar with the area still have context. */
   educationMode: boolean;
 }
 

--- a/src/globals.css
+++ b/src/globals.css
@@ -447,6 +447,53 @@
   background: oklch(0.65 0.13 15 / 70%);
 }
 
+/* Education Mode notes — short "here's what this term means" blocks
+   rendered inline with the slide narrative so the reader doesn't
+   break flow to look something up. Quieter than editorial-callout:
+   hairline left rule in muted gray, not claret, so it reads as an
+   aside rather than a call-to-action. */
+.education-notes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 0.65rem 0 0.65rem 1rem;
+  border-left: 1px solid oklch(0.55 0.02 65 / 30%);
+}
+
+.dark .education-notes {
+  border-left-color: oklch(0.7 0.02 65 / 24%);
+}
+
+.education-note {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.education-note-label {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
+}
+
+.education-note-concept {
+  font-family: var(--font-serif);
+  font-feature-settings: 'opsz' 14;
+  font-size: 0.98rem;
+  font-weight: 540;
+  color: var(--foreground);
+  letter-spacing: -0.005em;
+}
+
+.education-note-explanation {
+  font-size: 0.875rem;
+  line-height: 1.55;
+  color: var(--foreground);
+  max-width: var(--measure-prose);
+}
+
 /* Multi-check list inside .editorial-callout. Each check is its own
    discrete item with a small brand-claret bullet so the reader can
    take them one at a time instead of parsing a run-on paragraph.

--- a/src/globals.css
+++ b/src/globals.css
@@ -447,51 +447,20 @@
   background: oklch(0.65 0.13 15 / 70%);
 }
 
-/* Education Mode notes — short "here's what this term means" blocks
-   rendered inline with the slide narrative so the reader doesn't
-   break flow to look something up. Quieter than editorial-callout:
-   hairline left rule in muted gray, not claret, so it reads as an
-   aside rather than a call-to-action. */
+/* Education Mode notes: hairline muted-gray left rail so the aside
+   reads as a margin note, not a call-to-action (claret is reserved
+   for active affordances). Inner structure reuses .slide-meta and
+   .slide-prose / .editorial-label for the heading + body. */
 .education-notes {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
-  padding: 0.65rem 0 0.65rem 1rem;
+  gap: 0.9rem;
+  padding: 0.25rem 0 0.25rem 1rem;
   border-left: 1px solid oklch(0.55 0.02 65 / 30%);
 }
 
 .dark .education-notes {
   border-left-color: oklch(0.7 0.02 65 / 24%);
-}
-
-.education-note {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-}
-
-.education-note-label {
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--muted-foreground);
-}
-
-.education-note-concept {
-  font-family: var(--font-serif);
-  font-feature-settings: 'opsz' 14;
-  font-size: 0.98rem;
-  font-weight: 540;
-  color: var(--foreground);
-  letter-spacing: -0.005em;
-}
-
-.education-note-explanation {
-  font-size: 0.875rem;
-  line-height: 1.55;
-  color: var(--foreground);
-  max-width: var(--measure-prose);
 }
 
 /* Multi-check list inside .editorial-callout. Each check is its own

--- a/src/main.ts
+++ b/src/main.ts
@@ -502,6 +502,7 @@ async function triggerProactiveReview(
       thinking,
       smartImports: prefs.smartImports,
       reviewSuggestions: prefs.reviewSuggestions,
+      educationMode: prefs.educationMode,
     };
 
     await runBackgroundGeneration(reviewId, request, prData, abortController.signal);
@@ -959,6 +960,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   proactiveProvider: 'claude',
   proactiveModel: 'claude-sonnet-4-6',
   proactiveThinking: false,
+  educationMode: true,
 };
 
 function applyBinaryOverrides(prefs: Preferences): void {
@@ -1327,7 +1329,7 @@ async function runBackgroundGeneration(
   prData: Awaited<ReturnType<typeof getPrMetadata>>,
   signal: AbortSignal
 ): Promise<void> {
-  const { prUrl, provider, model, instructions, thinking, smartImports, reviewSuggestions, webResearch } =
+  const { prUrl, provider, model, instructions, thinking, smartImports, reviewSuggestions, webResearch, educationMode } =
     request;
 
   try {
@@ -1497,6 +1499,7 @@ async function runBackgroundGeneration(
               (chunk, isThinking) => broadcastToAllWindows('review-progress', { reviewId, chunk, isThinking }),
               thinking ?? false,
               signal,
+              educationMode ?? false,
             );
 
             const diffHunks = resolveDiffHunks(topic.hunkIds ?? [], hunkMap, assignedIds);
@@ -1514,6 +1517,7 @@ async function runBackgroundGeneration(
               dependsOn: topic.dependsOn,
               mermaidDiagram: writerOutput.mermaidDiagram,
               reviewChecks: writerOutput.reviewChecks,
+              educationNotes: writerOutput.educationNotes,
               importance: topic.importance,
             } satisfies Slide;
         })
@@ -1574,7 +1578,8 @@ async function runBackgroundGeneration(
               // Best-effort
             }
           },
-          signal
+          signal,
+          educationMode ?? false
         );
       } finally {
         if (mcpConfigPath) cleanupMcpConfig(mcpConfigPath);
@@ -1601,6 +1606,7 @@ async function runBackgroundGeneration(
           dependsOn: aiSlide.dependsOn ?? [],
           mermaidDiagram: aiSlide.mermaidDiagram,
           reviewChecks: aiSlide.reviewChecks,
+          educationNotes: aiSlide.educationNotes,
           importance: aiSlide.importance ?? 'important',
         };
       });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1490,17 +1490,18 @@ async function runBackgroundGeneration(
               prData.title, prData.description, storyArc, sortedTopics,
             );
 
-            const writerOutput = await generateSlide(
-              topicCtx,
-              provider,
+            const writerOutput = await generateSlide({
+              topicContext: topicCtx,
+              providerName: provider,
               model,
               instructions,
-              reviewSuggestions ?? true,
-              (chunk, isThinking) => broadcastToAllWindows('review-progress', { reviewId, chunk, isThinking }),
-              thinking ?? false,
+              reviewSuggestions,
+              thinking,
+              educationMode,
+              onChunk: (chunk, isThinking) =>
+                broadcastToAllWindows('review-progress', { reviewId, chunk, isThinking }),
               signal,
-              educationMode ?? false,
-            );
+            });
 
             const diffHunks = resolveDiffHunks(topic.hunkIds ?? [], hunkMap, assignedIds);
 
@@ -1543,13 +1544,19 @@ async function runBackgroundGeneration(
 
       let lastStreamPhase: string | null = null;
       try {
-        aiResult = await generateReviewGuide(
+        aiResult = await generateReviewGuide({
           contextPackage,
           prUrl,
-          provider,
+          providerName: provider,
           model,
           instructions,
-          (chunk, isThinking) => {
+          thinking,
+          reviewSuggestions,
+          webResearch,
+          educationMode,
+          mcpConfigPath,
+          allowedTools,
+          onChunk: (chunk, isThinking) => {
             const phase = isThinking ? 'Thinking' : 'Generating review';
             if (phase !== lastStreamPhase) {
               lastStreamPhase = phase;
@@ -1557,13 +1564,8 @@ async function runBackgroundGeneration(
             }
             broadcastToAllWindows('review-progress', { reviewId, chunk, isThinking });
           },
-          thinking ?? false,
-          mcpConfigPath,
-          allowedTools,
-          reviewSuggestions ?? true,
-          webResearch ?? false,
-          (toolName) => broadcastToAllWindows('review-tool-use', { reviewId, toolName }),
-          (system, userMessage) => {
+          onToolUse: (toolName) => broadcastToAllWindows('review-tool-use', { reviewId, toolName }),
+          onPromptReady: (system, userMessage) => {
             broadcastToAllWindows('review-stats', {
               reviewId,
               inputBytes: system.length + userMessage.length,
@@ -1579,8 +1581,7 @@ async function runBackgroundGeneration(
             }
           },
           signal,
-          educationMode ?? false
-        );
+        });
       } finally {
         if (mcpConfigPath) cleanupMcpConfig(mcpConfigPath);
       }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -127,6 +127,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [smartImports, setSmartImports] = useState(true);
   const [reviewSuggestions, setReviewSuggestions] = useState(true);
   const [webResearch, setWebResearch] = useState(false);
+  const [educationMode, setEducationMode] = useState(true);
   const [instructions, setInstructions] = useState('');
   const [prefsLoaded, setPrefsLoaded] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -267,6 +268,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       setSmartImports(prefs.smartImports);
       setReviewSuggestions(prefs.reviewSuggestions);
       setWebResearch(prefs.enableWebResearch);
+      setEducationMode(prefs.educationMode);
       setIncludeAllFiles(prefs.includeAllFiles);
       setPrefsLoaded(true);
       if (!prefs.firstRunSeen) {
@@ -529,6 +531,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
           smartImports,
           reviewSuggestions,
           enableWebResearch: webResearch,
+          educationMode,
           includeAllFiles,
           ...overrides,
         });
@@ -542,6 +545,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       smartImports,
       reviewSuggestions,
       webResearch,
+      educationMode,
       includeAllFiles,
     ]
   );
@@ -557,6 +561,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
     smartImports,
     reviewSuggestions,
     webResearch,
+    educationMode,
     includeAllFiles,
     savePrefs,
   ]);
@@ -610,6 +615,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
         smartImports,
         reviewSuggestions,
         webResearch,
+        educationMode,
         excludedFiles: excludedFiles.length > 0 ? excludedFiles : undefined,
       });
       setGenerationStartTimes((prev) => new Map(prev).set(result.reviewId, Date.now()));
@@ -1292,6 +1298,13 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                       description="Generate 'What to check' for each slide"
                       checked={reviewSuggestions}
                       onToggle={() => setReviewSuggestions((r) => !r)}
+                    />
+                    <ToggleSwitch
+                      id="education-mode"
+                      label="Education mode"
+                      description="Small explainer notes for concepts the code assumes knowledge of (e.g. Unit of Work)"
+                      checked={educationMode}
+                      onToggle={() => setEducationMode((e) => !e)}
                     />
                     {provider === 'claude' && (
                       <ToggleSwitch


### PR DESCRIPTION
## What it does
When a slide's narrative references a named pattern, domain concept, or non-obvious primitive the code assumes knowledge of ("Unit of Work", "CORS preflight", "idempotency key", "backpressure", "tombstone row"), the AI can emit a short inline callout explaining it. The reviewer sees the term in context and gets an immediate 1–2 sentence plain-English definition without breaking reading flow.

## Default
**On** (opt-out). Aligns with the app's "understand the PR before reading the diff" positioning. Lean reviewers can disable it per-review or globally.

## Scope of the model's discretion
Prompt rules tell the model to:
- Only include notes when the concept is **genuinely referenced** AND **not obvious to a competent developer new to the area**.
- Cap at 3 notes per slide, prefer 0–1.
- "concept" is a 1–4 word headline. "explanation" is 1–2 plain sentences.
- Skip the obvious (variables, for-loops, HTTP 404). Omit the field when the slide has nothing to explain.

## Visual treatment
\`.education-notes\` renders as a quiet aside between the slide narrative and the "What to check" callout:
- Hairline left rule in **muted gray** (not claret) — reads as an aside, not a call-to-action.
- Small uppercase "Background" mono label.
- Concept in serif at ~1rem.
- Explanation rendered through \`<Markdown>\` at 0.875rem, max-width clamped to the editorial reading measure.

Color punctuation stays the way the brief demands — claret reserved for focus / active markers / review checks.

## Files
- \`lib/types.ts\` — \`EducationNote\`, Slide/AISlide/WriterSlideOutput additions, \`Preferences.educationMode\`, \`GenerateReviewRequest.educationMode\`.
- \`lib/agent.ts\` — \`EDUCATION_DIRECTIVE\`, conditional inclusion in both single-shot and writer system prompts, schema updates in both \`USER_SUFFIX\` and \`WRITER_USER_SUFFIX\`.
- \`src/main.ts\` — plumb \`educationMode\` through \`runBackgroundGeneration\` to both generation paths, default \`true\` in \`DEFAULT_PREFERENCES\`, pick up from prefs for proactive reviews.
- \`src/pages/HomePage.tsx\` — per-review toggle next to Web research + Review suggestions.
- \`components/SettingsDialog.tsx\` — global toggle in the Review section.
- \`components/SlideView.tsx\` — \`.education-notes\` aside rendering after narrative.
- \`src/globals.css\` — editorial styling for \`.education-notes\`, \`.education-note-*\`.

## Test plan
- [ ] Fresh install — Education mode shows ON by default in HomePage form and Settings
- [ ] Generate a review on a PR that uses a non-trivial pattern (e.g. anything with "repository pattern", "dependency injection", "backpressure"). Confirm notes appear in the relevant slides only.
- [ ] Turn off per-review from HomePage → next generation has no \`educationNotes\` on any slide
- [ ] Turn off globally from Settings → new reviews skip notes; persists across restarts
- [ ] Proactive review → respects the global pref
- [ ] Existing reviews (generated before this change) have no \`educationNotes\` — slide renders unchanged, no empty aside
- [ ] Light ↔ dark — aside readable in both

🤖 Generated with [Claude Code](https://claude.com/claude-code)