### PR TITLE
feat: persistent checkboxes on each review check

### DIFF
--- a/components/SlideView.tsx
+++ b/components/SlideView.tsx
@@ -18,6 +18,8 @@ interface Props {
   slideNumber: number;
   totalSlides: number;
   prUrl: string;
+  checkedChecks: Set<string>;
+  onToggleCheck: (key: string) => void;
   pendingComments?: PendingReviewComment[];
   commentCallbacks?: CommentCallbacks;
   diffLayout: Preferences['diffLayout'];
@@ -163,14 +165,72 @@ function isAnchorable(check: ReviewCheck, anchorable: Set<string>): boolean {
   return anchorable.has(`${check.filePath}:${check.startLine}`);
 }
 
+// djb2 — a tiny, stable string hash. Used as the trailing segment of
+// each checkbox's localStorage key so a reviewer's ticks survive
+// layout/renderer changes (bullet vs inline, prose-split reshape).
+function hashText(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(36);
+}
+
+function checkKey(slideId: string, text: string): string {
+  return `${slideId}:${hashText(text.trim())}`;
+}
+
+// Persistent "I've verified this" checkbox for a single item in the
+// "What to check" callout. Renders a native input (for real keyboard
+// semantics) styled to match the brand accent, plus a line-through
+// strike when checked so skimming back over the list the eye knows
+// what's already been done.
+function CheckTodo({
+  storageKey,
+  checked,
+  onToggle,
+  children,
+}: {
+  storageKey: string;
+  checked: boolean;
+  onToggle: (key: string) => void;
+  children: ReactNode;
+}) {
+  return (
+    <label className="check-todo">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => {
+          e.stopPropagation();
+          onToggle(storageKey);
+        }}
+        onClick={(e) => e.stopPropagation()}
+        className="check-todo-input"
+        aria-label={checked ? 'Mark check not done' : 'Mark check done'}
+      />
+      <span className={checked ? 'check-todo-done' : ''}>{children}</span>
+    </label>
+  );
+}
+
 function renderReviewChecks(
   checks: ReviewCheck[] | undefined,
   reviewFocus: string | null,
   anchorable: Set<string>,
   onCheckClick: (check: ReviewCheck) => void,
+  slideId: string,
   slideTitle: string,
-  prUrl: string
+  prUrl: string,
+  checkedChecks: Set<string>,
+  onToggleCheck: (key: string) => void
 ): ReactNode {
+  const todoFor = (text: string, children: ReactNode): ReactNode => {
+    const key = checkKey(slideId, text);
+    return (
+      <CheckTodo storageKey={key} checked={checkedChecks.has(key)} onToggle={onToggleCheck}>
+        {children}
+      </CheckTodo>
+    );
+  };
   const copyFor = (text: string, filePath?: string | null, startLine?: number | null) => (
     <CopyPromptButton
       prompt={buildAgentPrompt(text, slideTitle, prUrl, filePath, startLine)}
@@ -190,12 +250,15 @@ function renderReviewChecks(
             const isClickable = isAnchorable(check, anchorable);
             return (
               <li key={i} className="review-checks-item">
-                <span
-                  className={isClickable ? clickableCheckClass : ''}
-                  onClick={isClickable ? () => onCheckClick(check) : undefined}
-                >
-                  {check.text}
-                </span>
+                {todoFor(
+                  check.text,
+                  <span
+                    className={isClickable ? clickableCheckClass : ''}
+                    onClick={isClickable ? () => onCheckClick(check) : undefined}
+                  >
+                    {check.text}
+                  </span>
+                )}
                 {copyFor(check.text, check.filePath, check.startLine)}
               </li>
             );
@@ -227,12 +290,15 @@ function renderReviewChecks(
           <ul className="slide-prose review-checks-list mt-1.5">
             {split.map((sentence, i) => (
               <li key={i} className="review-checks-item">
-                <span
-                  className={isClickable ? clickableCheckClass : ''}
-                  onClick={isClickable ? () => onCheckClick(check) : undefined}
-                >
-                  <Markdown className="review-focus-markdown">{sentence}</Markdown>
-                </span>
+                {todoFor(
+                  sentence,
+                  <span
+                    className={isClickable ? clickableCheckClass : ''}
+                    onClick={isClickable ? () => onCheckClick(check) : undefined}
+                  >
+                    <Markdown className="review-focus-markdown">{sentence}</Markdown>
+                  </span>
+                )}
                 {copyFor(sentence, check.filePath, check.startLine)}
               </li>
             ))}
@@ -247,12 +313,15 @@ function renderReviewChecks(
             <span className="editorial-label">What to check.</span>
           </p>
           <div className="slide-prose mt-1.5 flex items-start gap-2">
-            <span
-              className={isClickable ? clickableCheckClass : ''}
-              onClick={isClickable ? () => onCheckClick(check) : undefined}
-            >
-              <Markdown className="review-focus-markdown">{check.text}</Markdown>
-            </span>
+            {todoFor(
+              check.text,
+              <span
+                className={isClickable ? clickableCheckClass : ''}
+                onClick={isClickable ? () => onCheckClick(check) : undefined}
+              >
+                <Markdown className="review-focus-markdown">{check.text}</Markdown>
+              </span>
+            )}
             {copyFor(check.text, check.filePath, check.startLine)}
           </div>
         </>
@@ -262,12 +331,15 @@ function renderReviewChecks(
       <p className="slide-prose">
         <span className="editorial-label">What to check.</span>{' '}
         <span className="review-focus-content">
-          <span
-            className={isClickable ? clickableCheckClass : ''}
-            onClick={isClickable ? () => onCheckClick(check) : undefined}
-          >
-            {check.text}
-          </span>
+          {todoFor(
+            check.text,
+            <span
+              className={isClickable ? clickableCheckClass : ''}
+              onClick={isClickable ? () => onCheckClick(check) : undefined}
+            >
+              {check.text}
+            </span>
+          )}
         </span>
         {copyFor(check.text, check.filePath, check.startLine)}
       </p>
@@ -298,7 +370,7 @@ function renderReviewChecks(
           <ul className="slide-prose review-checks-list mt-1.5">
             {split.map((sentence, i) => (
               <li key={i} className="review-checks-item">
-                <Markdown className="review-focus-markdown">{sentence}</Markdown>
+                {todoFor(sentence, <Markdown className="review-focus-markdown">{sentence}</Markdown>)}
                 {copyFor(sentence)}
               </li>
             ))}
@@ -312,7 +384,7 @@ function renderReviewChecks(
           <span className="editorial-label">What to check.</span>
         </p>
         <div className="slide-prose mt-1.5 flex items-start gap-2">
-          <Markdown className="review-focus-markdown">{focus}</Markdown>
+          {todoFor(focus, <Markdown className="review-focus-markdown">{focus}</Markdown>)}
           {copyFor(focus)}
         </div>
       </>
@@ -321,7 +393,7 @@ function renderReviewChecks(
   return (
     <p className="slide-prose">
       <span className="editorial-label">What to check.</span>{' '}
-      <span className="review-focus-content">{focus}</span>
+      <span className="review-focus-content">{todoFor(focus, <>{focus}</>)}</span>
       {copyFor(focus)}
     </p>
   );
@@ -381,6 +453,8 @@ export function SlideView({
   slide,
   slideNumber,
   prUrl,
+  checkedChecks,
+  onToggleCheck,
   pendingComments,
   commentCallbacks,
   diffLayout,
@@ -533,7 +607,17 @@ export function SlideView({
       )}
 
       <div className="editorial-callout select-text">
-        {renderReviewChecks(slide.reviewChecks, slide.reviewFocus, anchorable, handleCheckClick, slide.title, prUrl)}
+        {renderReviewChecks(
+          slide.reviewChecks,
+          slide.reviewFocus,
+          anchorable,
+          handleCheckClick,
+          slide.id,
+          slide.title,
+          prUrl,
+          checkedChecks,
+          onToggleCheck,
+        )}
         {anchorMiss && (
           <p className="slide-meta mt-2" role="status" aria-live="polite">
             Line {anchorMiss.line} in <span className="font-mono">{anchorMiss.filePath}</span> isn't in this slide's

--- a/src/globals.css
+++ b/src/globals.css
@@ -498,6 +498,44 @@
   background: oklch(0.65 0.13 15 / 70%);
 }
 
+/* Per-check "I've verified this" checkbox, shown next to every
+   rendered "What to check" item so the reviewer can tick them off as
+   they go. Marks persist per {prUrl, headSha, slideId, checkHash} in
+   localStorage. Claret accent on the native input ties the control
+   to the brand focus colour without adding new chrome. */
+.check-todo {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.55rem;
+  cursor: pointer;
+}
+
+.check-todo-input {
+  accent-color: var(--ring);
+  width: 0.95rem;
+  height: 0.95rem;
+  flex-shrink: 0;
+  cursor: pointer;
+  /* Nudge the native box into optical alignment with text's
+     baseline row — checkboxes typically render slightly low. */
+  transform: translateY(0.1em);
+  margin: 0;
+}
+
+.check-todo-done {
+  text-decoration: line-through;
+  text-decoration-color: oklch(0.5 0.012 65 / 60%);
+  text-decoration-thickness: 1px;
+  color: var(--muted-foreground);
+  transition: color 120ms ease-out, text-decoration-color 120ms ease-out;
+}
+
+/* When a check is ticked inside a bulleted list, dim the bullet too
+   so the visual mirrors the completed state. */
+.review-checks-item:has(.check-todo-input:checked)::before {
+  opacity: 0.3;
+}
+
 /* Reused when a single packed check or a markdown-formatted
    reviewFocus is rendered as a block inside the callout. Tightens
    the default Markdown spacing so the block doesn't feel like an

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -54,6 +54,32 @@ function saveProgress(review: ReviewGuide, reviewed: Set<number>) {
   }
 }
 
+// Per-check "done" marks inside the "What to check" callout. Same
+// keying scheme as slide progress so one review's marks don't leak
+// into another review of the same PR. Each entry is
+// `${slideId}:${hash(check.text)}` — stable across re-renders and
+// robust to bullet-vs-inline layout choice.
+function checksKey(review: ReviewGuide): string {
+  return `gnosis-checks:${review.prUrl}:${review.headSha ?? 'unknown'}`;
+}
+
+function loadChecks(review: ReviewGuide): Set<string> {
+  try {
+    const stored = localStorage.getItem(checksKey(review));
+    return stored ? new Set(JSON.parse(stored) as string[]) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function saveChecks(review: ReviewGuide, checked: Set<string>) {
+  try {
+    localStorage.setItem(checksKey(review), JSON.stringify([...checked]));
+  } catch {
+    /* non-fatal */
+  }
+}
+
 export function ReviewPage({ review: initialReview, onBack, onReReview }: Props) {
   const [review, setReview] = useState(initialReview);
   const [currentSlide, setCurrentSlide] = useState(0);
@@ -77,6 +103,22 @@ export function ReviewPage({ review: initialReview, onBack, onReReview }: Props)
   // independently. Restored on mount so interrupted reviews resume
   // exactly where the user left off.
   const [reviewed, setReviewed] = useState<Set<number>>(() => loadProgress(initialReview));
+
+  // Per-check done marks (the "What to check" checkboxes). Same
+  // keying scheme as reviewed, but keyed by `slideId:hash(check.text)`.
+  const [checkedChecks, setCheckedChecks] = useState<Set<string>>(() => loadChecks(initialReview));
+  const toggleCheck = useCallback(
+    (key: string) => {
+      setCheckedChecks((prev) => {
+        const next = new Set(prev);
+        if (next.has(key)) next.delete(key);
+        else next.add(key);
+        saveChecks(review, next);
+        return next;
+      });
+    },
+    [review]
+  );
 
   // "Hide reviewed" toggle — when active, the TocRail collapses
   // reviewed entries and slide navigation skips them.
@@ -501,6 +543,8 @@ export function ReviewPage({ review: initialReview, onBack, onReReview }: Props)
               slideNumber={currentSlide}
               totalSlides={review.slides.length}
               prUrl={review.prUrl}
+              checkedChecks={checkedChecks}
+              onToggleCheck={toggleCheck}
               pendingComments={comments}
               commentCallbacks={commentCallbacks}
               diffLayout={diffLayout}


### PR DESCRIPTION
## What
Each item in the "What to check" callout now has a native checkbox. Tick as you verify; unchecked marks stay put across sessions.

## Persistence
- Outer key: \`gnosis-checks:\${prUrl}:\${headSha}\` (matches the existing "mark reviewed" slide-progress scope).
- Inner key per check: \`\${slideId}:\${hashText(check.text)}\`.
- Hash means ticks survive renderer changes — a check whose layout swings from inline → prose-split bullets → block keeps its checked state because it hashes from the same underlying text.

## Render sites covered
The checkbox renders in every branch of \`renderReviewChecks\`:
- Multi-item structured list
- Single packed check → prose-split bullets
- Single long check → Markdown block
- Single inline check
- \`reviewFocus\` prose-split
- \`reviewFocus\` block
- \`reviewFocus\` inline

## Visual
- Native \`<input type="checkbox">\` with \`accent-color: var(--ring)\` — brand claret on the tick without custom-drawing the control.
- Checked text gets a line-through + \`--muted-foreground\` so a skim of done vs not-done reads instantly.
- In the multi-item list, \`:has(.check-todo-input:checked)\` dims the bullet too.
- Keyboard/screen-reader-native — it's just an input inside a label.

## Files
- \`components/SlideView.tsx\` — \`hashText\` / \`checkKey\` / \`CheckTodo\`, wired through every \`renderReviewChecks\` branch
- \`src/pages/ReviewPage.tsx\` — \`checksKey\` / \`loadChecks\` / \`saveChecks\`, new \`checkedChecks\` state + \`toggleCheck\` callback, passed to \`SlideView\`
- \`src/globals.css\` — \`.check-todo\`, \`.check-todo-input\`, \`.check-todo-done\`, \`:has()\` bullet-dim

## Test plan
- [ ] Tick a check → line-through + muted style applied
- [ ] Navigate away and back → tick still there
- [ ] Restart the app → tick still there
- [ ] Re-generate the review for the same PR (new headSha) → new progress state (previous ticks don't leak)
- [ ] Inline single-sentence case: checkbox sits next to the sentence; ticking strikes the sentence
- [ ] Multi-bullet case: each bullet has its own checkbox; ticking one dims that bullet's marker
- [ ] prose-split case: each sentence has its own checkbox
- [ ] Screen reader: each checkbox announces as "Mark check done" / "Mark check not done"

🤖 Generated with [Claude Code](https://claude.com/claude-code)