### PR TITLE
feat: fold the PR repo's Claude Code conventions into reviews

### DIFF
--- a/components/OverviewSlide.tsx
+++ b/components/OverviewSlide.tsx
@@ -121,6 +121,7 @@ export function OverviewSlide({ review, prStatus, onNavigate }: Props) {
   const risk = safeConfigLookup(riskConfig, review.riskLevel, riskConfig.low);
   const [descOpen, setDescOpen] = useState(false);
   const [sourcesOpen, setSourcesOpen] = useState(false);
+  const [claudeCtxOpen, setClaudeCtxOpen] = useState(false);
   const [remainingOpen, setRemainingOpen] = useState(false);
 
   // Files that appear in changedFiles but not in any slide's
@@ -217,6 +218,62 @@ export function OverviewSlide({ review, prStatus, onNavigate }: Props) {
             )}
           </section>
         )}
+
+        {/* Project Claude context — the repo's CLAUDE.md / .claude/
+            that was folded into the review prompt. Shown as a quiet
+            disclosure so the reviewer can confirm what conventions
+            the AI was aware of. No external links — these files
+            belong to the PR repo, not the public web. */}
+        {review.projectClaudeContext && (() => {
+          const ctx = review.projectClaudeContext;
+          const parts: string[] = [];
+          if (ctx.projectInstructions) parts.push('CLAUDE.md');
+          if (ctx.commands.length) parts.push(`${ctx.commands.length} command${ctx.commands.length === 1 ? '' : 's'}`);
+          if (ctx.agents.length) parts.push(`${ctx.agents.length} agent${ctx.agents.length === 1 ? '' : 's'}`);
+          if (ctx.skills.length) parts.push(`${ctx.skills.length} skill${ctx.skills.length === 1 ? '' : 's'}`);
+          if (parts.length === 0) return null;
+          return (
+            <section className="animate-fade-in-up" style={{ animationDelay: '210ms' }}>
+              <button
+                onClick={() => setClaudeCtxOpen((v) => !v)}
+                className="slide-meta hover:text-foreground transition-colors flex items-center gap-1.5"
+              >
+                {claudeCtxOpen ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+                Project Claude context ({parts.join(' · ')})
+              </button>
+              {claudeCtxOpen && (
+                <ul className="mt-3 ml-4 flex flex-col gap-1.5 border-l border-border pl-4">
+                  {ctx.projectInstructions && (
+                    <li className="text-sm text-muted-foreground">
+                      <span className="text-foreground">CLAUDE.md</span>
+                      {ctx.projectInstructionsBytes
+                        ? ` — ${(ctx.projectInstructionsBytes / 1024).toFixed(1)} KB of project instructions`
+                        : ' — project instructions'}
+                    </li>
+                  )}
+                  {ctx.commands.map((c) => (
+                    <li key={`cmd-${c.name}`} className="text-sm text-muted-foreground">
+                      <span className="text-foreground font-mono">/{c.name}</span>
+                      {c.summary && ` — ${c.summary}`}
+                    </li>
+                  ))}
+                  {ctx.agents.map((a) => (
+                    <li key={`ag-${a.name}`} className="text-sm text-muted-foreground">
+                      <span className="text-foreground">agent: {a.name}</span>
+                      {a.summary && ` — ${a.summary}`}
+                    </li>
+                  ))}
+                  {ctx.skills.map((s) => (
+                    <li key={`sk-${s.name}`} className="text-sm text-muted-foreground">
+                      <span className="text-foreground">skill: {s.name}</span>
+                      {s.summary && ` — ${s.summary}`}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          );
+        })()}
 
         {/* Start reading — the explicit "click here to begin"
             affordance. The bottom nav also surfaces this as

--- a/components/OverviewSlide.tsx
+++ b/components/OverviewSlide.tsx
@@ -1,8 +1,88 @@
 import { useState } from 'react';
+import type { ReactNode } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { Markdown } from '@/components/Markdown';
 import { riskConfig, safeConfigLookup } from '@/lib/constants';
-import type { PrStatus, ReviewGuide } from '@/lib/types';
+import type { PrStatus, ProjectClaudeContext, ReviewGuide } from '@/lib/types';
+
+// Quiet disclosure used throughout the overview for PR description,
+// web sources, project conventions, and remaining-files — all share
+// the same mono title + chevron affordance and a left-rule content
+// frame. Extracted so adding a new section stays a one-liner and all
+// disclosures move together stylistically.
+function CollapsibleSection({
+  title,
+  delay,
+  className = '',
+  children,
+}: {
+  title: ReactNode;
+  delay?: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <section
+      className={`animate-fade-in-up ${className}`}
+      style={delay ? { animationDelay: delay } : undefined}
+    >
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="slide-meta hover:text-foreground transition-colors flex items-center gap-1.5"
+      >
+        {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        {title}
+      </button>
+      {open && children}
+    </section>
+  );
+}
+
+// CLAUDE.md / .claude/ conventions that were folded into the review
+// prompt. Shown so the reviewer can see what the AI was aware of —
+// no external links; these files belong to the PR repo, not the web.
+function ProjectClaudeContextSection({ ctx }: { ctx: ProjectClaudeContext }) {
+  const parts: string[] = [];
+  if (ctx.projectInstructions) parts.push('CLAUDE.md');
+  if (ctx.commands.length) parts.push(`${ctx.commands.length} command${ctx.commands.length === 1 ? '' : 's'}`);
+  if (ctx.agents.length) parts.push(`${ctx.agents.length} agent${ctx.agents.length === 1 ? '' : 's'}`);
+  if (ctx.skills.length) parts.push(`${ctx.skills.length} skill${ctx.skills.length === 1 ? '' : 's'}`);
+  if (parts.length === 0) return null;
+
+  return (
+    <CollapsibleSection title={`Project Claude context (${parts.join(' · ')})`} delay="210ms">
+      <ul className="mt-3 ml-4 flex flex-col gap-1.5 border-l border-border pl-4">
+        {ctx.projectInstructions && (
+          <li className="text-sm text-muted-foreground">
+            <span className="text-foreground">CLAUDE.md</span>
+            {ctx.projectInstructionsBytes
+              ? ` — ${(ctx.projectInstructionsBytes / 1024).toFixed(1)} KB of project instructions`
+              : ' — project instructions'}
+          </li>
+        )}
+        {ctx.commands.map((c) => (
+          <li key={`cmd-${c.name}`} className="text-sm text-muted-foreground">
+            <span className="text-foreground font-mono">/{c.name}</span>
+            {c.summary && ` — ${c.summary}`}
+          </li>
+        ))}
+        {ctx.agents.map((a) => (
+          <li key={`ag-${a.name}`} className="text-sm text-muted-foreground">
+            <span className="text-foreground">agent: {a.name}</span>
+            {a.summary && ` — ${a.summary}`}
+          </li>
+        ))}
+        {ctx.skills.map((s) => (
+          <li key={`sk-${s.name}`} className="text-sm text-muted-foreground">
+            <span className="text-foreground">skill: {s.name}</span>
+            {s.summary && ` — ${s.summary}`}
+          </li>
+        ))}
+      </ul>
+    </CollapsibleSection>
+  );
+}
 
 interface Props {
   review: ReviewGuide;
@@ -119,10 +199,6 @@ function StatusLine({ status }: { status: PrStatus | null }) {
 
 export function OverviewSlide({ review, prStatus, onNavigate }: Props) {
   const risk = safeConfigLookup(riskConfig, review.riskLevel, riskConfig.low);
-  const [descOpen, setDescOpen] = useState(false);
-  const [sourcesOpen, setSourcesOpen] = useState(false);
-  const [claudeCtxOpen, setClaudeCtxOpen] = useState(false);
-  const [remainingOpen, setRemainingOpen] = useState(false);
 
   // Files that appear in changedFiles but not in any slide's
   // affectedFiles. These are the "remaining changes" — files in the
@@ -173,107 +249,33 @@ export function OverviewSlide({ review, prStatus, onNavigate }: Props) {
           </p>
         </section>
 
-        {/* PR Description — collapsible inline disclosure. */}
         {review.prDescription && (
-          <section className="animate-fade-in-up" style={{ animationDelay: '120ms' }}>
-            <button
-              onClick={() => setDescOpen((v) => !v)}
-              className="slide-meta hover:text-foreground transition-colors flex items-center gap-1.5"
-            >
-              {descOpen ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              PR description
-            </button>
-            {descOpen && (
-              <div className="mt-3 ml-4 max-h-64 overflow-y-auto border-l border-border pl-4">
-                <Markdown className="text-sm text-muted-foreground leading-relaxed">{review.prDescription}</Markdown>
-              </div>
-            )}
-          </section>
+          <CollapsibleSection title="PR description" delay="120ms">
+            <div className="mt-3 ml-4 max-h-64 overflow-y-auto border-l border-border pl-4">
+              <Markdown className="text-sm text-muted-foreground leading-relaxed">{review.prDescription}</Markdown>
+            </div>
+          </CollapsibleSection>
         )}
 
-        {/* Web Sources — same pattern as PR description. */}
         {review.webSources && review.webSources.length > 0 && (
-          <section className="animate-fade-in-up" style={{ animationDelay: '180ms' }}>
-            <button
-              onClick={() => setSourcesOpen((v) => !v)}
-              className="slide-meta hover:text-foreground transition-colors flex items-center gap-1.5"
-            >
-              {sourcesOpen ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              Web sources ({review.webSources.length})
-            </button>
-            {sourcesOpen && (
-              <ul className="mt-3 ml-4 flex flex-col gap-1.5 border-l border-border pl-4">
-                {review.webSources.map((source, i) => (
-                  <li key={i}>
-                    <button
-                      onClick={() => window.electronAPI.openExternal(source.url)}
-                      className="text-sm text-[var(--ring)] hover:underline truncate max-w-full text-left"
-                      title={source.url}
-                    >
-                      {source.title || source.url}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </section>
+          <CollapsibleSection title={`Web sources (${review.webSources.length})`} delay="180ms">
+            <ul className="mt-3 ml-4 flex flex-col gap-1.5 border-l border-border pl-4">
+              {review.webSources.map((source, i) => (
+                <li key={i}>
+                  <button
+                    onClick={() => window.electronAPI.openExternal(source.url)}
+                    className="text-sm text-[var(--ring)] hover:underline truncate max-w-full text-left"
+                    title={source.url}
+                  >
+                    {source.title || source.url}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </CollapsibleSection>
         )}
 
-        {/* Project Claude context — the repo's CLAUDE.md / .claude/
-            that was folded into the review prompt. Shown as a quiet
-            disclosure so the reviewer can confirm what conventions
-            the AI was aware of. No external links — these files
-            belong to the PR repo, not the public web. */}
-        {review.projectClaudeContext && (() => {
-          const ctx = review.projectClaudeContext;
-          const parts: string[] = [];
-          if (ctx.projectInstructions) parts.push('CLAUDE.md');
-          if (ctx.commands.length) parts.push(`${ctx.commands.length} command${ctx.commands.length === 1 ? '' : 's'}`);
-          if (ctx.agents.length) parts.push(`${ctx.agents.length} agent${ctx.agents.length === 1 ? '' : 's'}`);
-          if (ctx.skills.length) parts.push(`${ctx.skills.length} skill${ctx.skills.length === 1 ? '' : 's'}`);
-          if (parts.length === 0) return null;
-          return (
-            <section className="animate-fade-in-up" style={{ animationDelay: '210ms' }}>
-              <button
-                onClick={() => setClaudeCtxOpen((v) => !v)}
-                className="slide-meta hover:text-foreground transition-colors flex items-center gap-1.5"
-              >
-                {claudeCtxOpen ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-                Project Claude context ({parts.join(' · ')})
-              </button>
-              {claudeCtxOpen && (
-                <ul className="mt-3 ml-4 flex flex-col gap-1.5 border-l border-border pl-4">
-                  {ctx.projectInstructions && (
-                    <li className="text-sm text-muted-foreground">
-                      <span className="text-foreground">CLAUDE.md</span>
-                      {ctx.projectInstructionsBytes
-                        ? ` — ${(ctx.projectInstructionsBytes / 1024).toFixed(1)} KB of project instructions`
-                        : ' — project instructions'}
-                    </li>
-                  )}
-                  {ctx.commands.map((c) => (
-                    <li key={`cmd-${c.name}`} className="text-sm text-muted-foreground">
-                      <span className="text-foreground font-mono">/{c.name}</span>
-                      {c.summary && ` — ${c.summary}`}
-                    </li>
-                  ))}
-                  {ctx.agents.map((a) => (
-                    <li key={`ag-${a.name}`} className="text-sm text-muted-foreground">
-                      <span className="text-foreground">agent: {a.name}</span>
-                      {a.summary && ` — ${a.summary}`}
-                    </li>
-                  ))}
-                  {ctx.skills.map((s) => (
-                    <li key={`sk-${s.name}`} className="text-sm text-muted-foreground">
-                      <span className="text-foreground">skill: {s.name}</span>
-                      {s.summary && ` — ${s.summary}`}
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </section>
-          );
-        })()}
+        {review.projectClaudeContext && <ProjectClaudeContextSection ctx={review.projectClaudeContext} />}
 
         {/* Start reading — the explicit "click here to begin"
             affordance. The bottom nav also surfaces this as
@@ -302,30 +304,22 @@ export function OverviewSlide({ review, prStatus, onNavigate }: Props) {
             distract, but visible enough that the reviewer knows
             they exist and can inspect them. Ensures 100% coverage. */}
         {remainingFiles.length > 0 && (
-          <section
-            className="animate-fade-in-up pt-6 mt-2 border-t border-border"
-            style={{ animationDelay: '300ms' }}
+          <CollapsibleSection
+            title={`${remainingFiles.length} ${remainingFiles.length === 1 ? 'file' : 'files'} not featured in the walkthrough`}
+            delay="300ms"
+            className="pt-6 mt-2 border-t border-border"
           >
-            <button
-              onClick={() => setRemainingOpen((v) => !v)}
-              className="slide-meta hover:text-foreground transition-colors flex items-center gap-1.5"
-            >
-              {remainingOpen ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              {remainingFiles.length} {remainingFiles.length === 1 ? 'file' : 'files'} not featured in the walkthrough
-            </button>
-            {remainingOpen && (
-              <ul className="mt-3 ml-4 flex flex-col gap-1 border-l border-border pl-4">
-                {remainingFiles.map((f) => (
-                  <li key={f.filename} className="slide-meta flex items-center gap-3">
-                    <span className="truncate">{f.filename}</span>
-                    <span className="shrink-0 opacity-60">
-                      +{f.additions} −{f.deletions}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </section>
+            <ul className="mt-3 ml-4 flex flex-col gap-1 border-l border-border pl-4">
+              {remainingFiles.map((f) => (
+                <li key={f.filename} className="slide-meta flex items-center gap-3">
+                  <span className="truncate">{f.filename}</span>
+                  <span className="shrink-0 opacity-60">
+                    +{f.additions} −{f.deletions}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </CollapsibleSection>
         )}
       </div>
     </div>

--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -142,6 +142,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
   const [maxPrsPerRepo, setMaxPrsPerRepo] = useState(10);
   const [parallelReview, setParallelReview] = useState(false);
   const [educationMode, setEducationMode] = useState(true);
+  const [claudeContext, setClaudeContext] = useState(true);
   const [analytics, setAnalytics] = useState(true);
   const [proactiveReviewOverrides, setProactiveReviewOverrides] = useState(false);
   const [proactiveProvider, setProactiveProvider] = useState<Provider>('claude');
@@ -169,6 +170,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
       setMaxPrsPerRepo(prefs.maxPrsPerRepo);
       setParallelReview(prefs.parallelReview);
       setEducationMode(prefs.educationMode);
+      setClaudeContext(prefs.claudeContext);
       setAnalytics(prefs.analytics);
       setProactiveReviewOverrides(prefs.proactiveReviewOverrides);
       setProactiveProvider(prefs.proactiveProvider);
@@ -303,6 +305,21 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
                   const next = !educationMode;
                   setEducationMode(next);
                   saveField({ educationMode: next });
+                }}
+              />
+            </SettingRow>
+
+            <SettingRow
+              label="Apply project's Claude conventions"
+              description="When reviewing a PR, read the repo's CLAUDE.md and .claude/ (commands, agents, skills) and feed them into the prompt so the review respects the team's Claude Code setup."
+            >
+              <Toggle
+                checked={claudeContext}
+                ariaLabel="Apply project's Claude conventions"
+                onChange={() => {
+                  const next = !claudeContext;
+                  setClaudeContext(next);
+                  saveField({ claudeContext: next });
                 }}
               />
             </SettingRow>

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -140,6 +140,14 @@ const CONCISE_SUFFIX = `
 
 IMPORTANT: Be concise. Keep narrative and reviewFocus under 2 sentences each. Omit contextSnippets entirely (use empty arrays). Limit diffHunkIds to the 5 most important hunk IDs per slide. Return only raw JSON starting with { and ending with }.`;
 
+const CLAUDE_CONTEXT_DIRECTIVE = `
+PROJECT CONVENTIONS — ACTIVE
+This repo ships its own Claude Code conventions under <project_claude_context>. Apply them:
+- Treat <project_instructions> (the repo's CLAUDE.md) as authoritative project norms. Flag diff changes that violate them.
+- If <custom_commands>, <custom_agents>, or <custom_skills> exist, they reveal domain workflows the team has built — weigh risks in light of those workflows (e.g. a repo with a "security-audit" skill probably cares about auth changes more than average).
+- Do NOT invent rules. Only cite conventions that are literally present in <project_claude_context>.
+`;
+
 const EDUCATION_DIRECTIVE = `
 EDUCATION MODE — ACTIVE
 The reviewer may not be familiar with every concept the code assumes knowledge of. Where a slide's narrative references a named pattern, domain concept, or non-obvious library primitive, include a short entry in "educationNotes" for that slide explaining it.
@@ -206,6 +214,9 @@ export interface GenerateReviewGuideOptions {
   reviewSuggestions?: boolean;
   webResearch?: boolean;
   educationMode?: boolean;
+  /** Set when the contextPackage already includes a `<project_claude_context>` block.
+   *  Only effect is appending the PROJECT CONVENTIONS directive so the model applies it. */
+  hasClaudeContext?: boolean;
   mcpConfigPath?: string;
   allowedTools?: string[];
   onChunk?: (chunk: string, isThinking: boolean) => void;
@@ -225,6 +236,7 @@ export async function generateReviewGuide(opts: GenerateReviewGuideOptions): Pro
     reviewSuggestions = true,
     webResearch = false,
     educationMode = false,
+    hasClaudeContext = false,
     mcpConfigPath,
     allowedTools,
     onChunk,
@@ -256,10 +268,11 @@ export async function generateReviewGuide(opts: GenerateReviewGuideOptions): Pro
 
     const webResearchDirective = webResearch ? WEB_RESEARCH_DIRECTIVE : '';
     const educationDirective = educationMode ? EDUCATION_DIRECTIVE : '';
+    const claudeContextDirective = hasClaudeContext ? CLAUDE_CONTEXT_DIRECTIVE : '';
 
     // Signal boost is always on — deprioritize formatting and
     // import-only changes, emphasize design decisions.
-    const baseSystem = `${FOCUS_DIRECTIVE}\n${webResearchDirective}${educationDirective}${SYSTEM_PROMPT}${reviewSuggestionsDirective}`;
+    const baseSystem = `${FOCUS_DIRECTIVE}\n${webResearchDirective}${educationDirective}${claudeContextDirective}${SYSTEM_PROMPT}${reviewSuggestionsDirective}`;
 
     const system = customInstructions
       ? `${baseSystem}\n\nIMPORTANT — CUSTOM REVIEWER INSTRUCTIONS:\nThe reviewer has provided the following instructions. These take precedence over the default writing style and tone guidelines above. Adapt your narrative, reviewFocus, summary, and all prose fields accordingly.\n\n<instructions>\n${customInstructions}\n</instructions>`
@@ -485,6 +498,7 @@ export interface GenerateSlideOptions {
   reviewSuggestions?: boolean;
   thinking?: boolean;
   educationMode?: boolean;
+  hasClaudeContext?: boolean;
   onChunk?: (chunk: string, isThinking: boolean) => void;
   signal?: AbortSignal;
 }
@@ -498,6 +512,7 @@ export async function generateSlide(opts: GenerateSlideOptions): Promise<WriterS
     reviewSuggestions = true,
     thinking = false,
     educationMode = false,
+    hasClaudeContext = false,
     onChunk,
     signal,
   } = opts;
@@ -507,8 +522,9 @@ export async function generateSlide(opts: GenerateSlideOptions): Promise<WriterS
     ? ''
     : '\nSet "reviewFocus" to null. Do not generate review focus content.\n';
   const educationDirective = educationMode ? EDUCATION_DIRECTIVE : '';
+  const claudeContextDirective = hasClaudeContext ? CLAUDE_CONTEXT_DIRECTIVE : '';
 
-  let system = WRITER_SYSTEM + reviewSuggestionsDirective + educationDirective;
+  let system = WRITER_SYSTEM + reviewSuggestionsDirective + educationDirective + claudeContextDirective;
   if (instructions?.trim()) {
     system += `\n\nCUSTOM REVIEWER INSTRUCTIONS (take precedence over style guidelines):\n${instructions.trim()}`;
   }

--- a/lib/context-builder.ts
+++ b/lib/context-builder.ts
@@ -146,14 +146,6 @@ ${expandedDiff}
     neighborStr += '</neighbor_files>';
   }
 
-  // Step 1b: Drop the Claude project-context block. Helpful but not
-  // load-bearing — the diff and file contents carry the actual
-  // review signal.
-  if (totalSize() > MAX_CHARS && claudeContextSection) {
-    console.warn('[context-builder] Context too large — dropping project Claude context');
-    claudeContextSection = '';
-  }
-
   // Step 2: Truncate file contents to 200 lines each
   if (totalSize() > MAX_CHARS) {
     console.warn('[context-builder] Context too large — truncating file contents to 200 lines each');
@@ -174,6 +166,14 @@ ${expandedDiff}
   if (totalSize() > MAX_CHARS) {
     console.warn('[context-builder] Still too large — dropping neighbor files');
     neighborStr = '<neighbor_files>\n<!-- omitted: context budget exceeded -->\n</neighbor_files>';
+  }
+
+  // Step 3b: Drop the Claude project-context block. Small but not
+  // load-bearing vs. the diff and file contents carrying the actual
+  // review signal.
+  if (totalSize() > MAX_CHARS && claudeContextSection) {
+    console.warn('[context-builder] Still too large — dropping project Claude context');
+    claudeContextSection = '';
   }
 
   // Step 4: Drop file contents entirely (keep only the diff)

--- a/lib/context-builder.ts
+++ b/lib/context-builder.ts
@@ -1,4 +1,4 @@
-import type { PrMetadata, ChangedFile, TopicPlan } from './types';
+import type { PrMetadata, ChangedFile, ProjectClaudeContext, TopicPlan } from './types';
 import type { IndexedHunk } from './diff-parse';
 
 const CHARS_PER_TOKEN = 4;
@@ -12,6 +12,37 @@ function truncateFileContent(content: string, maxLines: number): string {
   return lines.slice(0, maxLines).join('\n') + `\n... [truncated after ${maxLines} lines]`;
 }
 
+// Render the Claude-conventions block for the prompt. Returns empty
+// string when there's nothing to include — callers can concatenate
+// unconditionally. Omits inner tags with no content so the prompt
+// isn't cluttered by empty envelopes.
+function renderClaudeContextSection(ctx: ProjectClaudeContext | null | undefined): string {
+  if (!ctx) return '';
+  const parts: string[] = [];
+  if (ctx.projectInstructions) {
+    parts.push(`<project_instructions source="CLAUDE.md">\n${ctx.projectInstructions}\n</project_instructions>`);
+  }
+  if (ctx.commands.length > 0) {
+    parts.push(
+      '<custom_commands>\n' +
+        ctx.commands.map((c) => `- /${c.name} — ${c.summary}`).join('\n') +
+        '\n</custom_commands>'
+    );
+  }
+  if (ctx.agents.length > 0) {
+    parts.push(
+      '<custom_agents>\n' + ctx.agents.map((a) => `- ${a.name} — ${a.summary}`).join('\n') + '\n</custom_agents>'
+    );
+  }
+  if (ctx.skills.length > 0) {
+    parts.push(
+      '<custom_skills>\n' + ctx.skills.map((s) => `- ${s.name} — ${s.summary}`).join('\n') + '\n</custom_skills>'
+    );
+  }
+  if (parts.length === 0) return '';
+  return '<project_claude_context>\n' + parts.join('\n\n') + '\n</project_claude_context>';
+}
+
 export function buildContextPackage(
   prData: PrMetadata,
   expandedDiff: string,
@@ -20,7 +51,8 @@ export function buildContextPackage(
   headFileContents: Record<string, string>,
   neighborFiles: Record<string, string>,
   hunkIndex: string,
-  excludedFilesSummary?: string
+  excludedFilesSummary?: string,
+  claudeContext?: ProjectClaudeContext | null
 ): string {
   const totalAdditions = changedFiles.reduce((s, f) => s + f.additions, 0);
   const totalDeletions = changedFiles.reduce((s, f) => s + f.deletions, 0);
@@ -32,6 +64,8 @@ Description: ${prData.description || '(no description)'}
 Base branch: ${prData.baseBranch}
 Files changed: ${changedFiles.length} | Lines added: ${totalAdditions} | Lines deleted: ${totalDeletions}
 </pr_metadata>`;
+
+  let claudeContextSection = renderClaudeContextSection(claudeContext);
 
   const diffSection = `<full_diff>
 ${expandedDiff}
@@ -70,6 +104,7 @@ ${expandedDiff}
   function totalSize(): number {
     return (
       metaSection.length +
+      (claudeContextSection ? claudeContextSection.length + 4 : 0) +
       excludedStr.length +
       4 +
       diffStr.length +
@@ -109,6 +144,14 @@ ${expandedDiff}
       neighborStr += `  <file path="${p}" relationship="imported by changed files">\n${content}\n  </file>\n`;
     }
     neighborStr += '</neighbor_files>';
+  }
+
+  // Step 1b: Drop the Claude project-context block. Helpful but not
+  // load-bearing — the diff and file contents carry the actual
+  // review signal.
+  if (totalSize() > MAX_CHARS && claudeContextSection) {
+    console.warn('[context-builder] Context too large — dropping project Claude context');
+    claudeContextSection = '';
   }
 
   // Step 2: Truncate file contents to 200 lines each
@@ -159,6 +202,7 @@ ${expandedDiff}
 
   const finalPackage =
     metaSection +
+    (claudeContextSection ? '\n\n' + claudeContextSection : '') +
     (excludedStr ? '\n\n' + excludedStr : '') +
     '\n\n' +
     diffStr +
@@ -190,6 +234,7 @@ export function buildPlannerContext(
   changedFiles: ChangedFile[],
   hunkIndex: string,
   excludedFilesSummary?: string,
+  claudeContext?: ProjectClaudeContext | null,
 ): string {
   const totalAdditions = changedFiles.reduce((s, f) => s + f.additions, 0);
   const totalDeletions = changedFiles.reduce((s, f) => s + f.deletions, 0);
@@ -202,6 +247,8 @@ Base branch: ${prData.baseBranch}
 Files changed: ${changedFiles.length} | Lines added: ${totalAdditions} | Lines deleted: ${totalDeletions}
 </pr_metadata>`;
 
+  const claudeSection = renderClaudeContextSection(claudeContext);
+  if (claudeSection) ctx += '\n\n' + claudeSection;
   if (excludedFilesSummary) ctx += '\n\n' + excludedFilesSummary;
   ctx += '\n\n' + hunkIndex;
 
@@ -222,6 +269,7 @@ export function buildTopicContext(
   prDescription: string,
   storyArc: string,
   allTopics: TopicPlan[],
+  claudeContext?: ProjectClaudeContext | null,
 ): string {
   const relevantHunks = topic.hunkIds
     .map((id) => hunkMap.get(id))
@@ -237,11 +285,12 @@ export function buildTopicContext(
     .map((t) => `- "${t.title}" (${t.slideType}): ${t.narrativeBrief}`)
     .join('\n');
 
+  const claudeSection = renderClaudeContextSection(claudeContext);
   let ctx = `<story_arc>${storyArc}</story_arc>
 
 <narrative_brief>${topic.narrativeBrief}</narrative_brief>
 
-${depBriefs ? `<prior_topics>\nThis slide builds on:\n${depBriefs}\n</prior_topics>\n\n` : ''}<topic>
+${claudeSection ? claudeSection + '\n\n' : ''}${depBriefs ? `<prior_topics>\nThis slide builds on:\n${depBriefs}\n</prior_topics>\n\n` : ''}<topic>
 Title: ${topic.title}
 Type: ${topic.slideType}
 Importance: ${topic.importance}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,6 +1,16 @@
 import { Octokit } from '@octokit/rest';
 import { getProvider } from './provider';
-import type { ChangedFile, CiCheck, FileMetadata, PrMetadata, PrSearchResult, Provider, RepoSearchResult, ReviewSummary } from './types';
+import type {
+  ChangedFile,
+  CiCheck,
+  FileMetadata,
+  PrMetadata,
+  PrSearchResult,
+  ProjectClaudeContext,
+  Provider,
+  RepoSearchResult,
+  ReviewSummary,
+} from './types';
 
 export function parsePrUrl(url: string): { owner: string; repo: string; pullNumber: number } {
   const match = url.match(/github\.com\/([^/]+)\/([^/]+)\/pulls?\/(\d+)/);
@@ -580,4 +590,135 @@ export async function getFileMetadata(
   }
 
   return metadata;
+}
+
+// ── Claude Code project conventions ─────────────────────────────
+
+const CLAUDE_MD_MAX_CHARS = 8 * 1024;
+const CLAUDE_ENTRY_SUMMARY_CHARS = 240;
+
+async function listDirMarkdown(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  path: string,
+  ref: string
+): Promise<string[]> {
+  try {
+    const { data } = await octokit.repos.getContent({ owner, repo, path, ref });
+    if (!Array.isArray(data)) return [];
+    return data.filter((e) => e.type === 'file' && e.name.endsWith('.md')).map((e) => e.path);
+  } catch {
+    return [];
+  }
+}
+
+async function listDirSubdirs(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  path: string,
+  ref: string
+): Promise<string[]> {
+  try {
+    const { data } = await octokit.repos.getContent({ owner, repo, path, ref });
+    if (!Array.isArray(data)) return [];
+    return data.filter((e) => e.type === 'dir').map((e) => e.path);
+  } catch {
+    return [];
+  }
+}
+
+// Extract a short "what this does" summary from a markdown agent /
+// command file. Prefers a front-matter `description:` field, then the
+// first non-empty paragraph of body prose. Hard-truncated so a single
+// verbose file can't eat the context budget.
+function summariseClaudeEntry(content: string): string {
+  const fmMatch = /^---\n([\s\S]*?)\n---\n?/.exec(content);
+  let body = content;
+  if (fmMatch) {
+    body = content.slice(fmMatch[0].length);
+    const descMatch = /^description:\s*(.+)$/m.exec(fmMatch[1]);
+    if (descMatch) {
+      return descMatch[1].trim().slice(0, CLAUDE_ENTRY_SUMMARY_CHARS);
+    }
+  }
+  const firstPara = body
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .find((p) => p.length > 0 && !p.startsWith('#'));
+  return (firstPara ?? body.trim()).replace(/\s+/g, ' ').slice(0, CLAUDE_ENTRY_SUMMARY_CHARS);
+}
+
+function entryName(path: string): string {
+  const base = path.split('/').pop() ?? path;
+  return base.replace(/\.md$/, '');
+}
+
+async function fetchSummarisedEntries(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  paths: string[],
+  ref: string
+): Promise<{ name: string; summary: string }[]> {
+  const results: { name: string; summary: string }[] = [];
+  const concurrency = 5;
+  for (let i = 0; i < paths.length; i += concurrency) {
+    const batch = paths.slice(i, i + concurrency);
+    await Promise.all(
+      batch.map(async (p) => {
+        const content = await getFileContent(octokit, owner, repo, p, ref);
+        if (content) results.push({ name: entryName(p), summary: summariseClaudeEntry(content) });
+      })
+    );
+  }
+  results.sort((a, b) => a.name.localeCompare(b.name));
+  return results;
+}
+
+// Probe the PR repo for Claude-Code conventions at the given ref.
+// Returns `null` when nothing is found so callers can skip the
+// prompt/UI surface cleanly. All errors are swallowed — a missing
+// `.claude/` directory or a 403 just means "no conventions here",
+// never a generation failure.
+export async function getProjectClaudeContext(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  ref: string
+): Promise<ProjectClaudeContext | null> {
+  const [claudeMdRaw, commandPaths, agentPaths, skillDirs] = await Promise.all([
+    getFileContent(octokit, owner, repo, 'CLAUDE.md', ref),
+    listDirMarkdown(octokit, owner, repo, '.claude/commands', ref),
+    listDirMarkdown(octokit, owner, repo, '.claude/agents', ref),
+    listDirSubdirs(octokit, owner, repo, '.claude/skills', ref),
+  ]);
+
+  const hasAny = !!claudeMdRaw || commandPaths.length > 0 || agentPaths.length > 0 || skillDirs.length > 0;
+  if (!hasAny) return null;
+
+  let projectInstructions: string | null = null;
+  let projectInstructionsBytes: number | undefined;
+  if (claudeMdRaw) {
+    projectInstructionsBytes = Buffer.byteLength(claudeMdRaw, 'utf-8');
+    projectInstructions =
+      claudeMdRaw.length > CLAUDE_MD_MAX_CHARS
+        ? claudeMdRaw.slice(0, CLAUDE_MD_MAX_CHARS) + `\n\n… [truncated, original ${projectInstructionsBytes} bytes]`
+        : claudeMdRaw;
+  }
+
+  const [commands, agents, skills] = await Promise.all([
+    fetchSummarisedEntries(octokit, owner, repo, commandPaths, ref),
+    fetchSummarisedEntries(octokit, owner, repo, agentPaths, ref),
+    fetchSummarisedEntries(
+      octokit,
+      owner,
+      repo,
+      skillDirs.map((d) => `${d}/SKILL.md`),
+      ref
+    ),
+  ]);
+
+  return { projectInstructions, projectInstructionsBytes, commands, agents, skills };
 }

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -596,43 +596,39 @@ export async function getFileMetadata(
 
 const CLAUDE_MD_MAX_CHARS = 8 * 1024;
 const CLAUDE_ENTRY_SUMMARY_CHARS = 240;
+const CLAUDE_PATHS = {
+  md: 'CLAUDE.md',
+  root: '.claude',
+  commands: 'commands',
+  agents: 'agents',
+  skills: 'skills',
+} as const;
 
-async function listDirMarkdown(
+type DirEntry = { type: string; name: string; path: string };
+
+async function listDirEntries(
   octokit: Octokit,
   owner: string,
   repo: string,
   path: string,
-  ref: string
+  ref: string,
+  predicate: (entry: DirEntry) => boolean
 ): Promise<string[]> {
   try {
     const { data } = await octokit.repos.getContent({ owner, repo, path, ref });
     if (!Array.isArray(data)) return [];
-    return data.filter((e) => e.type === 'file' && e.name.endsWith('.md')).map((e) => e.path);
+    return data.filter(predicate).map((e) => e.path);
   } catch {
     return [];
   }
 }
 
-async function listDirSubdirs(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  path: string,
-  ref: string
-): Promise<string[]> {
-  try {
-    const { data } = await octokit.repos.getContent({ owner, repo, path, ref });
-    if (!Array.isArray(data)) return [];
-    return data.filter((e) => e.type === 'dir').map((e) => e.path);
-  } catch {
-    return [];
-  }
-}
+const isMarkdown = (e: DirEntry) => e.type === 'file' && e.name.endsWith('.md');
+const isDir = (e: DirEntry) => e.type === 'dir';
 
-// Extract a short "what this does" summary from a markdown agent /
-// command file. Prefers a front-matter `description:` field, then the
-// first non-empty paragraph of body prose. Hard-truncated so a single
-// verbose file can't eat the context budget.
+// Prefers a front-matter `description:` field, then the first
+// non-empty paragraph. Hard-truncated so a verbose file can't eat
+// the context budget.
 function summariseClaudeEntry(content: string): string {
   const fmMatch = /^---\n([\s\S]*?)\n---\n?/.exec(content);
   let body = content;
@@ -655,21 +651,23 @@ function entryName(path: string): string {
   return base.replace(/\.md$/, '');
 }
 
-// Decide whether a .claude/ command/agent/skill is worth including
-// in the review prompt. Whitelist by positive signal — review
-// relevance, code quality, conventions, security, testing, design
-// systems, refactor tools. Entries that only teach how to use a
-// dev-environment tool (install this, configure that MCP, set an
-// API key) add noise without helping the reviewer.
-const CLAUDE_REVIEW_POSITIVE =
-  /\b(review|audit|lint|security|accessib|convention|coding\s*style|style\s*guide|architecture|refactor|critique|invariant|contract|type\s*safety|quality|design\s*(system|pattern|principle|quality)|correctness|harden|simplify|polish|distill|normalize|responsive|a11y|performance|optim|vulnerab|best\s*practice|anti[- ]?pattern|testing|test\s*strategy|naming\s*convention|frontend|ui\s+(design|component)|visual|typograph)\b/;
-
+// Whitelist of review-signal keywords. Expressed as an array so
+// adding / removing a term doesn't risk breaking regex escaping or
+// accidental alternation boundaries.
+const CLAUDE_REVIEW_KEYWORDS = [
+  'review', 'audit', 'lint', 'security', 'accessib', 'convention', 'coding\\s*style',
+  'style\\s*guide', 'architecture', 'refactor', 'critique', 'invariant', 'contract',
+  'type\\s*safety', 'quality', 'design\\s*(system|pattern|principle|quality)', 'correctness',
+  'harden', 'simplify', 'polish', 'distill', 'normalize', 'responsive', 'a11y', 'performance',
+  'optim', 'vulnerab', 'best\\s*practice', 'anti[- ]?pattern', 'testing', 'test\\s*strategy',
+  'naming\\s*convention', 'frontend', 'ui\\s+(design|component)', 'visual', 'typograph',
+];
+const CLAUDE_REVIEW_POSITIVE = new RegExp(`\\b(${CLAUDE_REVIEW_KEYWORDS.join('|')})\\b`);
 const CLAUDE_REVIEW_HARD_NEGATIVE = /\bmcp\b|\bapi[- ]?key\b/;
 
 function isReviewRelevantClaudeEntry(name: string, content: string): boolean {
-  // Only look at name + the first chunk of content — summaries are
-  // usually up top (front matter / first paragraph) and a 20 KB body
-  // dragging in a passing positive match isn't a good signal.
+  // Scan name + first 2 KB only — summaries are up top, and a pass
+  // match buried 20 KB into a body isn't a trustworthy signal.
   const lower = (name + ' ' + content.slice(0, 2000)).toLowerCase();
   if (CLAUDE_REVIEW_HARD_NEGATIVE.test(lower)) return false;
   return CLAUDE_REVIEW_POSITIVE.test(lower);
@@ -706,24 +704,45 @@ async function fetchSummarisedEntries(
 }
 
 // Probe the PR repo for Claude-Code conventions at the given ref.
-// Returns `null` when nothing is found so callers can skip the
-// prompt/UI surface cleanly. All errors are swallowed — a missing
-// `.claude/` directory or a 403 just means "no conventions here",
-// never a generation failure.
+// Returns `null` when nothing is found. All errors swallow to null
+// so a missing `.claude/` or a 403 never fails the review.
 export async function getProjectClaudeContext(
   octokit: Octokit,
   owner: string,
   repo: string,
   ref: string
 ): Promise<ProjectClaudeContext | null> {
-  const [claudeMdRaw, commandPaths, agentPaths, skillDirs] = await Promise.all([
-    getFileContent(octokit, owner, repo, 'CLAUDE.md', ref),
-    listDirMarkdown(octokit, owner, repo, '.claude/commands', ref),
-    listDirMarkdown(octokit, owner, repo, '.claude/agents', ref),
-    listDirSubdirs(octokit, owner, repo, '.claude/skills', ref),
+  // First pass: CLAUDE.md + one listing of `.claude/` itself. Skips
+  // the three subdir requests on repos that have no Claude setup
+  // (the common case in public repos).
+  const [claudeMdRaw, claudeRootEntries] = await Promise.all([
+    getFileContent(octokit, owner, repo, CLAUDE_PATHS.md, ref),
+    listDirEntries(octokit, owner, repo, CLAUDE_PATHS.root, ref, isDir),
   ]);
 
-  const hasAny = !!claudeMdRaw || commandPaths.length > 0 || agentPaths.length > 0 || skillDirs.length > 0;
+  const hasRoot = claudeRootEntries.some((p) => p.endsWith(`/${CLAUDE_PATHS.commands}`)
+    || p.endsWith(`/${CLAUDE_PATHS.agents}`)
+    || p.endsWith(`/${CLAUDE_PATHS.skills}`));
+
+  // Second pass: fetch the subdir listings, but only for ones that
+  // actually exist in the root listing.
+  const hasCommands = claudeRootEntries.some((p) => p.endsWith(`/${CLAUDE_PATHS.commands}`));
+  const hasAgents = claudeRootEntries.some((p) => p.endsWith(`/${CLAUDE_PATHS.agents}`));
+  const hasSkills = claudeRootEntries.some((p) => p.endsWith(`/${CLAUDE_PATHS.skills}`));
+
+  const [commandPaths, agentPaths, skillDirs] = await Promise.all([
+    hasCommands
+      ? listDirEntries(octokit, owner, repo, `${CLAUDE_PATHS.root}/${CLAUDE_PATHS.commands}`, ref, isMarkdown)
+      : Promise.resolve<string[]>([]),
+    hasAgents
+      ? listDirEntries(octokit, owner, repo, `${CLAUDE_PATHS.root}/${CLAUDE_PATHS.agents}`, ref, isMarkdown)
+      : Promise.resolve<string[]>([]),
+    hasSkills
+      ? listDirEntries(octokit, owner, repo, `${CLAUDE_PATHS.root}/${CLAUDE_PATHS.skills}`, ref, isDir)
+      : Promise.resolve<string[]>([]),
+  ]);
+
+  const hasAny = !!claudeMdRaw || hasRoot;
   if (!hasAny) return null;
 
   let projectInstructions: string | null = null;

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -655,26 +655,54 @@ function entryName(path: string): string {
   return base.replace(/\.md$/, '');
 }
 
+// Decide whether a .claude/ command/agent/skill is worth including
+// in the review prompt. Whitelist by positive signal — review
+// relevance, code quality, conventions, security, testing, design
+// systems, refactor tools. Entries that only teach how to use a
+// dev-environment tool (install this, configure that MCP, set an
+// API key) add noise without helping the reviewer.
+const CLAUDE_REVIEW_POSITIVE =
+  /\b(review|audit|lint|security|accessib|convention|coding\s*style|style\s*guide|architecture|refactor|critique|invariant|contract|type\s*safety|quality|design\s*(system|pattern|principle|quality)|correctness|harden|simplify|polish|distill|normalize|responsive|a11y|performance|optim|vulnerab|best\s*practice|anti[- ]?pattern|testing|test\s*strategy|naming\s*convention|frontend|ui\s+(design|component)|visual|typograph)\b/;
+
+const CLAUDE_REVIEW_HARD_NEGATIVE = /\bmcp\b|\bapi[- ]?key\b/;
+
+function isReviewRelevantClaudeEntry(name: string, content: string): boolean {
+  // Only look at name + the first chunk of content — summaries are
+  // usually up top (front matter / first paragraph) and a 20 KB body
+  // dragging in a passing positive match isn't a good signal.
+  const lower = (name + ' ' + content.slice(0, 2000)).toLowerCase();
+  if (CLAUDE_REVIEW_HARD_NEGATIVE.test(lower)) return false;
+  return CLAUDE_REVIEW_POSITIVE.test(lower);
+}
+
 async function fetchSummarisedEntries(
   octokit: Octokit,
   owner: string,
   repo: string,
   paths: string[],
-  ref: string
-): Promise<{ name: string; summary: string }[]> {
-  const results: { name: string; summary: string }[] = [];
+  ref: string,
+  filter: (name: string, content: string) => boolean = () => true
+): Promise<{ included: { name: string; summary: string }[]; droppedCount: number }> {
+  const included: { name: string; summary: string }[] = [];
+  let droppedCount = 0;
   const concurrency = 5;
   for (let i = 0; i < paths.length; i += concurrency) {
     const batch = paths.slice(i, i + concurrency);
     await Promise.all(
       batch.map(async (p) => {
         const content = await getFileContent(octokit, owner, repo, p, ref);
-        if (content) results.push({ name: entryName(p), summary: summariseClaudeEntry(content) });
+        if (!content) return;
+        const name = entryName(p);
+        if (!filter(name, content)) {
+          droppedCount += 1;
+          return;
+        }
+        included.push({ name, summary: summariseClaudeEntry(content) });
       })
     );
   }
-  results.sort((a, b) => a.name.localeCompare(b.name));
-  return results;
+  included.sort((a, b) => a.name.localeCompare(b.name));
+  return { included, droppedCount };
 }
 
 // Probe the PR repo for Claude-Code conventions at the given ref.
@@ -708,17 +736,41 @@ export async function getProjectClaudeContext(
         : claudeMdRaw;
   }
 
-  const [commands, agents, skills] = await Promise.all([
-    fetchSummarisedEntries(octokit, owner, repo, commandPaths, ref),
-    fetchSummarisedEntries(octokit, owner, repo, agentPaths, ref),
+  const [cmdResult, agentResult, skillResult] = await Promise.all([
+    fetchSummarisedEntries(octokit, owner, repo, commandPaths, ref, isReviewRelevantClaudeEntry),
+    fetchSummarisedEntries(octokit, owner, repo, agentPaths, ref, isReviewRelevantClaudeEntry),
     fetchSummarisedEntries(
       octokit,
       owner,
       repo,
       skillDirs.map((d) => `${d}/SKILL.md`),
-      ref
+      ref,
+      isReviewRelevantClaudeEntry
     ),
   ]);
 
-  return { projectInstructions, projectInstructionsBytes, commands, agents, skills };
+  const totalDropped = cmdResult.droppedCount + agentResult.droppedCount + skillResult.droppedCount;
+  if (totalDropped > 0) {
+    console.log(
+      `[claude-context] Filtered out ${totalDropped} non-review entries (commands: ${cmdResult.droppedCount}, agents: ${agentResult.droppedCount}, skills: ${skillResult.droppedCount})`
+    );
+  }
+
+  // If post-filter nothing of substance remains (no CLAUDE.md and
+  // every command/agent/skill got dropped as non-review), drop the
+  // whole context so the UI doesn't render an empty disclosure.
+  const postFilterHasAny =
+    !!projectInstructions ||
+    cmdResult.included.length > 0 ||
+    agentResult.included.length > 0 ||
+    skillResult.included.length > 0;
+  if (!postFilterHasAny) return null;
+
+  return {
+    projectInstructions,
+    projectInstructionsBytes,
+    commands: cmdResult.included,
+    agents: agentResult.included,
+    skills: skillResult.included,
+  };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -77,6 +77,19 @@ export interface WebSource {
   title: string;
 }
 
+// Claude Code conventions discovered in the target repo — fed into
+// the review prompt and surfaced on the overview slide so the user
+// knows what the AI saw.
+export interface ProjectClaudeContext {
+  /** Full CLAUDE.md contents, truncated at a hard cap. */
+  projectInstructions: string | null;
+  /** CLAUDE.md size in bytes before any truncation — shown in the UI. */
+  projectInstructionsBytes?: number;
+  commands: { name: string; summary: string }[];
+  agents: { name: string; summary: string }[];
+  skills: { name: string; summary: string }[];
+}
+
 export interface AIReviewGuide {
   prTitle: string;
   prDescription: string;
@@ -148,6 +161,7 @@ export interface ReviewGuide {
   slides: Slide[];
   headSha?: string;
   webSources?: WebSource[];
+  projectClaudeContext?: ProjectClaudeContext;
   // Full list of changed files with metadata (age, churn). Used by
   // the Remaining Changes section (files not in any slide) and by
   // file age/churn badges on diff headers.
@@ -266,6 +280,7 @@ export interface Preferences {
   proactiveModel: ModelId;
   proactiveThinking: boolean;
   educationMode: boolean;
+  claudeContext: boolean;
 }
 
 export interface SendSlideChatRequest {
@@ -293,6 +308,7 @@ export interface GenerateReviewRequest {
   reviewSuggestions?: boolean;
   webResearch?: boolean;
   educationMode?: boolean;
+  claudeContext?: boolean;
   excludedFiles?: string[];
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import {
   getFileContent,
   getFileMetadata,
   getNeighborFiles,
+  getProjectClaudeContext,
   searchPullRequests,
   searchRepos,
   listRepoPullRequests,
@@ -503,6 +504,7 @@ async function triggerProactiveReview(
       smartImports: prefs.smartImports,
       reviewSuggestions: prefs.reviewSuggestions,
       educationMode: prefs.educationMode,
+      claudeContext: prefs.claudeContext,
     };
 
     await runBackgroundGeneration(reviewId, request, prData, abortController.signal);
@@ -961,6 +963,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   proactiveModel: 'claude-sonnet-4-6',
   proactiveThinking: false,
   educationMode: true,
+  claudeContext: true,
 };
 
 function applyBinaryOverrides(prefs: Preferences): void {
@@ -1329,8 +1332,18 @@ async function runBackgroundGeneration(
   prData: Awaited<ReturnType<typeof getPrMetadata>>,
   signal: AbortSignal
 ): Promise<void> {
-  const { prUrl, provider, model, instructions, thinking, smartImports, reviewSuggestions, webResearch, educationMode } =
-    request;
+  const {
+    prUrl,
+    provider,
+    model,
+    instructions,
+    thinking,
+    smartImports,
+    reviewSuggestions,
+    webResearch,
+    educationMode,
+    claudeContext,
+  } = request;
 
   try {
     const token = getResolvedToken();
@@ -1411,15 +1424,27 @@ async function runBackgroundGeneration(
     broadcastToAllWindows('review-phase', { reviewId, phase: 'Resolving imports' });
 
     const allFileContents = { ...fileContents, ...headFileContents };
-    const neighborFiles = await getNeighborFiles(
-      octokit,
-      owner,
-      repo,
-      normalFiles.map((f) => f.filename),
-      allFileContents,
-      baseRef,
-      smartImports ? provider : undefined
-    );
+    // Fire the Claude-context probe in parallel with the neighbour
+    // fetch — it hits `.claude/` and `CLAUDE.md` at head, which is
+    // independent of the import graph we're walking in neighbours.
+    const [neighborFiles, projectClaudeContext] = await Promise.all([
+      getNeighborFiles(
+        octokit,
+        owner,
+        repo,
+        normalFiles.map((f) => f.filename),
+        allFileContents,
+        baseRef,
+        smartImports ? provider : undefined
+      ),
+      claudeContext ? getProjectClaudeContext(octokit, owner, repo, headRef) : Promise.resolve(null),
+    ]);
+    if (projectClaudeContext) {
+      const { commands, agents, skills, projectInstructionsBytes } = projectClaudeContext;
+      console.log(
+        `[claude-context] CLAUDE.md=${projectInstructionsBytes ?? 0}B, commands=${commands.length}, agents=${agents.length}, skills=${skills.length}`
+      );
+    }
 
     broadcastToAllWindows('review-phase', { reviewId, phase: 'Building context' });
 
@@ -1441,7 +1466,8 @@ async function runBackgroundGeneration(
         headFileContents,
         neighborFiles,
         hunkIndex,
-        excludedFilesSummary
+        excludedFilesSummary,
+        projectClaudeContext
       );
     }
 
@@ -1459,7 +1485,7 @@ async function runBackgroundGeneration(
       // ── Two-phase: planner → parallel writers ──
       broadcastToAllWindows('review-phase', { reviewId, phase: 'Planning review structure' });
 
-      const plannerContext = buildPlannerContext(prData, changedFiles, hunkIndex, excludedFilesSummary);
+      const plannerContext = buildPlannerContext(prData, changedFiles, hunkIndex, excludedFilesSummary, projectClaudeContext);
       plan = await planReview(
         hunkIndex,
         plannerContext,
@@ -1488,6 +1514,7 @@ async function runBackgroundGeneration(
             const topicCtx = buildTopicContext(
               topic, hunkMap, fileContents, headFileContents, neighborFiles,
               prData.title, prData.description, storyArc, sortedTopics,
+              projectClaudeContext,
             );
 
             const writerOutput = await generateSlide({
@@ -1498,6 +1525,7 @@ async function runBackgroundGeneration(
               reviewSuggestions,
               thinking,
               educationMode,
+              hasClaudeContext: !!projectClaudeContext,
               onChunk: (chunk, isThinking) =>
                 broadcastToAllWindows('review-progress', { reviewId, chunk, isThinking }),
               signal,
@@ -1554,6 +1582,7 @@ async function runBackgroundGeneration(
           reviewSuggestions,
           webResearch,
           educationMode,
+          hasClaudeContext: !!projectClaudeContext,
           mcpConfigPath,
           allowedTools,
           onChunk: (chunk, isThinking) => {
@@ -1683,6 +1712,7 @@ async function runBackgroundGeneration(
       slides: resolvedSlides,
       headSha: prData.headSha,
       webSources: aiResult?.webSources,
+      projectClaudeContext: projectClaudeContext ?? undefined,
       changedFiles: fileMetadata,
     };
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -128,6 +128,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [reviewSuggestions, setReviewSuggestions] = useState(true);
   const [webResearch, setWebResearch] = useState(false);
   const [educationMode, setEducationMode] = useState(true);
+  const [claudeContext, setClaudeContext] = useState(true);
   const [instructions, setInstructions] = useState('');
   const [prefsLoaded, setPrefsLoaded] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -269,6 +270,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       setReviewSuggestions(prefs.reviewSuggestions);
       setWebResearch(prefs.enableWebResearch);
       setEducationMode(prefs.educationMode);
+      setClaudeContext(prefs.claudeContext);
       setIncludeAllFiles(prefs.includeAllFiles);
       setPrefsLoaded(true);
       if (!prefs.firstRunSeen) {
@@ -532,6 +534,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
           reviewSuggestions,
           enableWebResearch: webResearch,
           educationMode,
+          claudeContext,
           includeAllFiles,
           ...overrides,
         });
@@ -546,6 +549,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       reviewSuggestions,
       webResearch,
       educationMode,
+      claudeContext,
       includeAllFiles,
     ]
   );
@@ -562,6 +566,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
     reviewSuggestions,
     webResearch,
     educationMode,
+    claudeContext,
     includeAllFiles,
     savePrefs,
   ]);
@@ -616,6 +621,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
         reviewSuggestions,
         webResearch,
         educationMode,
+        claudeContext,
         excludedFiles: excludedFiles.length > 0 ? excludedFiles : undefined,
       });
       setGenerationStartTimes((prev) => new Map(prev).set(result.reviewId, Date.now()));
@@ -1305,6 +1311,13 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                       description="Small explainer notes for concepts the code assumes knowledge of (e.g. Unit of Work)"
                       checked={educationMode}
                       onToggle={() => setEducationMode((e) => !e)}
+                    />
+                    <ToggleSwitch
+                      id="claude-context"
+                      label="Apply project's Claude conventions"
+                      description="Read CLAUDE.md and .claude/ in the PR repo so the review respects the team's Claude Code setup"
+                      checked={claudeContext}
+                      onToggle={() => setClaudeContext((c) => !c)}
                     />
                     {provider === 'claude' && (
                       <ToggleSwitch


### PR DESCRIPTION
## What
When Gnosis generates a review, it now discovers the target repo's Claude-Code-compatible conventions — \`CLAUDE.md\` at the root; custom commands, agents, and skills under \`.claude/\` — and feeds them into the review prompt. Reviewers see what was found on the overview slide.

Read-only discovery only. No hooks executed, no settings interpreted as permissions, no local-only files fetched. Opt-in preference (\`claudeContext\`), default on.

## How
### Fetching — \`lib/github.ts\`
\`getProjectClaudeContext(octokit, owner, repo, ref)\` does four parallel reads:
- \`CLAUDE.md\` via existing \`getFileContent\`.
- \`.claude/commands/*.md\`, \`.claude/agents/*.md\`, \`.claude/skills/*/SKILL.md\` via \`octokit.repos.getContent\` (directory listing) + batched-concurrency fetch (same pattern as the neighbour-file loader).
- Uses the PR **head ref** so PR edits to CLAUDE.md are reflected.
- Hard caps: CLAUDE.md at 8 KB, each command/agent/skill summary at ~240 chars (prefers front-matter \`description:\`, falls back to first body paragraph).
- 404 / 403 / rate-limit errors degrade silently to "none found".

### Prompt — \`lib/context-builder.ts\` + \`lib/agent.ts\`
- New \`<project_claude_context>\` block, rendered after \`<pr_metadata>\`. Inner tags (\`<project_instructions>\`, \`<custom_commands>\`, etc.) only emitted when populated; outer block omitted when empty.
- Included in all three builders (\`buildContextPackage\`, \`buildPlannerContext\`, \`buildTopicContext\`).
- Token-budget cascade drops the Claude block first — after neighbour-file truncation — since the diff + file contents are more load-bearing.
- New \`CLAUDE_CONTEXT_DIRECTIVE\` conditionally included in both \`SYSTEM_PROMPT\` (single-shot) and \`WRITER_SYSTEM\` (parallel writer) when a block is actually present. Tells the model to apply the repo's conventions and cite only what's literally in the block — no inventing rules.

### Wiring
- \`claudeContext: boolean\` on \`Preferences\` (default true) and optional on \`GenerateReviewRequest\`.
- Fetched in parallel with the neighbour fetch in \`runBackgroundGeneration\`; passed to all three context builders and as \`hasClaudeContext\` to the generator options.
- Proactive reviews pick up \`prefs.claudeContext\` when assembling the request.
- Attached to the final \`ReviewGuide.projectClaudeContext\` before save so the UI has data to render.

### UI
- **HomePage**: \`ToggleSwitch\` in the preferences panel next to Education mode / Web research.
- **SettingsDialog**: \`SettingRow\` + \`Toggle\` in the Review section.
- **Overview slide**: new collapsible block next to Web sources: *"Project Claude context (CLAUDE.md · 3 commands · 2 skills)"*. Expanded state lists each item with its summary.

## What NOT to do (explicit)
- No new deps.
- No new IPC surface.
- No fetch of \`.claude/hooks/\` or \`.claude/settings.local.json\`.
- No invocation of discovered commands / agents / skills.

## Files
- \`lib/types.ts\` — \`ProjectClaudeContext\` interface; \`claudeContext\` preference field; optional on \`GenerateReviewRequest\`; optional on \`ReviewGuide\`.
- \`lib/github.ts\` — new \`getProjectClaudeContext\` + helpers.
- \`lib/context-builder.ts\` — new param on three builders; new \`<project_claude_context>\` XML block; budget-cascade drop step.
- \`lib/agent.ts\` — \`CLAUDE_CONTEXT_DIRECTIVE\`; new \`hasClaudeContext\` option on both generator option types.
- \`src/main.ts\` — parallel fetch; default \`true\` in \`DEFAULT_PREFERENCES\`; thread through manual + proactive paths; attach to saved \`ReviewGuide\`.
- \`src/pages/HomePage.tsx\` — state + load + toggle + savePrefs + request plumbing.
- \`components/SettingsDialog.tsx\` — \`SettingRow\` in the Review section.
- \`components/OverviewSlide.tsx\` — new collapsible block.

## Test plan
- [ ] Generate a review on a repo with \`CLAUDE.md\` (e.g. \`oddur/gnosis\` itself). Overview slide shows \"Project Claude context\" disclosure; expanded lists CLAUDE.md + any commands/agents/skills. The saved \`{reviewId}-prompt.md\` contains the \`<project_claude_context>\` block.
- [ ] Generate on a repo without any Claude files. No overview block. No \`<project_claude_context>\` in the prompt dump.
- [ ] Per-review toggle off in HomePage — prompt has no \`<project_claude_context>\` even on a repo that has CLAUDE.md.
- [ ] Global toggle off in Settings — proactive reviews skip the fetch (no \`.claude/\` dir request in logs).
- [ ] Force a 403 on \`.claude/\` (private subrepo, missing scope). Review completes; no user-facing error; no block rendered.
- [ ] \`npx tsc --noEmit\` clean; \`npx eslint\` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)