### PR TITLE
feat: dynamic /changelog page from GitHub releases

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'site/**'
       - '.github/workflows/site.yml'
+  # Re-trigger on every published release so /changelog stays in
+  # sync without a manual push to site/.
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -35,6 +39,11 @@ jobs:
 
       - run: npm ci
       - run: npm run build
+        env:
+          # Used by src/pages/changelog.astro to authenticate the
+          # GitHub API fetch at build time. Without it the call is
+          # anonymous and capped at 60/hour/IP.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/check": "^0.9.4",
         "@tailwindcss/vite": "^4.0.0",
         "astro": "^5.1.5",
+        "marked": "^18.0.2",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.2"
       }
@@ -4642,6 +4643,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
+      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-definitions": {

--- a/site/package.json
+++ b/site/package.json
@@ -12,6 +12,7 @@
     "@astrojs/check": "^0.9.4",
     "@tailwindcss/vite": "^4.0.0",
     "astro": "^5.1.5",
+    "marked": "^18.0.2",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.2"
   }

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -1,0 +1,146 @@
+---
+import Base from '../layouts/Base.astro';
+import { marked } from 'marked';
+
+interface GitHubRelease {
+  tag_name: string;
+  name: string | null;
+  body: string | null;
+  published_at: string;
+  html_url: string;
+  draft: boolean;
+  prerelease: boolean;
+}
+
+// Fetch release notes from the GitHub API at build time. No runtime
+// calls, no client JS, no rate-limit exposure at page load. The
+// workflow re-triggers on `release: published` so the site stays in
+// sync without a manual push.
+const token = process.env.GITHUB_TOKEN;
+const headers: Record<string, string> = {
+  'User-Agent': 'gnosis-site',
+  Accept: 'application/vnd.github+json',
+};
+if (token) headers.Authorization = `Bearer ${token}`;
+
+let releases: GitHubRelease[] = [];
+let fetchError: string | null = null;
+
+try {
+  const res = await fetch(
+    'https://api.github.com/repos/oddur/gnosis/releases?per_page=20',
+    { headers }
+  );
+  if (res.ok) {
+    const data: GitHubRelease[] = await res.json();
+    releases = data.filter((r) => !r.draft).slice(0, 20);
+  } else {
+    fetchError = `GitHub API returned ${res.status}`;
+  }
+} catch (err) {
+  fetchError = err instanceof Error ? err.message : String(err);
+}
+
+marked.setOptions({ gfm: true, breaks: false });
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+// Release body comes from a repo maintainer's markdown. Trust level
+// is "same as CLAUDE.md / source files" — we don't sanitize.
+function renderBody(body: string | null): string {
+  if (!body) return '';
+  const out = marked.parse(body);
+  return typeof out === 'string' ? out : '';
+}
+---
+
+<Base
+  title="Changelog — Gnosis"
+  description="Recent Gnosis releases, pulled from GitHub."
+>
+  <a href="#top" class="skip-link">Skip to content</a>
+  <main id="top" class="mx-auto max-w-3xl px-6 py-16 sm:py-24 flex flex-col gap-12">
+    <header class="flex flex-col gap-5">
+      <p class="slide-chapter">
+        <a href="/" class="link-claret">← gnosis.to</a>
+      </p>
+      <h1 class="slide-title">Changelog.</h1>
+      <p class="slide-prose">
+        Recent releases, pulled from
+        <a
+          class="link-claret"
+          href="https://github.com/oddur/gnosis/releases"
+          target="_blank"
+          rel="noopener noreferrer"
+        >GitHub</a>. The site rebuilds whenever a new release is published.
+      </p>
+    </header>
+
+    {fetchError && (
+      <section class="hairline pt-12">
+        <p class="slide-prose">
+          Couldn't load releases at build time ({fetchError}). Head to
+          <a
+            class="link-claret"
+            href="https://github.com/oddur/gnosis/releases"
+            target="_blank"
+            rel="noopener noreferrer"
+          >GitHub</a>
+          to see what's new.
+        </p>
+      </section>
+    )}
+
+    {releases.length > 0 && (
+      <ol class="flex flex-col gap-12 list-none p-0 m-0">
+        {releases.map((r) => (
+          <li class="hairline pt-10 flex flex-col gap-4">
+            <header class="flex flex-col gap-2">
+              <p class="slide-chapter">
+                <span class="release-tag">{r.tag_name}</span>
+                <span aria-hidden="true">·</span>
+                <span>{formatDate(r.published_at)}</span>
+                {r.prerelease && <>
+                  <span aria-hidden="true">·</span>
+                  <span>prerelease</span>
+                </>}
+              </p>
+              {r.name && r.name !== r.tag_name && (
+                <h2 class="editorial-heading">{r.name}</h2>
+              )}
+            </header>
+            {r.body && r.body.trim().length > 0 && (
+              <div class="slide-prose release-body" set:html={renderBody(r.body)} />
+            )}
+            <p class="slide-meta">
+              <a
+                class="link-claret"
+                href={r.html_url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >View on GitHub →</a>
+            </p>
+          </li>
+        ))}
+      </ol>
+    )}
+
+    <footer class="hairline pt-8 flex flex-col gap-2 slide-meta">
+      <p>
+        <a
+          class="link-claret"
+          href="https://github.com/oddur/gnosis/releases"
+          target="_blank"
+          rel="noopener noreferrer"
+        >All releases on GitHub</a>
+        · <a class="link-claret" href="/">Back to gnosis.to</a>
+      </p>
+    </footer>
+  </main>
+</Base>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -355,6 +355,7 @@ const sections: Section[] = [
     <footer class="hairline pt-8 flex flex-col gap-2 slide-meta reveal">
       <p>
         <a class="link-claret" href="https://github.com/oddur/gnosis" target="_blank" rel="noopener noreferrer">github.com/oddur/gnosis</a>
+        · <a class="link-claret" href="/changelog">Changelog</a>
         · MIT licence
       </p>
       <p>An experiment in changing how code review feels.</p>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -362,6 +362,90 @@ code {
   letter-spacing: 0.02em;
 }
 
+/* Changelog page — the release tag sits inside .slide-chapter so
+   it inherits mono + muted, but it wants the brand claret so the
+   version reads as the primary identifier on each release. */
+.release-tag {
+  color: var(--ring);
+  font-weight: 600;
+}
+
+/* Markdown output inside a release body. GitHub release notes use
+   headings, lists, inline code, and links — each mapped to the
+   site's editorial vocabulary instead of the browser's default
+   prose reset. */
+.release-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.release-body > *:first-child {
+  margin-top: 0;
+}
+.release-body > *:last-child {
+  margin-bottom: 0;
+}
+.release-body p {
+  margin: 0;
+}
+.release-body h1,
+.release-body h2,
+.release-body h3,
+.release-body h4 {
+  font-family: var(--font-serif);
+  font-variation-settings: 'opsz' 28;
+  font-weight: 540;
+  font-size: 1.05rem;
+  line-height: 1.3;
+  margin: 0.5rem 0 0 0;
+  color: var(--foreground);
+  letter-spacing: -0.005em;
+}
+.release-body ul,
+.release-body ol {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+.release-body li {
+  margin: 0.15rem 0;
+}
+.release-body li::marker {
+  color: var(--ring);
+}
+.release-body a {
+  color: var(--ring);
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 3px;
+}
+.release-body a:hover {
+  text-decoration-style: solid;
+}
+.release-body code {
+  background: var(--muted);
+  padding: 0.05rem 0.3rem;
+  border-radius: 0.25rem;
+}
+.release-body pre {
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 0.4rem;
+  padding: 0.65rem 0.85rem;
+  overflow-x: auto;
+  margin: 0.25rem 0;
+}
+.release-body pre code {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+}
+.release-body blockquote {
+  margin: 0;
+  padding-left: 0.85rem;
+  border-left: 2px solid var(--border);
+  color: var(--muted-foreground);
+}
+
 /* ── Motion ──
    The brief asks for page-turn motion, not SaaS pop-zoom. Two
    primitives only: a brief opacity + tiny Y-translate, used as a


### PR DESCRIPTION
## What
A new \`/changelog\` route that pulls the last 20 GitHub releases at build time and renders them with proper markdown formatting. Tile count: zero client JS, zero runtime fetches, zero rate-limit risk at page load.

## How it stays fresh
- \`site.yml\` workflow now triggers on \`release: published\` in addition to \`site/**\` pushes. Any new release you cut re-builds and re-deploys the site automatically.
- \`GITHUB_TOKEN\` passed through to the build step — API limit jumps from 60/hr/IP (anon) to 5,000/hr (authenticated), plenty of headroom.
- If the GitHub API is unreachable at build time the page falls back to an explanatory block with a link to the releases page. The build itself still succeeds.

## Visuals
- Version tag rendered in brand claret (the only chromatic moment on the page, consistent with the homepage's claret link convention).
- Release body parsed with \`marked\` (GFM), then styled through a scoped \`.release-body\` rule: Fraunces small headings, claret list markers, muted code backgrounds — the editorial vocabulary rather than the browser prose reset.
- Prereleases show a small "prerelease" chip in the chapter line.

## Files
- \`site/src/pages/changelog.astro\` (new, 146 lines)
- \`site/src/styles/global.css\` (+84 lines: .release-tag, .release-body rules)
- \`site/src/pages/index.astro\` (+1 line: footer link to /changelog)
- \`.github/workflows/site.yml\` (+9 lines: release trigger, GITHUB_TOKEN env)
- \`site/package.json\` / \`site/package-lock.json\` (marked dependency)

## Test plan
- [x] \`npm run build\` locally → 12 releases baked into \`dist/changelog/index.html\`, page is 19 KB
- [ ] After merge, workflow runs clean on the release trigger the next time I cut a version
- [ ] \`/changelog\` links back to \`/\` via the back arrow and footer
- [ ] Homepage footer shows "Changelog" link
- [ ] Prerelease badge shows if any release has prerelease: true

🤖 Generated with [Claude Code](https://claude.com/claude-code)