### PR TITLE
feat+fix: newspaper masthead + unblock changelog CI

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -14,6 +14,9 @@
         "marked": "^18.0.2",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.2"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0"
       }
     },
     "node_modules/@astrojs/check": {
@@ -2268,6 +2271,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/unist": {
@@ -6463,6 +6476,13 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/site/package.json
+++ b/site/package.json
@@ -15,5 +15,8 @@
     "marked": "^18.0.2",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.2"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0"
   }
 }

--- a/site/src/pages/changelog.astro
+++ b/site/src/pages/changelog.astro
@@ -66,6 +66,15 @@ function renderBody(body: string | null): string {
 >
   <a href="#top" class="skip-link">Skip to content</a>
   <main id="top" class="mx-auto max-w-3xl px-6 py-16 sm:py-24 flex flex-col gap-12">
+    <!-- Shared newspaper nameplate — same as the homepage so the two
+         routes read as editions of the same broadsheet. -->
+    <div class="newspaper-masthead">
+      <hr class="newspaper-rule--double" aria-hidden="true" />
+      <span class="nameplate">Gnosis</span>
+      <p class="newspaper-tagline">Code Review, Narrated</p>
+      <hr class="newspaper-rule--double" aria-hidden="true" />
+    </div>
+
     <header class="flex flex-col gap-5">
       <p class="slide-chapter">
         <a href="/" class="link-claret">← gnosis.to</a>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -160,7 +160,18 @@ const sections: Section[] = [
 <Base title="Gnosis — AI-guided code review">
   <a href="#read" class="skip-link">Skip to content</a>
   <main class="mx-auto max-w-3xl px-6 py-16 sm:py-24 flex flex-col gap-16">
-    <!-- Masthead — staggered settle on load.
+    <!-- Newspaper nameplate — same broadsheet header the app uses
+         on its auth screen. Sits above the page's actual header as
+         a brand mark; visually large but not an <h1> (that's the
+         value-prop headline below). -->
+    <div class="newspaper-masthead settle">
+      <hr class="newspaper-rule--double" aria-hidden="true" />
+      <span class="nameplate">Gnosis</span>
+      <p class="newspaper-tagline">Code Review, Narrated</p>
+      <hr class="newspaper-rule--double" aria-hidden="true" />
+    </div>
+
+    <!-- Value-prop header — staggered settle on load.
          Chapter line: each item in its own span with the middot
          separators marked aria-hidden so screen readers hear a
          comma-separated list instead of "middle dot middle dot". -->

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -160,6 +160,47 @@ body {
   border-top: 1px solid var(--border);
 }
 
+/* ── Newspaper masthead ──
+   Ported from the app's globals.css. Sits above the page content
+   as a broadsheet nameplate: uppercase wide-tracked Fraunces at
+   opsz 96 with a thick-thin double rule above and below. Not an
+   <h1> — the page's actual h1 is the value prop. This is a visual
+   brand mark. */
+.newspaper-masthead {
+  text-align: center;
+  padding: 1.5rem 0 0;
+}
+.newspaper-masthead .nameplate {
+  display: block;
+  font-family: var(--font-serif);
+  font-size: clamp(2.25rem, 1.5rem + 3.5vw, 3.75rem);
+  font-weight: 300;
+  letter-spacing: 0.22em;
+  line-height: 1;
+  font-variation-settings: 'opsz' 96;
+  color: var(--foreground);
+  text-transform: uppercase;
+  margin: 0;
+}
+.newspaper-tagline {
+  font-family: var(--font-serif);
+  font-size: 0.9375rem;
+  font-weight: 300;
+  font-style: italic;
+  letter-spacing: 0.04em;
+  color: var(--muted-foreground);
+  font-variation-settings: 'opsz' 12;
+  margin: 0.25rem 0 0;
+}
+.newspaper-rule--double {
+  height: 0;
+  border-top: 2px solid var(--foreground);
+  border-bottom: 1px solid var(--foreground);
+  padding-top: 3px;
+  background: none;
+  margin: 0;
+}
+
 /* Skip-to-content link. Visually hidden until focused, then anchors
    to the top-left so a keyboard user can jump past the masthead on
    every visit. The :focus-visible rule above wraps it in the brand


### PR DESCRIPTION
## What
Two things in one branch — the newspaper masthead the user asked for, plus the CI fix that #94 needed.

### Newspaper masthead (feature)
Ports \`.newspaper-masthead\` / \`.nameplate\` / \`.newspaper-tagline\` / \`.newspaper-rule--double\` from the app's \`src/globals.css\` into the site. Both \`/\` and \`/changelog\` now open with the broadsheet nameplate the app uses on its auth screen — uppercase wide-tracked Fraunces at opsz 96 between thick-thin double rules, \"Code Review, Narrated\" tagline in italic serif below.

Not an \`<h1>\` — the page's actual h1 stays the value-prop headline (\"Understand the pull request…\"). This is a visual brand mark above it. The two routes now read as editions of the same broadsheet.

### Unblock #94's CI build (fix)
\`astro check\` was failing on the merged changelog branch because it couldn't resolve \`process.env.GITHUB_TOKEN\` in \`changelog.astro\` — \`@types/node\` wasn't declared in \`site/package.json\`. Locally the build worked because node types leak in from the parent Electron project's \`node_modules\`, but CI runs from \`site/\` only.

Added \`@types/node\` as a devDependency. Failing run: https://github.com/oddur/gnosis/actions/runs/24766231259

## Files
- \`site/src/styles/global.css\` — masthead CSS (~40 lines)
- \`site/src/pages/index.astro\` — masthead above the existing header
- \`site/src/pages/changelog.astro\` — same masthead, shared visual identity
- \`site/package.json\` / \`site/package-lock.json\` — @types/node

## Test plan
- [x] \`npm run build\` clean locally (2 pages, 2 routes)
- [ ] CI build succeeds this time (previously failed on ts(2580) for process)
- [ ] Homepage shows "GNOSIS / Code Review, Narrated" above the existing value-prop headline
- [ ] /changelog shows the same masthead above the "Changelog." h1

🤖 Generated with [Claude Code](https://claude.com/claude-code)