### PR TITLE
feat: aptabase (site + app init fix) + update-ready banner replay

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gnosis-site",
       "version": "0.0.0",
       "dependencies": {
+        "@aptabase/web": "^0.5.0",
         "@astrojs/check": "^0.9.4",
         "@tailwindcss/vite": "^4.0.0",
         "astro": "^5.1.5",
@@ -18,6 +19,12 @@
       "devDependencies": {
         "@types/node": "^25.6.0"
       }
+    },
+    "node_modules/@aptabase/web": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@aptabase/web/-/web-0.5.0.tgz",
+      "integrity": "sha512-+RFdaS0bLJtqTZyB1uG32S7tuTfJTGbG2bkdVMs3AT7yG7DP2yb6JY5rZoBf3UyW9sigFHGRkbXoAXdCMZibWA==",
+      "license": "MIT"
     },
     "node_modules/@astrojs/check": {
       "version": "0.9.8",

--- a/site/package.json
+++ b/site/package.json
@@ -9,6 +9,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
+    "@aptabase/web": "^0.5.0",
     "@astrojs/check": "^0.9.4",
     "@tailwindcss/vite": "^4.0.0",
     "astro": "^5.1.5",

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -35,6 +35,11 @@ const { title, description = 'AI-guided code review. Understand the story before
       rel="stylesheet"
     />
     <title>{title}</title>
+    <script>
+      import { init, trackEvent } from '@aptabase/web';
+      init('A-EU-1996018704');
+      trackEvent('pageview', { path: location.pathname });
+    </script>
   </head>
   <body>
     <slot />

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,6 +63,17 @@ const GITHUB_CLIENT_SECRET: string = typeof __GH_CLIENT_SECRET__ !== 'undefined'
 const APTABASE_APP_KEY = 'A-EU-7599830434';
 let aptabaseInitialized = false;
 
+// Aptabase's Electron SDK requires initialize() to run BEFORE app.whenReady().
+// loadPreferences() only touches app.getPath('userData'), which is safe pre-ready.
+try {
+  if (loadPreferences().analytics) {
+    void initAptabase(APTABASE_APP_KEY);
+    aptabaseInitialized = true;
+  }
+} catch {
+  /* prefs unreadable — skip analytics */
+}
+
 function enableAnalyticsIfAllowed(prefs: Preferences): void {
   if (!prefs.analytics || aptabaseInitialized) return;
   void initAptabase(APTABASE_APP_KEY);


### PR DESCRIPTION
## Summary

Three related fixes that were all about events silently failing to reach the user:

### 1. Aptabase on the marketing site
`@aptabase/web` in the shared Base layout, fires a `pageview` event with `path` per load. Uses key `A-EU-1996018704` — separate from the app's key so site and app traffic stay distinct.

### 2. Aptabase init timing in the app
The Aptabase Electron SDK requires `initialize()` to run **before** `app.whenReady()`. It was being called inside the ready handler, so events (including `app_started`) were silently dropped — visible in user logs as `"Aptabase: initialize must be invoked before the app is ready. Tracking will be disabled."` Moved to module scope, guarded by `loadPreferences().analytics`. The existing `enableAnalyticsIfAllowed` fallback remains so mid-session opt-in still works.

### 3. "Update ready" banner race
Squirrel's `update-downloaded` event fires on a timer that routinely beats the renderer's IPC subscription (user log shows it firing 6s after launch). The `webContents.send('update-ready', ...)` message was being dropped, so the "will install on next restart" banner never appeared. Now the main process caches the ready version and the banner pulls it on mount via a new `get-pending-update-ready` IPC.

Plus a `GNOSIS_FAKE_UPDATE_READY` env var that seeds the cache at startup, so the banner is testable in dev without going through a real Squirrel download.

## Test plan
- [x] Dev: `GNOSIS_FAKE_UPDATE_READY=0.22.0 npm start` → banner shows on home and review pages
- [ ] Site: visit gnosis.to, confirm pageview in Aptabase (site key)
- [ ] Packaged app: launch, confirm `app_started` lands in Aptabase (app key)
- [ ] Opt out of analytics in Settings, relaunch, confirm no events
- [ ] Real update: publish a release, install older build, confirm the update-ready banner appears reliably after download