### PR TITLE
Review local git diffs with optional tool mode

### DIFF
--- a/components/LocalRepoDialog.tsx
+++ b/components/LocalRepoDialog.tsx
@@ -1,0 +1,429 @@
+import { useState, useCallback, useEffect } from 'react';
+import { FolderOpen, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called with a synthetic `local:…#base..head` URL and the tool-mode flag
+   *  on success. `localTools` is true when the reviewer opted in to run
+   *  project-local skills / MCP servers / tests during the review. */
+  onSubmit: (localUrl: string, opts: { localTools: boolean }) => void;
+}
+
+const LAST_REPO_PATH_KEY = 'gnosis-local-repo-last-path';
+const LAST_LOCAL_TOOLS_KEY = 'gnosis-local-repo-last-tools';
+
+function buildUrl(repoPath: string, baseRef: string, headRef: string): string {
+  return `local:${repoPath}#${baseRef}..${headRef}`;
+}
+
+// Read last path lazily — localStorage access inside the component body,
+// not top-level, so SSR / test environments without `window` don't break.
+function loadLastRepoPath(): string {
+  try {
+    return localStorage.getItem(LAST_REPO_PATH_KEY) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function saveLastRepoPath(p: string): void {
+  try {
+    localStorage.setItem(LAST_REPO_PATH_KEY, p);
+  } catch {
+    /* quota / disabled — fine */
+  }
+}
+
+export function LocalRepoDialog({ open, onOpenChange, onSubmit }: Props) {
+  const [repoPath, setRepoPath] = useState('');
+  const [baseRef, setBaseRef] = useState('HEAD~1');
+  const [headRef, setHeadRef] = useState('HEAD');
+  const [localTools, setLocalTools] = useState(false);
+  const [validating, setValidating] = useState(false);
+  const [error, setError] = useState<{ title: string; hint: string; detail?: string } | null>(null);
+  const [refs, setRefs] = useState<{ branches: string[]; tags: string[] }>({ branches: [], tags: [] });
+  const [loadingRefs, setLoadingRefs] = useState(false);
+  const [preview, setPreview] = useState<{ changedFileCount: number; mergeBase: string | null } | null>(null);
+  const [loadingPreview, setLoadingPreview] = useState(false);
+
+  // Seed path + tool-mode preference from last-used values on open.
+  useEffect(() => {
+    if (!open) return;
+    const last = loadLastRepoPath();
+    if (last) setRepoPath(last);
+    try {
+      setLocalTools(localStorage.getItem(LAST_LOCAL_TOOLS_KEY) === '1');
+    } catch {
+      /* localStorage unavailable */
+    }
+  }, [open]);
+
+  // Fetch branches + tags whenever the repo path changes (debounced).
+  useEffect(() => {
+    const trimmed = repoPath.trim();
+    if (!trimmed) {
+      setRefs({ branches: [], tags: [] });
+      return;
+    }
+    let cancelled = false;
+    setLoadingRefs(true);
+    const timer = setTimeout(() => {
+      window.electronAPI
+        .listRepoRefs(trimmed)
+        .then((result) => {
+          if (cancelled) return;
+          setRefs({ branches: result.branches, tags: result.tags });
+          if (result.defaultBase && (baseRef === 'HEAD~1' || baseRef === '')) {
+            setBaseRef(result.defaultBase);
+          }
+          if (result.defaultHead && (headRef === 'HEAD' || headRef === '')) {
+            setHeadRef(result.defaultHead);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) setRefs({ branches: [], tags: [] });
+        })
+        .finally(() => {
+          if (!cancelled) setLoadingRefs(false);
+        });
+    }, 250);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [repoPath]);
+
+  // Preview the diff whenever all three inputs are populated — gives the user
+  // early warning if the picked base produces a runaway file count (e.g. a
+  // stale local main → huge merge-base gap).
+  useEffect(() => {
+    const rp = repoPath.trim();
+    const br = baseRef.trim();
+    const hr = headRef.trim();
+    if (!rp || !br || !hr) {
+      setPreview(null);
+      return;
+    }
+    if (br === hr) {
+      setPreview(null);
+      return;
+    }
+    let cancelled = false;
+    setLoadingPreview(true);
+    const timer = setTimeout(() => {
+      window.electronAPI
+        .validateLocalRepo(rp, br, hr)
+        .then((result) => {
+          if (cancelled) return;
+          if (result.ok) {
+            setPreview({ changedFileCount: result.changedFileCount, mergeBase: result.mergeBase });
+          } else {
+            setPreview(null);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) setPreview(null);
+        })
+        .finally(() => {
+          if (!cancelled) setLoadingPreview(false);
+        });
+    }, 400);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [repoPath, baseRef, headRef]);
+
+  const handleBrowse = useCallback(async () => {
+    const dir = await window.electronAPI.pickRepoDir();
+    if (dir) {
+      setRepoPath(dir);
+      setError(null);
+    }
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (e: React.SyntheticEvent) => {
+      e.preventDefault();
+      const rp = repoPath.trim();
+      const br = baseRef.trim();
+      const hr = headRef.trim();
+      if (!rp || !br || !hr) return;
+
+      // Client-side short-circuit: identical refs. Saves a round trip and
+      // surfaces the same message that main.ts would return anyway.
+      if (br === hr) {
+        setError({
+          title: 'Base and head are the same.',
+          hint: 'Pick two different commits to compare.',
+        });
+        return;
+      }
+
+      setValidating(true);
+      setError(null);
+      try {
+        const result = await window.electronAPI.validateLocalRepo(rp, br, hr);
+        if (!result.ok) {
+          setError(explainValidationFailure(result, rp));
+          return;
+        }
+        saveLastRepoPath(rp);
+        try {
+          localStorage.setItem(LAST_LOCAL_TOOLS_KEY, localTools ? '1' : '0');
+        } catch {
+          /* localStorage unavailable */
+        }
+        onSubmit(buildUrl(rp, br, hr), { localTools });
+        onOpenChange(false);
+      } finally {
+        setValidating(false);
+      }
+    },
+    [repoPath, baseRef, headRef, localTools, onSubmit, onOpenChange],
+  );
+
+  const inputClass =
+    'w-full bg-transparent border-0 border-b border-border px-0 py-2 text-base placeholder:text-muted-foreground/60 focus:outline-none focus:border-[var(--ring)] transition-colors';
+
+  const refOptions = [...refs.branches, ...refs.tags];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Review a local git diff</DialogTitle>
+          <DialogDescription>
+            Point Gnosis at a local git repository and two commit refs. Any ref works —
+            a SHA, branch, tag, or <code>HEAD~n</code>.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-5 pt-2">
+          <div className="flex flex-col gap-1">
+            <label className="slide-meta text-foreground/70" htmlFor="local-repo-path">
+              Repository
+            </label>
+            <div className="flex items-center gap-3">
+              <input
+                id="local-repo-path"
+                type="text"
+                placeholder="/absolute/path/to/repo"
+                value={repoPath}
+                onChange={(e) => setRepoPath(e.target.value)}
+                className={inputClass}
+                aria-describedby="local-repo-status"
+                required
+                autoFocus
+              />
+              <button
+                type="button"
+                onClick={handleBrowse}
+                className="slide-meta hover:text-foreground transition-colors flex items-center gap-1 pb-1"
+              >
+                <FolderOpen className="h-3.5 w-3.5" />
+                Browse
+              </button>
+            </div>
+          </div>
+
+          {/* Shared datalist — both inputs point at it so a single list of
+              branches + tags drives autocomplete on both fields. */}
+          <datalist id="local-ref-suggestions">
+            {refOptions.map((ref) => (
+              <option key={ref} value={ref} />
+            ))}
+          </datalist>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="flex flex-col gap-1">
+              <label className="slide-meta text-foreground/70" htmlFor="local-base-ref">
+                Base
+              </label>
+              <input
+                id="local-base-ref"
+                type="text"
+                list="local-ref-suggestions"
+                placeholder="HEAD~1"
+                value={baseRef}
+                onChange={(e) => setBaseRef(e.target.value)}
+                className={inputClass}
+                required
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="slide-meta text-foreground/70" htmlFor="local-head-ref">
+                Head
+              </label>
+              <input
+                id="local-head-ref"
+                type="text"
+                list="local-ref-suggestions"
+                placeholder="HEAD"
+                value={headRef}
+                onChange={(e) => setHeadRef(e.target.value)}
+                className={inputClass}
+                required
+              />
+            </div>
+          </div>
+
+          {/* Fixed-height status row — reserves space so loading → empty
+              doesn't shift layout. Doubles as the error surface and diff
+              preview. Errors take priority; otherwise show the file count
+              so the user can catch a bad base before kicking off the review. */}
+          <div
+            id="local-repo-status"
+            className="min-h-[2.5rem] slide-meta"
+            aria-live="polite"
+          >
+            {error ? (
+              <div className="text-destructive">
+                <p className="text-sm font-medium">{error.title}</p>
+                <p className="text-xs opacity-80 break-words mt-0.5">{error.hint}</p>
+                {error.detail && (
+                  <p className="text-[11px] font-mono opacity-60 break-words mt-1">{error.detail}</p>
+                )}
+              </div>
+            ) : loadingRefs ? (
+              <span className="text-muted-foreground">Reading branches…</span>
+            ) : preview ? (
+              <DiffPreview
+                count={preview.changedFileCount}
+                mergeBase={preview.mergeBase}
+                loading={loadingPreview}
+              />
+            ) : loadingPreview ? (
+              <span className="text-muted-foreground">Checking diff…</span>
+            ) : null}
+          </div>
+
+          {/* Tool-mode opt-in. Off by default because running project-local
+              scripts is a trust boundary — it executes code from whichever
+              branch is checked out. */}
+          <label
+            htmlFor="local-tools"
+            className="flex items-start gap-3 cursor-pointer select-none group"
+          >
+            <input
+              id="local-tools"
+              type="checkbox"
+              checked={localTools}
+              onChange={(e) => setLocalTools(e.target.checked)}
+              className="mt-1 h-4 w-4 rounded border-border bg-transparent accent-[var(--ring)] cursor-pointer"
+            />
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm text-foreground/90 group-hover:text-foreground transition-colors">
+                Run project tools during review
+              </span>
+              <span className="slide-meta leading-relaxed">
+                Lets Claude run tests, read the whole tree, and use the repo's own MCP
+                servers and skills. Only enable for repos you trust.
+              </span>
+            </div>
+          </label>
+
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={validating} className="gap-2">
+              {validating ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Validating…
+                </>
+              ) : (
+                'Begin review'
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// File count above which the diff is almost certainly too big to be
+// useful — typically a stale base or a long-lived feature branch that
+// hasn't been rebased. Surfaced as a gentle warning, not a hard block.
+const LARGE_DIFF_THRESHOLD = 500;
+
+interface DiffPreviewProps {
+  count: number;
+  mergeBase: string | null;
+  loading: boolean;
+}
+
+function DiffPreview({ count, mergeBase, loading }: DiffPreviewProps) {
+  if (count === 0) {
+    return (
+      <span className="text-muted-foreground">
+        No changed files in this range. Pick a different base or head.
+      </span>
+    );
+  }
+  const huge = count >= LARGE_DIFF_THRESHOLD;
+  return (
+    <div className={huge ? 'text-destructive' : 'text-muted-foreground'}>
+      <p>
+        {count.toLocaleString()} file{count === 1 ? '' : 's'} will be reviewed
+        {mergeBase && (
+          <>
+            {' '}from merge-base <span className="font-mono">{mergeBase.slice(0, 7)}</span>
+          </>
+        )}
+        {loading && '…'}
+      </p>
+      {huge && (
+        <p className="text-xs opacity-80 mt-0.5">
+          That's a lot — often means the base branch is stale. Try{' '}
+          <code>git fetch</code> and pick <code>origin/main</code>, or choose a more
+          recent base.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// Map main-process validation failures onto user-facing copy. The main
+// process classifies the failure; this is just the humanizer.
+function explainValidationFailure(
+  result: Exclude<Awaited<ReturnType<typeof window.electronAPI.validateLocalRepo>>, { ok: true }>,
+  repoPath: string,
+): { title: string; hint: string; detail?: string } {
+  switch (result.reason) {
+    case 'not-a-repo':
+      return {
+        title: `Not a git repository`,
+        hint: `${repoPath} doesn't contain a .git directory. Pick a different folder, or run "git init" there first.`,
+      };
+    case 'unknown-ref':
+      return {
+        title: `Couldn't find "${result.ref ?? '?'}"`,
+        hint: `Any branch, tag, SHA, or HEAD~n works. Check spelling and try again.`,
+      };
+    case 'same-refs':
+      return {
+        title: 'Base and head are the same.',
+        hint: 'Pick two different commits to compare.',
+      };
+    case 'other':
+    default:
+      return {
+        title: "Couldn't open that repo",
+        hint: 'Something went wrong resolving the commits. The raw git message is below.',
+        detail: result.message,
+      };
+  }
+}

--- a/components/OnboardingRepoSetup.tsx
+++ b/components/OnboardingRepoSetup.tsx
@@ -94,6 +94,9 @@ export function OnboardingRepoSetup({ open, onComplete, onSkip }: Props) {
           <p>
             Reviews refresh when PRs update and you'll get a notification when they're ready.
           </p>
+          <p className="text-xs opacity-80">
+            Prefer to work offline? You can also review any local git repo — skip this step and use <em>Review a local git diff</em> from the home screen.
+          </p>
         </div>
 
         {/* Search input */}

--- a/components/PRSummaryBanner.tsx
+++ b/components/PRSummaryBanner.tsx
@@ -1,7 +1,8 @@
-import { ExternalLink, ArrowLeft, Settings } from 'lucide-react';
+import { ExternalLink, ArrowLeft, Settings, GitCompare } from 'lucide-react';
 import { GitHubIcon, riskConfig, safeConfigLookup } from '@/lib/constants';
 import type { ReviewGuide } from '@/lib/types';
 import { formatDuration } from '@/lib/utils';
+import { isLocalUrl } from '@/lib/diffSource';
 
 interface Props {
   review: ReviewGuide;
@@ -13,8 +14,25 @@ interface Props {
 // rounded-none border-x-0 border-t-0 — now just a thin row of type
 // on a hairline rule. Reads like the running header of a printed
 // monograph: title on the left, metadata on the right, no fills.
+/** Parse a `local:/abs/path#base..head` URL into its display-worthy parts.
+ *  Returns null for non-local URLs or malformed inputs. */
+function parseLocalRange(url: string): { base: string; head: string } | null {
+  if (!url.startsWith('local:')) return null;
+  const hash = url.lastIndexOf('#');
+  if (hash === -1) return null;
+  const range = url.slice(hash + 1);
+  const dot = range.indexOf('..');
+  if (dot === -1) return null;
+  const base = range.slice(0, dot);
+  let head = range.slice(dot + 2);
+  if (head.startsWith('.')) head = head.slice(1);
+  return base && head ? { base, head } : null;
+}
+
 export function PRSummaryBanner({ review, onBack, onOpenSettings }: Props) {
   const risk = safeConfigLookup(riskConfig, review.riskLevel, riskConfig.low);
+  const isLocal = isLocalUrl(review.prUrl);
+  const localRange = isLocal ? parseLocalRange(review.prUrl) : null;
 
   return (
     <header className="border-b border-border px-6 py-3">
@@ -52,16 +70,32 @@ export function PRSummaryBanner({ review, onBack, onOpenSettings }: Props) {
               <Settings className="h-3.5 w-3.5" />
             </button>
           )}
-          <a
-            href={review.prUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-foreground transition-colors flex items-center gap-1"
-            title="Open on GitHub"
-          >
-            <GitHubIcon className="h-3.5 w-3.5" />
-            <ExternalLink className="h-3 w-3" />
-          </a>
+          {isLocal ? (
+            <span
+              className="flex items-center gap-1.5 text-muted-foreground font-mono tabular-nums"
+              title={review.prUrl}
+            >
+              <GitCompare className="h-3.5 w-3.5" />
+              {localRange ? (
+                <span className="truncate max-w-[28ch]">
+                  {localRange.base} <span className="text-muted-foreground/60">→</span> {localRange.head}
+                </span>
+              ) : (
+                <span>Local</span>
+              )}
+            </span>
+          ) : (
+            <a
+              href={review.prUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-foreground transition-colors flex items-center gap-1"
+              title="Open on GitHub"
+            >
+              <GitHubIcon className="h-3.5 w-3.5" />
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
         </div>
       </div>
     </header>

--- a/components/UpdateBanner.tsx
+++ b/components/UpdateBanner.tsx
@@ -11,14 +11,19 @@ export function UpdateBanner() {
   useEffect(() => {
     window.electronAPI.onUpdateAvailable((info) => setUpdate(info));
     window.electronAPI.onUpdateReady((version) => setReadyVersion(version));
+    // Squirrel often completes download before this effect mounts — replay.
+    void window.electronAPI.getPendingUpdateReady().then((v) => {
+      if (v) setReadyVersion((prev) => prev ?? v);
+    });
     return () => {
       window.electronAPI.offUpdateAvailable();
       window.electronAPI.offUpdateReady();
     };
   }, []);
 
-  // macOS/Windows: show banner when update has been downloaded and is ready to install
-  if (supportsAutoUpdate && readyVersion !== null) {
+  // Show "ready to install" on macOS/Windows. In dev, GNOSIS_FAKE_UPDATE_READY
+  // forces readyVersion so the banner can be tested without a packaged build.
+  if (window.electronAPI.platform !== 'linux' && readyVersion !== null) {
     return (
       <div className="updateBanner flex items-center justify-between gap-3 px-6 py-1.5 text-xs">
         <span>

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -219,6 +219,12 @@ export interface GenerateReviewGuideOptions {
   hasClaudeContext?: boolean;
   mcpConfigPath?: string;
   allowedTools?: string[];
+  /** Working directory for the CLI. Set for local reviews so project-local
+   *  MCP servers, skills, and tests are discoverable. */
+  cwd?: string;
+  /** When true, don't lock MCP to `mcpConfigPath` — lets the CLI also pick up
+   *  the repo's own `.mcp.json`. */
+  nonStrictMcp?: boolean;
   onChunk?: (chunk: string, isThinking: boolean) => void;
   onToolUse?: (toolName: string) => void;
   onPromptReady?: (system: string, userMessage: string) => void;
@@ -239,6 +245,8 @@ export async function generateReviewGuide(opts: GenerateReviewGuideOptions): Pro
     hasClaudeContext = false,
     mcpConfigPath,
     allowedTools,
+    cwd,
+    nonStrictMcp,
     onChunk,
     onToolUse,
     onPromptReady,
@@ -295,6 +303,8 @@ export async function generateReviewGuide(opts: GenerateReviewGuideOptions): Pro
       onToolUse,
       mcpConfigPath,
       allowedTools,
+      cwd,
+      nonStrictMcp,
       signal,
     });
     console.log('[agent] Generation complete, parsing response...');
@@ -403,7 +413,8 @@ export async function planReview(
   model: ModelId,
   onChunk?: (chunk: string, isThinking: boolean) => void,
   thinking: boolean = false,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  toolOpts?: { cwd?: string; mcpConfigPath?: string; allowedTools?: string[]; nonStrictMcp?: boolean },
 ): Promise<PlannerOutput> {
   const provider = getProvider(providerName);
   const userMessage = prMetadata + '\n' + hunkIndex + PLANNER_USER_SUFFIX;
@@ -415,6 +426,10 @@ export async function planReview(
     model,
     thinking,
     onChunk,
+    cwd: toolOpts?.cwd,
+    mcpConfigPath: toolOpts?.mcpConfigPath,
+    allowedTools: toolOpts?.allowedTools,
+    nonStrictMcp: toolOpts?.nonStrictMcp,
     signal,
   });
 
@@ -499,6 +514,10 @@ export interface GenerateSlideOptions {
   thinking?: boolean;
   educationMode?: boolean;
   hasClaudeContext?: boolean;
+  cwd?: string;
+  mcpConfigPath?: string;
+  allowedTools?: string[];
+  nonStrictMcp?: boolean;
   onChunk?: (chunk: string, isThinking: boolean) => void;
   signal?: AbortSignal;
 }
@@ -513,6 +532,10 @@ export async function generateSlide(opts: GenerateSlideOptions): Promise<WriterS
     thinking = false,
     educationMode = false,
     hasClaudeContext = false,
+    cwd,
+    mcpConfigPath,
+    allowedTools,
+    nonStrictMcp,
     onChunk,
     signal,
   } = opts;
@@ -542,6 +565,10 @@ export async function generateSlide(opts: GenerateSlideOptions): Promise<WriterS
       model,
       thinking,
       onChunk,
+      cwd,
+      mcpConfigPath,
+      allowedTools,
+      nonStrictMcp,
       signal,
     });
 

--- a/lib/claude-context.ts
+++ b/lib/claude-context.ts
@@ -1,0 +1,186 @@
+import type { ProjectClaudeContext } from './types';
+
+// Probing `.claude/` + `CLAUDE.md` conventions is identical whether the
+// content lives in a GitHub repo or on the local filesystem — the only
+// variable is HOW you read files and list directories. This module
+// codifies the shared probe and takes a small IO interface so each
+// DiffSource can plug in its own reader.
+
+export interface ClaudeContextIO {
+  /** Return file contents as UTF-8, or null when the path doesn't exist. */
+  readFile(path: string): Promise<string | null>;
+  /** List immediate children of `path`, filtered by `kind`. Return full
+   *  child paths (relative to the repo root), not just basenames. */
+  listDir(path: string, kind: 'file' | 'dir'): Promise<string[]>;
+}
+
+const CLAUDE_MD_MAX_CHARS = 8 * 1024;
+const CLAUDE_ENTRY_SUMMARY_CHARS = 240;
+
+export interface ProbeOptions {
+  /** Skip the review-relevance filter and the CLAUDE.md truncation. Use this
+   *  when the agent has filesystem access — every skill/command is reachable
+   *  anyway, and hiding entries or truncating the CLAUDE.md just forces the
+   *  agent to rediscover them via tools. */
+  unfiltered?: boolean;
+}
+const CLAUDE_PATHS = {
+  md: 'CLAUDE.md',
+  root: '.claude',
+  commands: 'commands',
+  agents: 'agents',
+  skills: 'skills',
+} as const;
+
+// Prefers a front-matter `description:` field, then the first
+// non-empty paragraph. Hard-truncated so a verbose file can't eat
+// the context budget.
+export function summariseClaudeEntry(content: string): string {
+  const fmMatch = /^---\n([\s\S]*?)\n---\n?/.exec(content);
+  let body = content;
+  if (fmMatch) {
+    body = content.slice(fmMatch[0].length);
+    const descMatch = /^description:\s*(.+)$/m.exec(fmMatch[1]);
+    if (descMatch) {
+      return descMatch[1].trim().slice(0, CLAUDE_ENTRY_SUMMARY_CHARS);
+    }
+  }
+  const firstPara = body
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .find((p) => p.length > 0 && !p.startsWith('#'));
+  return (firstPara ?? body.trim()).replace(/\s+/g, ' ').slice(0, CLAUDE_ENTRY_SUMMARY_CHARS);
+}
+
+function entryName(p: string): string {
+  const base = p.split('/').pop() ?? p;
+  return base.replace(/\.md$/, '');
+}
+
+// Whitelist of review-signal keywords. Expressed as an array so
+// adding / removing a term doesn't risk breaking regex escaping or
+// accidental alternation boundaries.
+const CLAUDE_REVIEW_KEYWORDS = [
+  'review', 'audit', 'lint', 'security', 'accessib', 'convention', 'coding\\s*style',
+  'style\\s*guide', 'architecture', 'refactor', 'critique', 'invariant', 'contract',
+  'type\\s*safety', 'quality', 'design\\s*(system|pattern|principle|quality)', 'correctness',
+  'harden', 'simplify', 'polish', 'distill', 'normalize', 'responsive', 'a11y', 'performance',
+  'optim', 'vulnerab', 'best\\s*practice', 'anti[- ]?pattern', 'testing', 'test\\s*strategy',
+  'naming\\s*convention', 'frontend', 'ui\\s+(design|component)', 'visual', 'typograph',
+];
+const CLAUDE_REVIEW_POSITIVE = new RegExp(`\\b(${CLAUDE_REVIEW_KEYWORDS.join('|')})\\b`);
+const CLAUDE_REVIEW_HARD_NEGATIVE = /\bmcp\b|\bapi[- ]?key\b/;
+
+export function isReviewRelevantClaudeEntry(name: string, content: string): boolean {
+  // Scan name + first 2 KB only — summaries are up top, and a pass
+  // match buried 20 KB into a body isn't a trustworthy signal.
+  const lower = (name + ' ' + content.slice(0, 2000)).toLowerCase();
+  if (CLAUDE_REVIEW_HARD_NEGATIVE.test(lower)) return false;
+  return CLAUDE_REVIEW_POSITIVE.test(lower);
+}
+
+async function fetchSummarisedEntries(
+  io: ClaudeContextIO,
+  paths: string[],
+  filter: (name: string, content: string) => boolean = () => true,
+): Promise<{ included: { name: string; summary: string }[]; droppedCount: number }> {
+  const included: { name: string; summary: string }[] = [];
+  let droppedCount = 0;
+  const concurrency = 5;
+  for (let i = 0; i < paths.length; i += concurrency) {
+    const batch = paths.slice(i, i + concurrency);
+    await Promise.all(
+      batch.map(async (p) => {
+        const content = await io.readFile(p);
+        if (!content) return;
+        const name = entryName(p);
+        if (!filter(name, content)) {
+          droppedCount += 1;
+          return;
+        }
+        included.push({ name, summary: summariseClaudeEntry(content) });
+      }),
+    );
+  }
+  included.sort((a, b) => a.name.localeCompare(b.name));
+  return { included, droppedCount };
+}
+
+export async function probeClaudeContext(
+  io: ClaudeContextIO,
+  opts: ProbeOptions = {},
+): Promise<ProjectClaudeContext | null> {
+  const unfiltered = opts.unfiltered ?? false;
+  const entryFilter = unfiltered ? undefined : isReviewRelevantClaudeEntry;
+  // First pass: CLAUDE.md + one listing of `.claude/` itself. Skips
+  // the three subdir requests on repos that have no Claude setup.
+  const [claudeMdRaw, claudeRootEntries] = await Promise.all([
+    io.readFile(CLAUDE_PATHS.md),
+    io.listDir(CLAUDE_PATHS.root, 'dir'),
+  ]);
+
+  const hasCommands = claudeRootEntries.some((p) => p.endsWith(`/${CLAUDE_PATHS.commands}`));
+  const hasAgents = claudeRootEntries.some((p) => p.endsWith(`/${CLAUDE_PATHS.agents}`));
+  const hasSkills = claudeRootEntries.some((p) => p.endsWith(`/${CLAUDE_PATHS.skills}`));
+  const hasRoot = hasCommands || hasAgents || hasSkills;
+
+  const [commandPaths, agentPaths, skillDirs] = await Promise.all([
+    hasCommands
+      ? io.listDir(`${CLAUDE_PATHS.root}/${CLAUDE_PATHS.commands}`, 'file').then((paths) => paths.filter((p) => p.endsWith('.md')))
+      : Promise.resolve<string[]>([]),
+    hasAgents
+      ? io.listDir(`${CLAUDE_PATHS.root}/${CLAUDE_PATHS.agents}`, 'file').then((paths) => paths.filter((p) => p.endsWith('.md')))
+      : Promise.resolve<string[]>([]),
+    hasSkills
+      ? io.listDir(`${CLAUDE_PATHS.root}/${CLAUDE_PATHS.skills}`, 'dir')
+      : Promise.resolve<string[]>([]),
+  ]);
+
+  const hasAny = !!claudeMdRaw || hasRoot;
+  if (!hasAny) return null;
+
+  let projectInstructions: string | null = null;
+  let projectInstructionsBytes: number | undefined;
+  if (claudeMdRaw) {
+    projectInstructionsBytes = Buffer.byteLength(claudeMdRaw, 'utf-8');
+    // Unfiltered mode keeps the full CLAUDE.md — the agent will use the
+    // guidance directly, and forcing it to Read() a truncated version back
+    // wastes a tool call.
+    projectInstructions =
+      !unfiltered && claudeMdRaw.length > CLAUDE_MD_MAX_CHARS
+        ? claudeMdRaw.slice(0, CLAUDE_MD_MAX_CHARS) + `\n\n… [truncated, original ${projectInstructionsBytes} bytes]`
+        : claudeMdRaw;
+  }
+
+  const [cmdResult, agentResult, skillResult] = await Promise.all([
+    fetchSummarisedEntries(io, commandPaths, entryFilter),
+    fetchSummarisedEntries(io, agentPaths, entryFilter),
+    fetchSummarisedEntries(
+      io,
+      skillDirs.map((d) => `${d}/SKILL.md`),
+      entryFilter,
+    ),
+  ]);
+
+  const totalDropped = cmdResult.droppedCount + agentResult.droppedCount + skillResult.droppedCount;
+  if (totalDropped > 0) {
+    console.log(
+      `[claude-context] Filtered out ${totalDropped} non-review entries (commands: ${cmdResult.droppedCount}, agents: ${agentResult.droppedCount}, skills: ${skillResult.droppedCount})`,
+    );
+  }
+
+  const postFilterHasAny =
+    !!projectInstructions ||
+    cmdResult.included.length > 0 ||
+    agentResult.included.length > 0 ||
+    skillResult.included.length > 0;
+  if (!postFilterHasAny) return null;
+
+  return {
+    projectInstructions,
+    projectInstructionsBytes,
+    commands: cmdResult.included,
+    agents: agentResult.included,
+    skills: skillResult.included,
+  };
+}

--- a/lib/diffSource.ts
+++ b/lib/diffSource.ts
@@ -1,0 +1,60 @@
+import type {
+  ChangedFile,
+  FileMetadata,
+  PrMetadata,
+  ProjectClaudeContext,
+  Provider,
+} from './types';
+
+/**
+ * Abstract source of diff + repo data for the review pipeline. Concrete
+ * implementations back this with either the GitHub API or a local git
+ * checkout. Constructed via `createDiffSource(url)`.
+ */
+export interface DiffSource {
+  readonly kind: 'github' | 'local';
+  /** Canonical URL used as history key and display label. */
+  readonly key: string;
+  /** Absolute path to the working directory, when one exists. Local sources
+   *  expose the repo path; GitHub sources return undefined. Used to run the
+   *  CLI with cwd set to the repo when tool-mode is enabled. */
+  readonly cwd?: string;
+
+  getMetadata(): Promise<PrMetadata>;
+  getDiff(changedFiles?: ChangedFile[]): Promise<string>;
+  getChangedFiles(): Promise<ChangedFile[]>;
+  getFileContent(path: string, ref: 'base' | 'head'): Promise<string | null>;
+  getFileMetadata(changedFiles: ChangedFile[]): Promise<FileMetadata[]>;
+  getNeighborFiles(
+    paths: string[],
+    contents: Record<string, string>,
+    ref: 'base' | 'head',
+    smartImportsProvider?: Provider,
+  ): Promise<Record<string, string>>;
+  getProjectClaudeContext(opts?: { unfiltered?: boolean }): Promise<ProjectClaudeContext | null>;
+
+  /** Optional pre-flight check for non-fatal issues (e.g. dirty working tree
+   *  on a local source). Returned strings are surfaced as review-phase
+   *  warnings; an empty array means everything is clean. */
+  checkRuntimeWarnings?(): Promise<string[]>;
+}
+
+export function isLocalUrl(url: string): boolean {
+  return url.startsWith('local:');
+}
+
+/**
+ * Dispatch on URL prefix: `local:/abs/path#base..head` → local git source,
+ * anything else → GitHub source.
+ */
+export async function createDiffSource(
+  url: string,
+  opts: { token?: string | null } = {},
+): Promise<DiffSource> {
+  if (isLocalUrl(url)) {
+    const { LocalGitDiffSource } = await import('./localGit');
+    return new LocalGitDiffSource(url);
+  }
+  const { GitHubDiffSource } = await import('./github');
+  return new GitHubDiffSource(url, opts.token ?? null);
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,5 +1,6 @@
 import { Octokit } from '@octokit/rest';
 import { getProvider } from './provider';
+import type { DiffSource } from './diffSource';
 import type {
   ChangedFile,
   CiCheck,
@@ -372,7 +373,7 @@ Rules:
 - Include file extensions (e.g., .cs, .rs, .py, .go, .ts)
 - Return unique paths only`;
 
-async function extractImportsWithLLM(
+export async function extractImportsWithLLM(
   changedFileContents: Record<string, string>,
   changedFilePaths: string[],
   providerName: Provider
@@ -593,203 +594,99 @@ export async function getFileMetadata(
 }
 
 // ── Claude Code project conventions ─────────────────────────────
+//
+// Shared probe lives in `lib/claude-context.ts` — this function only
+// wires up the GitHub-backed IO.
 
-const CLAUDE_MD_MAX_CHARS = 8 * 1024;
-const CLAUDE_ENTRY_SUMMARY_CHARS = 240;
-const CLAUDE_PATHS = {
-  md: 'CLAUDE.md',
-  root: '.claude',
-  commands: 'commands',
-  agents: 'agents',
-  skills: 'skills',
-} as const;
+import { probeClaudeContext, type ClaudeContextIO } from './claude-context';
 
-type DirEntry = { type: string; name: string; path: string };
-
-async function listDirEntries(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  path: string,
-  ref: string,
-  predicate: (entry: DirEntry) => boolean
-): Promise<string[]> {
-  try {
-    const { data } = await octokit.repos.getContent({ owner, repo, path, ref });
-    if (!Array.isArray(data)) return [];
-    return data.filter(predicate).map((e) => e.path);
-  } catch {
-    return [];
-  }
-}
-
-const isMarkdown = (e: DirEntry) => e.type === 'file' && e.name.endsWith('.md');
-const isDir = (e: DirEntry) => e.type === 'dir';
-
-// Prefers a front-matter `description:` field, then the first
-// non-empty paragraph. Hard-truncated so a verbose file can't eat
-// the context budget.
-function summariseClaudeEntry(content: string): string {
-  const fmMatch = /^---\n([\s\S]*?)\n---\n?/.exec(content);
-  let body = content;
-  if (fmMatch) {
-    body = content.slice(fmMatch[0].length);
-    const descMatch = /^description:\s*(.+)$/m.exec(fmMatch[1]);
-    if (descMatch) {
-      return descMatch[1].trim().slice(0, CLAUDE_ENTRY_SUMMARY_CHARS);
-    }
-  }
-  const firstPara = body
-    .split(/\n\s*\n/)
-    .map((p) => p.trim())
-    .find((p) => p.length > 0 && !p.startsWith('#'));
-  return (firstPara ?? body.trim()).replace(/\s+/g, ' ').slice(0, CLAUDE_ENTRY_SUMMARY_CHARS);
-}
-
-function entryName(path: string): string {
-  const base = path.split('/').pop() ?? path;
-  return base.replace(/\.md$/, '');
-}
-
-// Whitelist of review-signal keywords. Expressed as an array so
-// adding / removing a term doesn't risk breaking regex escaping or
-// accidental alternation boundaries.
-const CLAUDE_REVIEW_KEYWORDS = [
-  'review', 'audit', 'lint', 'security', 'accessib', 'convention', 'coding\\s*style',
-  'style\\s*guide', 'architecture', 'refactor', 'critique', 'invariant', 'contract',
-  'type\\s*safety', 'quality', 'design\\s*(system|pattern|principle|quality)', 'correctness',
-  'harden', 'simplify', 'polish', 'distill', 'normalize', 'responsive', 'a11y', 'performance',
-  'optim', 'vulnerab', 'best\\s*practice', 'anti[- ]?pattern', 'testing', 'test\\s*strategy',
-  'naming\\s*convention', 'frontend', 'ui\\s+(design|component)', 'visual', 'typograph',
-];
-const CLAUDE_REVIEW_POSITIVE = new RegExp(`\\b(${CLAUDE_REVIEW_KEYWORDS.join('|')})\\b`);
-const CLAUDE_REVIEW_HARD_NEGATIVE = /\bmcp\b|\bapi[- ]?key\b/;
-
-function isReviewRelevantClaudeEntry(name: string, content: string): boolean {
-  // Scan name + first 2 KB only — summaries are up top, and a pass
-  // match buried 20 KB into a body isn't a trustworthy signal.
-  const lower = (name + ' ' + content.slice(0, 2000)).toLowerCase();
-  if (CLAUDE_REVIEW_HARD_NEGATIVE.test(lower)) return false;
-  return CLAUDE_REVIEW_POSITIVE.test(lower);
-}
-
-async function fetchSummarisedEntries(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  paths: string[],
-  ref: string,
-  filter: (name: string, content: string) => boolean = () => true
-): Promise<{ included: { name: string; summary: string }[]; droppedCount: number }> {
-  const included: { name: string; summary: string }[] = [];
-  let droppedCount = 0;
-  const concurrency = 5;
-  for (let i = 0; i < paths.length; i += concurrency) {
-    const batch = paths.slice(i, i + concurrency);
-    await Promise.all(
-      batch.map(async (p) => {
-        const content = await getFileContent(octokit, owner, repo, p, ref);
-        if (!content) return;
-        const name = entryName(p);
-        if (!filter(name, content)) {
-          droppedCount += 1;
-          return;
-        }
-        included.push({ name, summary: summariseClaudeEntry(content) });
-      })
-    );
-  }
-  included.sort((a, b) => a.name.localeCompare(b.name));
-  return { included, droppedCount };
-}
-
-// Probe the PR repo for Claude-Code conventions at the given ref.
-// Returns `null` when nothing is found. All errors swallow to null
-// so a missing `.claude/` or a 403 never fails the review.
-export async function getProjectClaudeContext(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  ref: string
-): Promise<ProjectClaudeContext | null> {
-  // First pass: CLAUDE.md + one listing of `.claude/` itself. Skips
-  // the three subdir requests on repos that have no Claude setup
-  // (the common case in public repos).
-  const [claudeMdRaw, claudeRootEntries] = await Promise.all([
-    getFileContent(octokit, owner, repo, CLAUDE_PATHS.md, ref),
-    listDirEntries(octokit, owner, repo, CLAUDE_PATHS.root, ref, isDir),
-  ]);
-
-  const hasRoot = claudeRootEntries.some((p) => p.endsWith(`/${CLAUDE_PATHS.commands}`)
-    || p.endsWith(`/${CLAUDE_PATHS.agents}`)
-    || p.endsWith(`/${CLAUDE_PATHS.skills}`));
-
-  // Second pass: fetch the subdir listings, but only for ones that
-  // actually exist in the root listing.
-  const hasCommands = claudeRootEntries.some((p) => p.endsWith(`/${CLAUDE_PATHS.commands}`));
-  const hasAgents = claudeRootEntries.some((p) => p.endsWith(`/${CLAUDE_PATHS.agents}`));
-  const hasSkills = claudeRootEntries.some((p) => p.endsWith(`/${CLAUDE_PATHS.skills}`));
-
-  const [commandPaths, agentPaths, skillDirs] = await Promise.all([
-    hasCommands
-      ? listDirEntries(octokit, owner, repo, `${CLAUDE_PATHS.root}/${CLAUDE_PATHS.commands}`, ref, isMarkdown)
-      : Promise.resolve<string[]>([]),
-    hasAgents
-      ? listDirEntries(octokit, owner, repo, `${CLAUDE_PATHS.root}/${CLAUDE_PATHS.agents}`, ref, isMarkdown)
-      : Promise.resolve<string[]>([]),
-    hasSkills
-      ? listDirEntries(octokit, owner, repo, `${CLAUDE_PATHS.root}/${CLAUDE_PATHS.skills}`, ref, isDir)
-      : Promise.resolve<string[]>([]),
-  ]);
-
-  const hasAny = !!claudeMdRaw || hasRoot;
-  if (!hasAny) return null;
-
-  let projectInstructions: string | null = null;
-  let projectInstructionsBytes: number | undefined;
-  if (claudeMdRaw) {
-    projectInstructionsBytes = Buffer.byteLength(claudeMdRaw, 'utf-8');
-    projectInstructions =
-      claudeMdRaw.length > CLAUDE_MD_MAX_CHARS
-        ? claudeMdRaw.slice(0, CLAUDE_MD_MAX_CHARS) + `\n\n… [truncated, original ${projectInstructionsBytes} bytes]`
-        : claudeMdRaw;
-  }
-
-  const [cmdResult, agentResult, skillResult] = await Promise.all([
-    fetchSummarisedEntries(octokit, owner, repo, commandPaths, ref, isReviewRelevantClaudeEntry),
-    fetchSummarisedEntries(octokit, owner, repo, agentPaths, ref, isReviewRelevantClaudeEntry),
-    fetchSummarisedEntries(
-      octokit,
-      owner,
-      repo,
-      skillDirs.map((d) => `${d}/SKILL.md`),
-      ref,
-      isReviewRelevantClaudeEntry
-    ),
-  ]);
-
-  const totalDropped = cmdResult.droppedCount + agentResult.droppedCount + skillResult.droppedCount;
-  if (totalDropped > 0) {
-    console.log(
-      `[claude-context] Filtered out ${totalDropped} non-review entries (commands: ${cmdResult.droppedCount}, agents: ${agentResult.droppedCount}, skills: ${skillResult.droppedCount})`
-    );
-  }
-
-  // If post-filter nothing of substance remains (no CLAUDE.md and
-  // every command/agent/skill got dropped as non-review), drop the
-  // whole context so the UI doesn't render an empty disclosure.
-  const postFilterHasAny =
-    !!projectInstructions ||
-    cmdResult.included.length > 0 ||
-    agentResult.included.length > 0 ||
-    skillResult.included.length > 0;
-  if (!postFilterHasAny) return null;
-
+function makeGithubClaudeIO(octokit: Octokit, owner: string, repo: string, ref: string): ClaudeContextIO {
   return {
-    projectInstructions,
-    projectInstructionsBytes,
-    commands: cmdResult.included,
-    agents: agentResult.included,
-    skills: skillResult.included,
+    readFile: (p) => getFileContent(octokit, owner, repo, p, ref),
+    listDir: async (p, kind) => {
+      try {
+        const { data } = await octokit.repos.getContent({ owner, repo, path: p, ref });
+        if (!Array.isArray(data)) return [];
+        return data.filter((e) => (kind === 'dir' ? e.type === 'dir' : e.type === 'file')).map((e) => e.path);
+      } catch {
+        return [];
+      }
+    },
   };
+}
+
+export function getProjectClaudeContext(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  ref: string,
+  opts?: { unfiltered?: boolean },
+): Promise<ProjectClaudeContext | null> {
+  return probeClaudeContext(makeGithubClaudeIO(octokit, owner, repo, ref), opts);
+}
+
+// ── DiffSource adapter ──────────────────────────────────────────
+//
+// Thin wrapper around the exported functions above. The underlying
+// functions stay exported so callers that aren't on the review pipeline
+// path yet (proactive watch, PR picker, freshness checks) keep working
+// without migration.
+
+export class GitHubDiffSource implements DiffSource {
+  readonly kind = 'github' as const;
+  readonly key: string;
+  private readonly octokit: Octokit;
+  private readonly owner: string;
+  private readonly repo: string;
+  private readonly pullNumber: number;
+  private metadataPromise: Promise<PrMetadata> | null = null;
+
+  constructor(url: string, token: string | null) {
+    this.key = url;
+    this.octokit = new Octokit({ auth: token ?? undefined });
+    const parsed = parsePrUrl(url);
+    this.owner = parsed.owner;
+    this.repo = parsed.repo;
+    this.pullNumber = parsed.pullNumber;
+  }
+
+  getMetadata(): Promise<PrMetadata> {
+    this.metadataPromise ??= getPrMetadata(this.octokit, this.owner, this.repo, this.pullNumber);
+    return this.metadataPromise;
+  }
+
+  getDiff(changedFiles?: ChangedFile[]): Promise<string> {
+    return getPrDiff(this.octokit, this.owner, this.repo, this.pullNumber, changedFiles);
+  }
+
+  getChangedFiles(): Promise<ChangedFile[]> {
+    return getChangedFiles(this.octokit, this.owner, this.repo, this.pullNumber);
+  }
+
+  async getFileContent(filePath: string, ref: 'base' | 'head'): Promise<string | null> {
+    const meta = await this.getMetadata();
+    const gitRef = ref === 'base' ? meta.baseBranch : meta.headSha;
+    return getFileContent(this.octokit, this.owner, this.repo, filePath, gitRef);
+  }
+
+  async getFileMetadata(changedFiles: ChangedFile[]): Promise<FileMetadata[]> {
+    const meta = await this.getMetadata();
+    return getFileMetadata(this.octokit, this.owner, this.repo, this.pullNumber, meta.baseSha, changedFiles);
+  }
+
+  async getNeighborFiles(
+    paths: string[],
+    contents: Record<string, string>,
+    ref: 'base' | 'head',
+    smartImportsProvider?: Provider,
+  ): Promise<Record<string, string>> {
+    const meta = await this.getMetadata();
+    const gitRef = ref === 'base' ? meta.baseBranch : meta.headSha;
+    return getNeighborFiles(this.octokit, this.owner, this.repo, paths, contents, gitRef, smartImportsProvider);
+  }
+
+  async getProjectClaudeContext(opts?: { unfiltered?: boolean }): Promise<ProjectClaudeContext | null> {
+    const meta = await this.getMetadata();
+    return getProjectClaudeContext(this.octokit, this.owner, this.repo, meta.headSha, opts);
+  }
 }

--- a/lib/localGit.ts
+++ b/lib/localGit.ts
@@ -1,0 +1,443 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import path from 'path';
+import fs from 'fs/promises';
+import type { DiffSource } from './diffSource';
+import { probeClaudeContext, type ClaudeContextIO } from './claude-context';
+import type {
+  ChangedFile,
+  FileMetadata,
+  PrMetadata,
+  ProjectClaudeContext,
+  Provider,
+} from './types';
+
+const execFileP = promisify(execFile);
+
+// `git diff` output can be enormous for big branches — bump the default
+// child_process buffer (1 MB) well out of the way.
+const GIT_MAX_BUFFER = 256 * 1024 * 1024;
+
+interface ParsedLocalUrl {
+  repoPath: string;
+  baseRef: string;
+  headRef: string;
+}
+
+export function parseLocalUrl(url: string): ParsedLocalUrl {
+  if (!url.startsWith('local:')) {
+    throw new Error(`Not a local URL: ${url}`);
+  }
+  const body = url.slice('local:'.length);
+  const hashIdx = body.lastIndexOf('#');
+  if (hashIdx === -1) {
+    throw new Error(`Local URL missing commit range (expected local:/path#base..head): ${url}`);
+  }
+  const repoPath = body.slice(0, hashIdx);
+  const range = body.slice(hashIdx + 1);
+  // Support both `base..head` and `base...head` (three-dot = merge base diff).
+  // Normalize to two-dot; the user-facing docs say "two commits".
+  const dotIdx = range.indexOf('..');
+  if (dotIdx === -1) {
+    throw new Error(`Local URL range must be base..head: ${url}`);
+  }
+  const baseRef = range.slice(0, dotIdx);
+  let headRef = range.slice(dotIdx + 2);
+  if (headRef.startsWith('.')) headRef = headRef.slice(1); // handle `...`
+  if (!repoPath || !baseRef || !headRef) {
+    throw new Error(`Local URL malformed: ${url}`);
+  }
+  return { repoPath, baseRef, headRef };
+}
+
+export function buildLocalUrl(repoPath: string, baseRef: string, headRef: string): string {
+  return `local:${path.resolve(repoPath)}#${baseRef}..${headRef}`;
+}
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileP('git', args, {
+    cwd,
+    maxBuffer: GIT_MAX_BUFFER,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  });
+  return stdout;
+}
+
+async function gitOrNull(cwd: string, args: string[]): Promise<string | null> {
+  try {
+    return await git(cwd, args);
+  } catch {
+    return null;
+  }
+}
+
+/** Runs `git rev-parse <ref>` — throws with a helpful message if the ref is unknown. */
+async function resolveSha(repoPath: string, ref: string): Promise<string> {
+  const out = await gitOrNull(repoPath, ['rev-parse', '--verify', `${ref}^{commit}`]);
+  if (!out) {
+    throw new Error(`git: unknown revision "${ref}" in ${repoPath}`);
+  }
+  return out.trim();
+}
+
+interface NameStatusEntry {
+  status: ChangedFile['status'];
+  filename: string;
+  previous_filename?: string;
+}
+
+function parseNameStatus(out: string): NameStatusEntry[] {
+  const entries: NameStatusEntry[] = [];
+  for (const line of out.split('\n')) {
+    if (!line) continue;
+    const parts = line.split('\t');
+    const code = parts[0];
+    if (!code) continue;
+    // R100, C95 etc — rename/copy similarity score suffix.
+    const letter = code[0];
+    switch (letter) {
+      case 'A':
+        entries.push({ status: 'added', filename: parts[1] });
+        break;
+      case 'M':
+      case 'T': // type change — treat as modified
+        entries.push({ status: 'modified', filename: parts[1] });
+        break;
+      case 'D':
+        entries.push({ status: 'deleted', filename: parts[1] });
+        break;
+      case 'R':
+        entries.push({ status: 'renamed', filename: parts[2], previous_filename: parts[1] });
+        break;
+      case 'C':
+        entries.push({ status: 'added', filename: parts[2], previous_filename: parts[1] });
+        break;
+      default:
+        // Unmerged, unknown — skip.
+        break;
+    }
+  }
+  return entries;
+}
+
+function parseNumstat(out: string): Map<string, { additions: number; deletions: number }> {
+  const map = new Map<string, { additions: number; deletions: number }>();
+  for (const line of out.split('\n')) {
+    if (!line) continue;
+    const parts = line.split('\t');
+    if (parts.length < 3) continue;
+    // Binary files show "-\t-\tpath"
+    const additions = parts[0] === '-' ? 0 : parseInt(parts[0], 10) || 0;
+    const deletions = parts[1] === '-' ? 0 : parseInt(parts[1], 10) || 0;
+    // For renames, numstat uses "old => new" or "{dir => dir}/file" syntax.
+    // Strip those to the destination path; matched against name-status below.
+    let filename = parts[2];
+    const arrowIdx = filename.indexOf(' => ');
+    if (arrowIdx !== -1) {
+      const braceOpen = filename.indexOf('{');
+      const braceClose = filename.indexOf('}');
+      if (braceOpen !== -1 && braceClose !== -1 && braceOpen < arrowIdx && arrowIdx < braceClose) {
+        const before = filename.slice(0, braceOpen);
+        const newPart = filename.slice(arrowIdx + 4, braceClose);
+        const after = filename.slice(braceClose + 1);
+        filename = before + newPart + after;
+      } else {
+        filename = filename.slice(arrowIdx + 4);
+      }
+    }
+    map.set(filename, { additions, deletions });
+  }
+  return map;
+}
+
+export class LocalGitDiffSource implements DiffSource {
+  readonly kind = 'local' as const;
+  readonly key: string;
+  readonly cwd: string;
+  private readonly repoPath: string;
+  private readonly baseRefRaw: string;
+  private readonly headRefRaw: string;
+  private metadataPromise: Promise<PrMetadata> | null = null;
+  private shaPromise: Promise<{ baseSha: string; headSha: string }> | null = null;
+
+  constructor(url: string) {
+    const { repoPath, baseRef, headRef } = parseLocalUrl(url);
+    this.repoPath = path.resolve(repoPath);
+    this.cwd = this.repoPath;
+    this.baseRefRaw = baseRef;
+    this.headRefRaw = headRef;
+    this.key = buildLocalUrl(this.repoPath, baseRef, headRef);
+  }
+
+  private resolveRefs(): Promise<{ baseSha: string; headSha: string }> {
+    this.shaPromise ??= (async () => {
+      const [baseSha, headSha] = await Promise.all([
+        resolveSha(this.repoPath, this.baseRefRaw),
+        resolveSha(this.repoPath, this.headRefRaw),
+      ]);
+      return { baseSha, headSha };
+    })();
+    return this.shaPromise;
+  }
+
+  async getMetadata(): Promise<PrMetadata> {
+    this.metadataPromise ??= (async () => {
+      const { baseSha, headSha } = await this.resolveRefs();
+      // Head commit: subject, author, author-date, body.
+      const headInfo = await git(this.repoPath, [
+        'log',
+        '-1',
+        '--format=%H%n%an%n%aI%n%cI%n%s%n%b',
+        headSha,
+      ]);
+      const [, author, authorDate, commitDate, subject, ...bodyLines] = headInfo.split('\n');
+      const body = bodyLines.join('\n').trim();
+      // Commits between base and head — used for description + count.
+      const logBetween = await gitOrNull(this.repoPath, [
+        'log',
+        '--format=%s%n%n%b%n---',
+        `${baseSha}..${headSha}`,
+      ]);
+      const countOut = await gitOrNull(this.repoPath, [
+        'rev-list',
+        '--count',
+        `${baseSha}..${headSha}`,
+      ]);
+      const commitCount = countOut ? parseInt(countOut.trim(), 10) || 1 : 1;
+      const description = logBetween ? logBetween.trim() : body;
+
+      return {
+        title: subject || `${this.baseRefRaw}..${this.headRefRaw}`,
+        description,
+        author: author || 'unknown',
+        baseBranch: this.baseRefRaw,
+        headBranch: this.headRefRaw,
+        baseSha,
+        headSha,
+        merged: false,
+        state: 'open',
+        createdAt: authorDate || new Date().toISOString(),
+        updatedAt: commitDate || authorDate || new Date().toISOString(),
+        url: this.key,
+        labels: [],
+        mergeable: null,
+        isDraft: false,
+        commitCount,
+        requestedReviewers: [],
+        requestedTeams: [],
+        mergeableState: null,
+        autoMerge: null,
+        milestone: null,
+      };
+    })();
+    return this.metadataPromise;
+  }
+
+  async getChangedFiles(): Promise<ChangedFile[]> {
+    const range = await this.threeDotRange();
+    // Diagnostic: log the resolved range so the user can spot a bad base
+    // (e.g. stale local main causing a huge merge-base diff) in the console.
+    const mergeBase = await gitOrNull(this.repoPath, ['merge-base', ...range.split('...')]);
+    console.log(
+      `[localGit] diff range ${this.baseRefRaw}…${this.headRefRaw} (${range}); merge-base=${mergeBase?.trim().slice(0, 10) ?? '?'}`,
+    );
+    const [nameStatusOut, numstatOut] = await Promise.all([
+      git(this.repoPath, ['diff', '--name-status', '-M', '-C', range]),
+      git(this.repoPath, ['diff', '--numstat', range]),
+    ]);
+
+    const entries = parseNameStatus(nameStatusOut);
+    const stats = parseNumstat(numstatOut);
+
+    // Per-file `patch` is intentionally left undefined. It exists on the
+    // `ChangedFile` interface for GitHub's fallback path (reassemble unified
+    // diff when the API's full-diff endpoint returns `too_large`). Locally we
+    // always have the full diff from `getDiff()`, so computing per-file
+    // patches would mean N extra `git diff` subprocesses for zero benefit.
+    return entries.map((e) => {
+      const s = stats.get(e.filename) ?? { additions: 0, deletions: 0 };
+      const file: ChangedFile = {
+        filename: e.filename,
+        status: e.status,
+        additions: s.additions,
+        deletions: s.deletions,
+      };
+      if (e.previous_filename) file.previous_filename = e.previous_filename;
+      return file;
+    });
+  }
+
+  async getDiff(): Promise<string> {
+    const range = await this.threeDotRange();
+    return git(this.repoPath, ['diff', '-M', '-C', range]);
+  }
+
+  /** Resolve the three-dot range `base...head` — the diff from the merge-base
+   *  to head, matching GitHub PR semantics. Using two-dot (`base..head`)
+   *  would also include changes that landed on base since the branch
+   *  diverged, which is usually not what the reviewer wants. */
+  private async threeDotRange(): Promise<string> {
+    const { baseSha, headSha } = await this.resolveRefs();
+    return `${baseSha}...${headSha}`;
+  }
+
+  async getFileContent(filePath: string, ref: 'base' | 'head'): Promise<string | null> {
+    const { baseSha, headSha } = await this.resolveRefs();
+    const sha = ref === 'base' ? baseSha : headSha;
+    return gitOrNull(this.repoPath, ['show', `${sha}:${filePath}`]);
+  }
+
+  async getFileMetadata(changedFiles: ChangedFile[]): Promise<FileMetadata[]> {
+    const { baseSha, headSha } = await this.resolveRefs();
+
+    return Promise.all(
+      changedFiles.map(async (f) => {
+        const meta: FileMetadata = {
+          filename: f.filename,
+          status: f.status,
+          additions: f.additions,
+          deletions: f.deletions,
+        };
+
+        // Churn: commits in base..head touching this file.
+        const churnOut = await gitOrNull(this.repoPath, [
+          'rev-list',
+          '--count',
+          `${baseSha}..${headSha}`,
+          '--',
+          f.filename,
+        ]);
+        meta.prCommitCount = churnOut ? parseInt(churnOut.trim(), 10) || 1 : 1;
+
+        // Last modified before the range — only meaningful for non-added files.
+        if (f.status === 'added') {
+          meta.lastModified = null;
+        } else {
+          const refForHistory = f.status === 'renamed' && f.previous_filename ? f.previous_filename : f.filename;
+          const lastOut = await gitOrNull(this.repoPath, [
+            'log',
+            '-1',
+            '--format=%aI',
+            baseSha,
+            '--',
+            refForHistory,
+          ]);
+          meta.lastModified = lastOut ? lastOut.trim() || null : null;
+        }
+
+        return meta;
+      }),
+    );
+  }
+
+  async getNeighborFiles(
+    paths: string[],
+    contents: Record<string, string>,
+    ref: 'base' | 'head',
+    smartImportsProvider?: Provider,
+  ): Promise<Record<string, string>> {
+    if (smartImportsProvider) {
+      const { extractImportsWithLLM } = await import('./github');
+      console.log(`[localGit] Using smart (${smartImportsProvider}) import extraction`);
+      const importPaths = await extractImportsWithLLM(contents, paths, smartImportsProvider);
+      const neighborPaths = importPaths.filter((p) => !paths.includes(p));
+      const pathsToFetch = neighborPaths.slice(0, 30);
+      const result: Record<string, string> = {};
+      await Promise.all(
+        pathsToFetch.map(async (p) => {
+          const content = await this.getFileContent(p, ref);
+          if (content !== null) result[p] = content;
+        }),
+      );
+      return result;
+    }
+
+    // Default: regex-based extraction, mirroring the GitHub fallback path.
+    const neighbors = new Set<string>();
+    for (const p of paths) {
+      const content = contents[p];
+      if (!content) continue;
+      for (const imp of extractRelativeImports(content, p)) {
+        if (!paths.includes(imp)) neighbors.add(imp);
+      }
+    }
+
+    const pathsToFetch = Array.from(neighbors).slice(0, 30);
+    const result: Record<string, string> = {};
+    const TS_EXT = ['', '.ts', '.tsx', '.js', '.jsx', '/index.ts', '/index.tsx', '/index.js'];
+    await Promise.all(
+      pathsToFetch.map(async (base) => {
+        for (const ext of TS_EXT) {
+          const full = base + ext;
+          const content = await this.getFileContent(full, ref);
+          if (content !== null) {
+            result[full] = content;
+            return;
+          }
+        }
+      }),
+    );
+    return result;
+  }
+
+  async getProjectClaudeContext(opts?: { unfiltered?: boolean }): Promise<ProjectClaudeContext | null> {
+    return probeClaudeContext(makeFsClaudeIO(this.repoPath), opts);
+  }
+
+  async checkRuntimeWarnings(): Promise<string[]> {
+    const warnings: string[] = [];
+    const usesHead = this.baseRefRaw === 'HEAD' || this.headRefRaw === 'HEAD';
+    if (usesHead) {
+      const out = await gitOrNull(this.repoPath, ['status', '--porcelain']);
+      if (out && out.trim().length > 0) {
+        warnings.push('Working tree has uncommitted changes — reviewing committed state only');
+      }
+    }
+    return warnings;
+  }
+
+  get refs(): { baseRef: string; headRef: string; repoPath: string } {
+    return { baseRef: this.baseRefRaw, headRef: this.headRefRaw, repoPath: this.repoPath };
+  }
+}
+
+function makeFsClaudeIO(repoPath: string): ClaudeContextIO {
+  return {
+    readFile: async (p) => {
+      try {
+        return await fs.readFile(path.join(repoPath, p), 'utf-8');
+      } catch {
+        return null;
+      }
+    },
+    listDir: async (p, kind) => {
+      try {
+        const entries = await fs.readdir(path.join(repoPath, p), { withFileTypes: true });
+        return entries
+          .filter((e) => (kind === 'dir' ? e.isDirectory() : e.isFile()))
+          .map((e) => `${p}/${e.name}`);
+      } catch {
+        return [];
+      }
+    },
+  };
+}
+
+function extractRelativeImports(content: string, filePath: string): string[] {
+  const dir = filePath.split('/').slice(0, -1).join('/');
+  const imports: string[] = [];
+  const re = /import\s+(?:.*?\s+from\s+)?['"]([^'"]+)['"]/g;
+  let m;
+  while ((m = re.exec(content)) !== null) {
+    const spec = m[1];
+    if (!spec.startsWith('.')) continue;
+    const parts = (dir ? dir + '/' + spec : spec).split('/');
+    const normalized: string[] = [];
+    for (const part of parts) {
+      if (part === '..') normalized.pop();
+      else if (part !== '.') normalized.push(part);
+    }
+    imports.push(normalized.join('/'));
+  }
+  return imports;
+}

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -10,6 +10,12 @@ export interface GenerateOptions {
   onToolUse?: (toolName: string) => void;
   mcpConfigPath?: string;
   allowedTools?: string[];
+  /** Directory the CLI runs in. When set, project-local config
+   *  (.mcp.json, .claude/settings.json, skills) is auto-discovered. */
+  cwd?: string;
+  /** When true, don't pass --strict-mcp-config — lets the CLI pick up
+   *  the project's own `.mcp.json` in addition to any `mcpConfigPath`. */
+  nonStrictMcp?: boolean;
   signal?: AbortSignal;
 }
 
@@ -17,6 +23,7 @@ export interface QuickOptions {
   content: string;
   systemPrompt: string;
   model: ModelId;
+  cwd?: string;
 }
 
 export interface ModelInfo {

--- a/lib/providers/claude.ts
+++ b/lib/providers/claude.ts
@@ -23,7 +23,7 @@ export const claudeProvider: LLMProvider = {
     { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', quick: true },
   ],
 
-  async generate({ content, systemPrompt, model, thinking, onChunk, onToolUse, mcpConfigPath, allowedTools, signal }) {
+  async generate({ content, systemPrompt, model, thinking, onChunk, onToolUse, mcpConfigPath, allowedTools, cwd, nonStrictMcp, signal }) {
     const claudePath = resolveClaudePath();
     let fullText = '';
 
@@ -68,17 +68,20 @@ export const claudeProvider: LLMProvider = {
 
     const toolArgs: string[] = [];
     if (mcpConfigPath) {
-      toolArgs.push('--mcp-config', mcpConfigPath, '--strict-mcp-config');
+      toolArgs.push('--mcp-config', mcpConfigPath);
+      if (!nonStrictMcp) toolArgs.push('--strict-mcp-config');
     }
     if (allowedTools && allowedTools.length > 0) {
       toolArgs.push('--allowedTools', allowedTools.join(','));
-    } else if (!mcpConfigPath) {
+    } else if (!mcpConfigPath && !nonStrictMcp) {
+      // No explicit tool set AND no project-local MCP discovery → lock tools off.
       toolArgs.push('--tools', '');
     }
 
     await spawnCliStreaming({
       binPath: claudePath,
       cliName: 'Claude',
+      cwd,
       args: [
         '-p',
         '--model',
@@ -112,11 +115,12 @@ export const claudeProvider: LLMProvider = {
     return fullText.trim();
   },
 
-  quick({ content, systemPrompt, model }) {
+  quick({ content, systemPrompt, model, cwd }) {
     const claudePath = resolveClaudePath();
     return spawnCliQuick({
       binPath: claudePath,
       cliName: 'Claude',
+      cwd,
       args: [
         '-p',
         '--model',

--- a/lib/providers/shared.ts
+++ b/lib/providers/shared.ts
@@ -113,6 +113,9 @@ export interface StreamingCliOptions {
   processLine: (line: string) => void;
   /** Environment overrides (merged with process.env) */
   env?: NodeJS.ProcessEnv;
+  /** Working directory for the child process. When set, the CLI auto-discovers
+   *  project-local config (.mcp.json, .claude/settings.json, skills) from here. */
+  cwd?: string;
   /** Install instructions shown when CLI is not found */
   installHint: string;
   /** Custom error handler for non-zero exit codes. Return an Error or undefined to use default. */
@@ -133,7 +136,10 @@ function withBinDir(binPath: string, env: NodeJS.ProcessEnv | undefined): NodeJS
 
 export function spawnCliStreaming(opts: StreamingCliOptions): Promise<void> {
   return new Promise((resolve, reject) => {
-    const proc = spawn(opts.binPath, opts.args, { env: withBinDir(opts.binPath, opts.env) });
+    const proc = spawn(opts.binPath, opts.args, {
+      env: withBinDir(opts.binPath, opts.env),
+      cwd: opts.cwd,
+    });
     const tag = `[${opts.cliName}]`;
 
     if (opts.signal) {
@@ -207,6 +213,7 @@ export interface QuickCliOptions {
   args: string[];
   stdinContent: string;
   env?: NodeJS.ProcessEnv;
+  cwd?: string;
   installHint: string;
   handleExitError?: (stderr: string) => Error | undefined;
 }
@@ -217,7 +224,10 @@ export interface QuickCliOptions {
  */
 export function spawnCliQuick(opts: QuickCliOptions): Promise<string> {
   return new Promise((resolve, reject) => {
-    const proc = spawn(opts.binPath, opts.args, { env: withBinDir(opts.binPath, opts.env) });
+    const proc = spawn(opts.binPath, opts.args, {
+      env: withBinDir(opts.binPath, opts.env),
+      cwd: opts.cwd,
+    });
 
     proc.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code === 'ENOENT') {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -275,6 +275,10 @@ export interface Preferences {
   proactiveThinking: boolean;
   educationMode: boolean;
   claudeContext: boolean;
+  /** True once the user has opted in to using Gnosis without a GitHub
+   *  account. Unlocks the rest of the app (compose form, history, local
+   *  review) for users who only want to review local git diffs. */
+  guestMode: boolean;
 }
 
 export interface SendSlideChatRequest {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -304,6 +304,10 @@ export interface GenerateReviewRequest {
   educationMode?: boolean;
   claudeContext?: boolean;
   excludedFiles?: string[];
+  /** Local reviews only. When true, Claude runs with cwd=repoPath and can
+   *  discover the repo's project-local config (.mcp.json, .claude/settings.json,
+   *  skills) plus run read-only shell tools like tests. Ignored for GitHub URLs. */
+  localTools?: boolean;
 }
 
 export interface GenerateReviewResponse {

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,6 +8,7 @@
       "name": "gnosis-site",
       "version": "0.0.0",
       "dependencies": {
+        "@aptabase/web": "^0.5.0",
         "@astrojs/check": "^0.9.4",
         "@tailwindcss/vite": "^4.0.0",
         "astro": "^5.1.5",
@@ -18,6 +19,12 @@
       "devDependencies": {
         "@types/node": "^25.6.0"
       }
+    },
+    "node_modules/@aptabase/web": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@aptabase/web/-/web-0.5.0.tgz",
+      "integrity": "sha512-+RFdaS0bLJtqTZyB1uG32S7tuTfJTGbG2bkdVMs3AT7yG7DP2yb6JY5rZoBf3UyW9sigFHGRkbXoAXdCMZibWA==",
+      "license": "MIT"
     },
     "node_modules/@astrojs/check": {
       "version": "0.9.8",

--- a/site/package.json
+++ b/site/package.json
@@ -9,6 +9,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
+    "@aptabase/web": "^0.5.0",
     "@astrojs/check": "^0.9.4",
     "@tailwindcss/vite": "^4.0.0",
     "astro": "^5.1.5",

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -35,6 +35,11 @@ const { title, description = 'AI-guided code review. Understand the story before
       rel="stylesheet"
     />
     <title>{title}</title>
+    <script>
+      import { init, trackEvent } from '@aptabase/web';
+      init('A-EU-1996018704');
+      trackEvent('pageview', { path: location.pathname });
+    </script>
   </head>
   <body>
     <slot />

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,18 +8,14 @@ import { Octokit } from '@octokit/rest';
 import {
   parsePrUrl,
   getPrMetadata,
-  getPrDiff,
-  getChangedFiles,
-  getFileContent,
-  getFileMetadata,
-  getNeighborFiles,
-  getProjectClaudeContext,
   searchPullRequests,
   searchRepos,
   listRepoPullRequests,
   getCiStatus,
   getReviewStatus,
 } from '../lib/github';
+import { createDiffSource, isLocalUrl } from '../lib/diffSource';
+import type { DiffSource } from '../lib/diffSource';
 import type { CiCheck, FileMetadata, PrMetadata, PrSearchResult, PrStatus } from '../lib/types';
 import { buildContextPackage, buildPlannerContext, buildTopicContext } from '../lib/context-builder';
 import { generateReviewGuide, planReview, generateSlide } from '../lib/agent';
@@ -485,11 +481,12 @@ async function triggerProactiveReview(
   const reviewId = crypto.randomUUID();
 
   try {
+    // Proactive mode only ever operates on GitHub PR URLs — local
+    // reviews have no remote to poll.
+    const source = await createDiffSource(prUrl, { token: cachedToken });
     let prData = opts.prData;
     if (!prData) {
-      const octokit = new Octokit({ auth: cachedToken ?? undefined });
-      const { owner, repo, pullNumber } = parsePrUrl(prUrl);
-      prData = await getPrMetadata(octokit, owner, repo, pullNumber);
+      prData = await source.getMetadata();
     }
 
     // Cancel any in-flight generation for this PR
@@ -519,7 +516,7 @@ async function triggerProactiveReview(
       claudeContext: prefs.claudeContext,
     };
 
-    await runBackgroundGeneration(reviewId, request, prData, abortController.signal);
+    await runBackgroundGeneration(reviewId, request, source, prData, abortController.signal);
 
     broadcastToAllWindows('new-review-in-history');
     console.log(`[proactive] Completed ${opts.autoUpdated ? 'update' : 'review'} for ${prUrl}`);
@@ -613,6 +610,8 @@ async function runProactiveCheck() {
     for (const [prUrl, entry] of openCompletedByPr) {
       if (updateCount >= PROACTIVE_MAX_CONCURRENT_UPDATES) break;
       if (generatingPrUrls.has(prUrl)) continue;
+      // Local reviews are pinned to commit shas — nothing to poll.
+      if (isLocalUrl(prUrl)) continue;
 
       try {
         const { owner, repo, pullNumber } = parsePrUrl(prUrl);
@@ -1063,6 +1062,18 @@ const ALLOWED_TOOLS = [
 
 const WEB_ONLY_TOOLS = ['WebFetch', 'WebSearch'];
 
+// Read-only + test tools for local reviews. Lets Claude grep the tree,
+// read files, and run shell commands (tests, linters) without letting it
+// mutate the working tree. No Edit/Write/NotebookEdit.
+const LOCAL_REVIEW_TOOLS = [
+  'Bash',
+  'Read',
+  'Grep',
+  'Glob',
+  'WebFetch',
+  'WebSearch',
+];
+
 // ── IPC handlers ────────────────────────────────────────────────
 
 ipcMain.handle('dismiss-update', (_event, version: string) => {
@@ -1305,6 +1316,11 @@ ipcMain.handle('delete-all-reviews', () => {
 ipcMain.handle(
   'check-pr-freshness',
   async (_event, prUrl: string, headSha: string | undefined): Promise<FreshnessResult> => {
+    // Local reviews are pinned to a specific commit range — there's no
+    // remote to compare against, so the review is always "current".
+    if (isLocalUrl(prUrl)) {
+      return { status: 'current' };
+    }
     if (!headSha) {
       return { status: 'unknown', reason: 'Review has no stored head SHA' };
     }
@@ -1360,6 +1376,9 @@ ipcMain.handle(
 );
 
 async function fetchPrStatus(prUrl: string): Promise<PrStatus | null> {
+  // Local reviews have no CI, no reviewers, no mergeability — return null so
+  // callers that render PR status chrome simply show nothing.
+  if (isLocalUrl(prUrl)) return null;
   const token = getResolvedToken();
   if (!token) return null;
   const octokit = new Octokit({ auth: token });
@@ -1393,6 +1412,9 @@ async function fetchPrStatus(prUrl: string): Promise<PrStatus | null> {
 }
 
 ipcMain.handle('get-pr-status', async (_event, prUrl: string): Promise<PrStatus> => {
+  if (isLocalUrl(prUrl)) {
+    throw new Error('Local review — no PR status available');
+  }
   const status = await fetchPrStatus(prUrl);
   if (!status) throw new Error('Not authenticated');
   return status;
@@ -1401,6 +1423,13 @@ ipcMain.handle('get-pr-status', async (_event, prUrl: string): Promise<PrStatus>
 ipcMain.handle(
   'get-pr-state',
   async (_event, prUrl: string): Promise<{ prState: 'open' | 'merged' | 'closed'; headSha: string }> => {
+    if (isLocalUrl(prUrl)) {
+      // Local reviews are immutable — always report the commit range as open
+      // with the resolved head SHA.
+      const source = await createDiffSource(prUrl);
+      const meta = await source.getMetadata();
+      return { prState: 'open', headSha: meta.headSha };
+    }
     try {
       const token = getResolvedToken();
       const octokit = new Octokit({ auth: token ?? undefined });
@@ -1416,10 +1445,197 @@ ipcMain.handle(
 
 ipcMain.handle('get-pr-files', async (_event, prUrl: string): Promise<ChangedFile[]> => {
   const token = getResolvedToken();
-  const octokit = new Octokit({ auth: token ?? undefined });
-  const { owner, repo, pullNumber } = parsePrUrl(prUrl);
-  return getChangedFiles(octokit, owner, repo, pullNumber);
+  const source = await createDiffSource(prUrl, { token });
+  return source.getChangedFiles();
 });
+
+// ── Local git repo selection ────────────────────────────────────
+
+ipcMain.handle('pick-repo-dir', async (): Promise<string | null> => {
+  const windows = BrowserWindow.getAllWindows();
+  const win = BrowserWindow.getFocusedWindow() ?? (windows.length > 0 ? windows[0] : null);
+  const opts: Electron.OpenDialogOptions = {
+    title: 'Select a git repository',
+    buttonLabel: 'Select',
+    properties: ['openDirectory'],
+  };
+  const result = win
+    ? await dialog.showOpenDialog(win, opts)
+    : await dialog.showOpenDialog(opts);
+  if (result.canceled || result.filePaths.length === 0) return null;
+  return result.filePaths[0];
+});
+
+type ValidateLocalRepoResult =
+  | {
+      ok: true;
+      baseSha: string;
+      headSha: string;
+      /** Merge-base SHA of base & head — the fork point three-dot diff uses. */
+      mergeBase: string | null;
+      /** Changed file count in the three-dot diff. Surfaced so the reviewer
+       *  can spot a runaway diff (stale main, wrong base) before starting. */
+      changedFileCount: number;
+    }
+  | {
+      ok: false;
+      reason: 'not-a-repo' | 'same-refs' | 'unknown-ref' | 'other';
+      message: string;
+      /** For 'unknown-ref', which ref failed (the user-supplied string). */
+      ref?: string;
+    };
+
+interface LocalRepoRefs {
+  branches: string[];
+  tags: string[];
+  defaultBase: string | null;
+  defaultHead: string | null;
+  error?: string;
+}
+
+ipcMain.handle(
+  'list-repo-refs',
+  async (_event, repoPath: string): Promise<LocalRepoRefs> => {
+    const { execFile } = await import('child_process');
+    const { promisify } = await import('util');
+    const exec = promisify(execFile);
+    const run = async (args: string[]): Promise<string> => {
+      const { stdout } = await exec('git', args, { cwd: repoPath, maxBuffer: 16 * 1024 * 1024 });
+      return stdout;
+    };
+    try {
+      const [localOut, remoteOut, tagOut, headOut] = await Promise.all([
+        run(['for-each-ref', '--format=%(refname:short)', 'refs/heads']).catch(() => ''),
+        run(['for-each-ref', '--format=%(refname:short)', 'refs/remotes']).catch(() => ''),
+        run(['for-each-ref', '--format=%(refname:short)', 'refs/tags']).catch(() => ''),
+        run(['symbolic-ref', '--short', 'HEAD']).catch(() => ''),
+      ]);
+      const local = localOut.split('\n').filter(Boolean);
+      const remotes = remoteOut
+        .split('\n')
+        .filter(Boolean)
+        // Filter `origin/HEAD -> origin/main` rows.
+        .filter((b) => !b.endsWith('/HEAD'));
+      const tags = tagOut.split('\n').filter(Boolean);
+      const currentBranch = headOut.trim() || null;
+
+      // The default-base picker operates over the FULL list (local + all
+      // remotes, undeduped) so remote-tracking refs can win even when the
+      // user has a local branch of the same name. The display list is
+      // deduped separately below.
+      const allBranches = [...local, ...remotes];
+
+      // Pick a sensible default base — the branch we assume the user wants
+      // to compare *against*. Strategy, in order:
+      //   1. `origin/HEAD` (the remote's default branch) — the most reliable
+      //      signal for "what's main called here." Works for `main`, `master`,
+      //      `develop`, `trunk`, or anything custom.
+      //   2. Fall back to common names if origin/HEAD isn't set.
+      // Prefer remote-tracking refs over bare local branches — local `main`
+      // can be arbitrarily stale, `origin/main` follows upstream.
+      let defaultBase: string | null = null;
+      const remoteHeadOut = await run(['symbolic-ref', 'refs/remotes/origin/HEAD', '--short']).catch(() => '');
+      const remoteHead = remoteHeadOut.trim();
+      if (remoteHead && allBranches.includes(remoteHead)) {
+        defaultBase = remoteHead;
+      }
+      if (!defaultBase) {
+        const pick = (candidates: string[]) =>
+          candidates.find((c) => allBranches.includes(c)) ?? null;
+        defaultBase = pick([
+          'origin/main', 'origin/master', 'origin/develop', 'origin/trunk', 'origin/dev',
+          'main', 'master', 'develop', 'trunk', 'dev',
+        ]);
+      }
+
+      // De-dupe ONLY for the display list — if both `main` and `origin/main`
+      // exist, showing both in the autocomplete is noise.
+      const localSet = new Set(local);
+      const remotesFiltered = remotes.filter((r) => {
+        const short = r.split('/').slice(1).join('/');
+        return !localSet.has(short);
+      });
+      const branches = [...local, ...remotesFiltered];
+      // …but if the chosen default is a remote ref that got deduped out,
+      // re-add it so the input value has a matching datalist entry.
+      if (defaultBase && !branches.includes(defaultBase)) branches.unshift(defaultBase);
+      // If the user is already on the default branch, suggesting base=main,
+      // head=main would compare a branch against itself. Drop the default
+      // and let HEAD~1 stand — they probably want to review the latest commit.
+      if (currentBranch && defaultBase === currentBranch) defaultBase = null;
+
+      const defaultHead = currentBranch && branches.includes(currentBranch) ? currentBranch : null;
+      return { branches, tags, defaultBase, defaultHead };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { branches: [], tags: [], defaultBase: null, defaultHead: null, error: msg };
+    }
+  },
+);
+
+ipcMain.handle(
+  'validate-local-repo',
+  async (
+    _event,
+    repoPath: string,
+    baseRef: string,
+    headRef: string,
+  ): Promise<ValidateLocalRepoResult> => {
+    const { execFile } = await import('child_process');
+    const { promisify } = await import('util');
+    const exec = promisify(execFile);
+    const run = (args: string[]) =>
+      exec('git', args, { cwd: repoPath, maxBuffer: 16 * 1024 * 1024 });
+
+    // 1. Is this a git repo at all?
+    try {
+      await run(['rev-parse', '--git-dir']);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, reason: 'not-a-repo', message };
+    }
+
+    // 2. Resolve each ref individually so we can say which one failed.
+    const resolveOne = async (ref: string): Promise<string | null> => {
+      try {
+        const { stdout } = await run(['rev-parse', '--verify', `${ref}^{commit}`]);
+        return stdout.trim();
+      } catch {
+        return null;
+      }
+    };
+    const [baseSha, headSha] = await Promise.all([resolveOne(baseRef), resolveOne(headRef)]);
+    if (!baseSha) return { ok: false, reason: 'unknown-ref', message: `Couldn't find "${baseRef}"`, ref: baseRef };
+    if (!headSha) return { ok: false, reason: 'unknown-ref', message: `Couldn't find "${headRef}"`, ref: headRef };
+
+    // 3. Same ref on both sides → empty diff; catch it before the pipeline throws "no changed files".
+    if (baseSha === headSha) {
+      return { ok: false, reason: 'same-refs', message: 'Base and head point to the same commit.' };
+    }
+
+    // 4. Compute merge-base + changed-file count for the three-dot diff that
+    //    the pipeline will actually review. Surfacing this here lets the
+    //    dialog warn about runaway diffs (stale main → huge fork gap) before
+    //    the user kicks off generation.
+    let mergeBase: string | null = null;
+    try {
+      const { stdout } = await run(['merge-base', baseSha, headSha]);
+      mergeBase = stdout.trim() || null;
+    } catch {
+      // No merge-base (disjoint histories) — the three-dot diff would be
+      // effectively "everything." Let the user proceed but report it.
+    }
+    let changedFileCount = 0;
+    try {
+      const { stdout } = await run(['diff', '--name-only', `${baseSha}...${headSha}`]);
+      changedFileCount = stdout.split('\n').filter(Boolean).length;
+    } catch {
+      /* leave at 0; main pipeline will surface the real error */
+    }
+
+    return { ok: true, baseSha, headSha, mergeBase, changedFileCount };
+  },
+);
 
 // ── Background review generation ────────────────────────────────
 
@@ -1447,7 +1663,8 @@ function resolveDiffHunks(
 async function runBackgroundGeneration(
   reviewId: string,
   request: GenerateReviewRequest,
-  prData: Awaited<ReturnType<typeof getPrMetadata>>,
+  source: DiffSource,
+  prData: PrMetadata,
   signal: AbortSignal
 ): Promise<void> {
   const {
@@ -1465,21 +1682,32 @@ async function runBackgroundGeneration(
 
   try {
     const token = getResolvedToken();
-    const octokit = new Octokit({ auth: token ?? undefined });
-    const { owner, repo, pullNumber } = parsePrUrl(prUrl);
 
     broadcastToAllWindows('review-phase', { reviewId, phase: 'Fetching PR data' });
 
-    // Fetch changed files first so we can pass them to getPrDiff as fallback
-    const allChangedFiles = await getChangedFiles(octokit, owner, repo, pullNumber);
-    const diff = await getPrDiff(octokit, owner, repo, pullNumber, allChangedFiles);
+    // Surface non-fatal source-level warnings (e.g. dirty working tree on
+    // a local review). Fire-and-forget — never block the pipeline on this.
+    if (source.checkRuntimeWarnings) {
+      try {
+        const warnings = await source.checkRuntimeWarnings();
+        for (const phase of warnings) {
+          broadcastToAllWindows('review-phase', { reviewId, phase });
+        }
+      } catch {
+        // Warnings are best-effort.
+      }
+    }
+
+    // Fetch changed files first so we can pass them to getDiff as fallback
+    const allChangedFiles = await source.getChangedFiles();
+    const diff = await source.getDiff(allChangedFiles);
 
     // Fetch file metadata (age + churn) in the background while the
     // rest of the pipeline proceeds. We don't await it here — it
     // joins later when we assemble the ReviewGuide. This avoids
     // blocking the critical path (diff fetching, AI generation).
-    const fileMetadataPromise: Promise<FileMetadata[]> = getFileMetadata(
-      octokit, owner, repo, pullNumber, prData.baseSha, allChangedFiles
+    const fileMetadataPromise: Promise<FileMetadata[]> = source.getFileMetadata(
+      allChangedFiles
     ).catch((err: unknown) => {
       console.warn('[main] File metadata fetch failed, proceeding without:', err);
       return allChangedFiles.map((f) => ({
@@ -1513,9 +1741,6 @@ async function runBackgroundGeneration(
       );
     }
 
-    const baseRef = prData.baseBranch;
-    const headRef = prData.headSha;
-
     broadcastToAllWindows('review-phase', { reviewId, phase: 'Fetching file contents' });
 
     const fileContents: Record<string, string> = {};
@@ -1529,11 +1754,11 @@ async function runBackgroundGeneration(
       const baseBatch = filesToFetchBase.slice(i, i + concurrency);
       await Promise.all([
         ...headBatch.map(async (f) => {
-          const content = await getFileContent(octokit, owner, repo, f.filename, headRef);
+          const content = await source.getFileContent(f.filename, 'head');
           if (content !== null) headFileContents[f.filename] = content;
         }),
         ...baseBatch.map(async (f) => {
-          const content = await getFileContent(octokit, owner, repo, f.filename, baseRef);
+          const content = await source.getFileContent(f.filename, 'base');
           if (content !== null) fileContents[f.filename] = content;
         }),
       ]);
@@ -1546,16 +1771,15 @@ async function runBackgroundGeneration(
     // fetch — it hits `.claude/` and `CLAUDE.md` at head, which is
     // independent of the import graph we're walking in neighbours.
     const [neighborFiles, projectClaudeContext] = await Promise.all([
-      getNeighborFiles(
-        octokit,
-        owner,
-        repo,
+      source.getNeighborFiles(
         normalFiles.map((f) => f.filename),
         allFileContents,
-        baseRef,
-        smartImports ? provider : undefined
+        'base',
+        smartImports ? provider : undefined,
       ),
-      claudeContext ? getProjectClaudeContext(octokit, owner, repo, headRef) : Promise.resolve(null),
+      claudeContext
+        ? source.getProjectClaudeContext({ unfiltered: !!request.localTools })
+        : Promise.resolve(null),
     ]);
     if (projectClaudeContext) {
       const { commands, agents, skills, projectInstructionsBytes } = projectClaudeContext;
@@ -1599,6 +1823,21 @@ async function runBackgroundGeneration(
     const hunkMap = new Map(indexedHunks.map((h) => [h.id, h]));
     const assignedIds = new Set<string>();
 
+    // Local-tool mode: when the reviewer opted in on a local review, run the
+    // CLI with cwd = repo, stop writing the GitHub-specific MCP config, and
+    // allow a read-only + test tool set. The repo's own `.mcp.json` and
+    // `.claude/skills/` are auto-discovered from the cwd.
+    const localToolsOn = source.kind === 'local' && !!request.localTools && !!source.cwd;
+    if (localToolsOn) {
+      broadcastToAllWindows('review-phase', {
+        reviewId,
+        phase: 'Tool mode: project skills, MCP, and tests enabled',
+      });
+    }
+    const toolCwd = localToolsOn ? source.cwd : undefined;
+    const toolNonStrictMcp = localToolsOn;
+    const toolLocalAllowed = localToolsOn ? LOCAL_REVIEW_TOOLS : undefined;
+
     if (prefs.parallelReview) {
       // ── Two-phase: planner → parallel writers ──
       broadcastToAllWindows('review-phase', { reviewId, phase: 'Planning review structure' });
@@ -1612,6 +1851,7 @@ async function runBackgroundGeneration(
         (chunk, isThinking) => broadcastToAllWindows('review-progress', { reviewId, chunk, isThinking }),
         thinking ?? false,
         signal,
+        { cwd: toolCwd, allowedTools: toolLocalAllowed, nonStrictMcp: toolNonStrictMcp },
       );
 
       console.log(`[main] Planner produced ${plan.topics.length} topics`);
@@ -1644,6 +1884,9 @@ async function runBackgroundGeneration(
               thinking,
               educationMode,
               hasClaudeContext: !!projectClaudeContext,
+              cwd: toolCwd,
+              allowedTools: toolLocalAllowed,
+              nonStrictMcp: toolNonStrictMcp,
               onChunk: (chunk, isThinking) =>
                 broadcastToAllWindows('review-progress', { reviewId, chunk, isThinking }),
               signal,
@@ -1677,7 +1920,11 @@ async function runBackgroundGeneration(
 
       let mcpConfigPath: string | undefined;
       let allowedTools: string[] | undefined;
-      if (prefs.enableTools) {
+      if (localToolsOn) {
+        // Local-tool mode: the repo's own `.mcp.json` is discovered from cwd.
+        // Don't write a GitHub-specific MCP config.
+        allowedTools = LOCAL_REVIEW_TOOLS;
+      } else if (prefs.enableTools) {
         if (token) {
           mcpConfigPath = writeMcpConfig(token);
           allowedTools = ALLOWED_TOOLS;
@@ -1703,6 +1950,8 @@ async function runBackgroundGeneration(
           hasClaudeContext: !!projectClaudeContext,
           mcpConfigPath,
           allowedTools,
+          cwd: toolCwd,
+          nonStrictMcp: toolNonStrictMcp,
           onChunk: (chunk, isThinking) => {
             const phase = isThinking ? 'Thinking' : 'Generating review';
             if (phase !== lastStreamPhase) {
@@ -1895,11 +2144,10 @@ function formatMs(ms: number): string {
 
 ipcMain.handle('start-review', async (_event, request: GenerateReviewRequest): Promise<StartReviewResult> => {
   const token = getResolvedToken();
-  const octokit = new Octokit({ auth: token ?? undefined });
-  const { owner, repo, pullNumber } = parsePrUrl(request.prUrl);
+  const source = await createDiffSource(request.prUrl, { token });
 
-  // Fetch PR metadata (fast, single API call)
-  const prData = await getPrMetadata(octokit, owner, repo, pullNumber);
+  // Fetch PR metadata (fast, single API call / git command)
+  const prData = await source.getMetadata();
 
   const reviewId = crypto.randomUUID();
   const prState = prData.merged ? 'merged' : prData.state === 'open' ? 'open' : 'closed';
@@ -1921,7 +2169,7 @@ ipcMain.handle('start-review', async (_event, request: GenerateReviewRequest): P
   // Track and fire off background generation (no await)
   const abortController = new AbortController();
   activeGenerations.set(reviewId, { abortController, prUrl: request.prUrl });
-  void runBackgroundGeneration(reviewId, request, prData, abortController.signal);
+  void runBackgroundGeneration(reviewId, request, source, prData, abortController.signal);
 
   return {
     reviewId,
@@ -1981,6 +2229,9 @@ ipcMain.handle('send-slide-chat', async (_event, req: SendSlideChatRequest) => {
 });
 
 ipcMain.handle('submit-review', async (_event, req: SubmitReviewRequest) => {
+  if (isLocalUrl(req.prUrl)) {
+    throw new Error('Local reviews cannot be submitted back to GitHub — there is no remote PR to comment on.');
+  }
   const token = getResolvedToken();
   const octokit = new Octokit({ auth: token ?? undefined });
   const { owner, repo, pullNumber } = parsePrUrl(req.prUrl);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1006,6 +1006,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   proactiveThinking: false,
   educationMode: true,
   claudeContext: true,
+  guestMode: false,
 };
 
 function applyBinaryOverrides(prefs: Preferences): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,6 +63,17 @@ const GITHUB_CLIENT_SECRET: string = typeof __GH_CLIENT_SECRET__ !== 'undefined'
 const APTABASE_APP_KEY = 'A-EU-7599830434';
 let aptabaseInitialized = false;
 
+// Aptabase's Electron SDK requires initialize() to run BEFORE app.whenReady().
+// loadPreferences() only touches app.getPath('userData'), which is safe pre-ready.
+try {
+  if (loadPreferences().analytics) {
+    void initAptabase(APTABASE_APP_KEY);
+    aptabaseInitialized = true;
+  }
+} catch {
+  /* prefs unreadable — skip analytics */
+}
+
 function enableAnalyticsIfAllowed(prefs: Preferences): void {
   if (!prefs.analytics || aptabaseInitialized) return;
   void initAptabase(APTABASE_APP_KEY);

--- a/src/main.ts
+++ b/src/main.ts
@@ -655,6 +655,15 @@ function stopProactivePolling() {
 }
 
 // ── Auto-updater (Squirrel) ─────────────────────────────────────
+
+// Squirrel fires update-downloaded at most once per launch, and if the
+// download completes before the renderer has mounted its IPC listener,
+// the event is dropped. Cache the last-known ready version so a newly
+// mounted banner can pull it on startup.
+// GNOSIS_FAKE_UPDATE_READY=<version> surfaces the "ready to install" banner
+// in dev without needing a packaged build and Squirrel round-trip.
+let pendingUpdateReadyVersion: string | null = process.env.GNOSIS_FAKE_UPDATE_READY ?? null;
+
 function setupAutoUpdater() {
   if (!app.isPackaged) return;
   if (process.platform === 'linux') return;
@@ -667,10 +676,23 @@ function setupAutoUpdater() {
     return;
   }
 
+  autoUpdater.on('checking-for-update', () => {
+    console.log('[main] Auto-updater: checking for update');
+  });
+
+  autoUpdater.on('update-available', () => {
+    console.log('[main] Auto-updater: update available, downloading');
+  });
+
+  autoUpdater.on('update-not-available', () => {
+    console.log('[main] Auto-updater: no update available');
+  });
+
   autoUpdater.on('update-downloaded', (_event, _releaseNotes, releaseName) => {
     const version = releaseName.replace(/^v/, '');
     const label = version ? ` ${version}` : '';
     console.log(`[main] Update${label} downloaded, will install on exit`);
+    pendingUpdateReadyVersion = version;
     if (loadPreferences().notifications) {
       const notif = new Notification({
         title: 'A new update is ready to install',
@@ -1046,6 +1068,8 @@ const WEB_ONLY_TOOLS = ['WebFetch', 'WebSearch'];
 ipcMain.handle('dismiss-update', (_event, version: string) => {
   dismissedUpdateVersion = version;
 });
+
+ipcMain.handle('get-pending-update-ready', () => pendingUpdateReadyVersion);
 
 ipcMain.handle('open-external', (_event, url: string) => {
   try {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -12,6 +12,7 @@ import {
   GitMerge,
   GitPullRequest,
   GitPullRequestClosed,
+  GitCompare,
   AlertTriangle,
   Eraser,
   Share2,
@@ -131,6 +132,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [includeAllFiles, setIncludeAllFiles] = useState(true);
   const [prPickerOpen, setPrPickerOpen] = useState(false);
   const [localRepoOpen, setLocalRepoOpen] = useState(false);
+  const [guestMode, setGuestMode] = useState(false);
   const [filePickerOpen, setFilePickerOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [cliNotFound, setCliNotFound] = useState<{ provider: string } | null>(null);
@@ -270,8 +272,9 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       setEducationMode(prefs.educationMode);
       setClaudeContext(prefs.claudeContext);
       setIncludeAllFiles(prefs.includeAllFiles);
+      setGuestMode(prefs.guestMode);
       setPrefsLoaded(true);
-      if (!prefs.firstRunSeen) {
+      if (!prefs.firstRunSeen && !prefs.guestMode) {
         setRepoSetupOpen(true);
       }
     });
@@ -781,7 +784,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
         </div>
       )}
 
-      {authStatus === 'unauthenticated' && (
+      {authStatus === 'unauthenticated' && !guestMode && (
         <div className="newspaper">
           <header className="newspaper-masthead">
             <hr className="newspaper-rule--double" />
@@ -789,78 +792,112 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
             <p className="newspaper-tagline">Code Review, Narrated</p>
             <hr className="newspaper-rule--double" />
           </header>
-          <div className="max-w-md mx-auto w-full pt-8 flex flex-col gap-8">
+          <div className="max-w-[52ch] mx-auto w-full pt-8 flex flex-col gap-10">
             {authError && (
               <Alert variant="destructive">
                 <AlertDescription>{authError}</AlertDescription>
               </Alert>
             )}
-            <div className="flex flex-col gap-4 text-center">
-              <p className="newspaper-lede">
-                Sign in with your GitHub account to begin reading.
+
+            <p className="newspaper-lede">
+              Two ways in. Pick whichever fits the change you want to read.
+            </p>
+
+            {/* ── Path 1: GitHub ── */}
+            <section className="flex flex-col gap-3">
+              <h2 className="text-base font-semibold text-foreground">
+                With a GitHub account
+              </h2>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Sign in and Gnosis fetches pull request diffs, remembers your reviews,
+                and can submit comments back. Uses your account only to talk to
+                GitHub — nothing leaves your machine otherwise.
               </p>
-              <p className="slide-meta max-w-[52ch] mx-auto">
-                Gnosis uses your GitHub account to fetch pull request diffs, post review comments, and remember which
-                reviews are yours. Nothing leaves your machine besides the requests to GitHub.
-              </p>
-            </div>
-            <Button onClick={handleSignIn} className="w-full gap-2">
-              <GitHubIcon className="h-4 w-4" />
-              Sign in with GitHub
-            </Button>
-            <button
-              type="button"
-              className="slide-meta hover:text-foreground transition-colors flex items-center gap-1.5 self-center"
-              onClick={() => {
-                setPatExpanded((v) => !v);
-                setPatError(null);
-              }}
-            >
-              {patExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
-              Use a Personal Access Token instead
-            </button>
-            {patExpanded && (
-              <div className="border-l border-border pl-4 flex flex-col gap-3">
-                <p className="slide-meta">
-                  Create a token with <code className="font-mono">repo</code> scope at{' '}
-                  <button
-                    type="button"
-                    className="underline hover:text-foreground"
-                    onClick={() =>
-                      void window.electronAPI.openExternal(
-                        'https://github.com/settings/tokens/new?scopes=repo&description=Gnosis'
-                      )
-                    }
+              <Button onClick={handleSignIn} className="w-fit gap-2">
+                <GitHubIcon className="h-4 w-4" />
+                Sign in with GitHub
+              </Button>
+              <button
+                type="button"
+                className="slide-meta hover:text-foreground transition-colors flex items-center gap-1.5 self-start"
+                onClick={() => {
+                  setPatExpanded((v) => !v);
+                  setPatError(null);
+                }}
+              >
+                {patExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+                Use a Personal Access Token instead
+              </button>
+              {patExpanded && (
+                <div className="border-l border-border pl-4 flex flex-col gap-3 mt-1">
+                  <p className="slide-meta">
+                    Create a token with <code className="font-mono">repo</code> scope at{' '}
+                    <button
+                      type="button"
+                      className="underline hover:text-foreground"
+                      onClick={() =>
+                        void window.electronAPI.openExternal(
+                          'https://github.com/settings/tokens/new?scopes=repo&description=Gnosis'
+                        )
+                      }
+                    >
+                      github.com/settings/tokens
+                    </button>
+                    , then paste it below.
+                  </p>
+                  <input
+                    type="password"
+                    placeholder="ghp_…"
+                    value={patToken}
+                    onChange={(e) => setPatToken(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') void handleConnectPat();
+                    }}
+                    className="w-full bg-transparent border-0 border-b border-border px-0 py-2 text-sm placeholder:text-muted-foreground/60 transition-colors"
+                  />
+                  {patError && (
+                    <Alert variant="destructive">
+                      <AlertDescription>{patError}</AlertDescription>
+                    </Alert>
+                  )}
+                  <Button
+                    onClick={() => void handleConnectPat()}
+                    disabled={!patToken.trim() || patConnecting}
+                    className="w-fit"
+                    size="sm"
                   >
-                    github.com/settings/tokens
-                  </button>
-                  , then paste it below.
-                </p>
-                <input
-                  type="password"
-                  placeholder="ghp_…"
-                  value={patToken}
-                  onChange={(e) => setPatToken(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') void handleConnectPat();
-                  }}
-                  className="w-full bg-transparent border-0 border-b border-border px-0 py-2 text-sm placeholder:text-muted-foreground/60 transition-colors"
-                />
-                {patError && (
-                  <Alert variant="destructive">
-                    <AlertDescription>{patError}</AlertDescription>
-                  </Alert>
-                )}
-                <Button
-                  onClick={() => void handleConnectPat()}
-                  disabled={!patToken.trim() || patConnecting}
-                  className="w-full"
-                  size="sm"
-                >
-                  {patConnecting ? 'Connecting…' : 'Connect'}
-                </Button>
-              </div>
-            )}
+                    {patConnecting ? 'Connecting…' : 'Connect'}
+                  </Button>
+                </div>
+              )}
+            </section>
+
+            <div className="relative flex items-center gap-3 text-muted-foreground/60">
+              <span className="flex-1 h-px bg-border" />
+              <span className="slide-meta">or</span>
+              <span className="flex-1 h-px bg-border" />
+            </div>
+
+            {/* ── Path 2: Local git ── */}
+            <section className="flex flex-col gap-3">
+              <h2 className="text-base font-semibold text-foreground">
+                With any local git repository
+              </h2>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                No account needed. Point Gnosis at a folder on your machine and two
+                commits — a branch against <code className="font-mono">main</code>, a
+                tag against HEAD, any two refs. Works fully offline, and with the
+                repo's own Claude skills and MCP servers if you want them.
+              </p>
+              <Button
+                variant="outline"
+                onClick={() => setLocalRepoOpen(true)}
+                className="w-fit gap-2"
+              >
+                <GitCompare className="h-4 w-4" />
+                Review a local git diff
+              </Button>
+            </section>
           </div>
         </div>
       )}
@@ -879,7 +916,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
           story, dispatches sidebar, classified submission form,
           and a multi-column archives grid.
           ══════════════════════════════════════════════════════════ */}
-      {isAuthenticated && (
+      {(isAuthenticated || guestMode) && (
         <div className="newspaper">
           {/* ── Masthead ── */}
           <header className="newspaper-masthead">
@@ -888,18 +925,30 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
             <p className="newspaper-tagline">Code Review, Narrated</p>
             <p className="newspaper-dateline">
               No. {editionNumber} · {dateline} ·{' '}
-              <span className="inline-flex items-center gap-1.5">
-                <Avatar className="h-3.5 w-3.5 inline-block align-middle">
-                  <AvatarImage
-                    src={`https://github.com/${login}.png`}
-                    alt={login}
-                  />
-                  <AvatarFallback className="text-[8px]">
-                    {login.slice(0, 2).toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
-                @{login}
-              </span>
+              {isAuthenticated ? (
+                <span className="inline-flex items-center gap-1.5">
+                  <Avatar className="h-3.5 w-3.5 inline-block align-middle">
+                    <AvatarImage
+                      src={`https://github.com/${login}.png`}
+                      alt={login}
+                    />
+                    <AvatarFallback className="text-[8px]">
+                      {login.slice(0, 2).toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                  @{login}
+                </span>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleSignIn}
+                  className="inline-flex items-center gap-1 hover:text-foreground transition-colors"
+                  title="Connect a GitHub account to review pull requests"
+                >
+                  <GitHubIcon className="h-3 w-3" />
+                  Guest · connect GitHub
+                </button>
+              )}
             </p>
             <hr className="newspaper-rule--double" />
           </header>
@@ -1176,17 +1225,22 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
 
               {/* Alternative source pickers — framed as prose so they read
                   as options, not as primary actions competing with the
-                  Generate review button. */}
+                  Generate review button. Guest-mode users only see the
+                  local option; browsing PRs requires a GitHub account. */}
               <p className="slide-meta -mt-1">
                 or{' '}
-                <button
-                  type="button"
-                  onClick={() => setPrPickerOpen(true)}
-                  className="pb-0.5 border-b border-transparent hover:text-foreground hover:border-[var(--ring)] transition-colors"
-                >
-                  browse your pull requests
-                </button>
-                {' · '}
+                {isAuthenticated && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => setPrPickerOpen(true)}
+                      className="pb-0.5 border-b border-transparent hover:text-foreground hover:border-[var(--ring)] transition-colors"
+                    >
+                      browse your pull requests
+                    </button>
+                    {' · '}
+                  </>
+                )}
                 <button
                   type="button"
                   onClick={() => setLocalRepoOpen(true)}
@@ -1361,6 +1415,19 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
             open={localRepoOpen}
             onOpenChange={setLocalRepoOpen}
             onSubmit={(localUrl, { localTools }) => {
+              // Flip guestMode on first local review from the welcome gate
+              // so the rest of the app unlocks without forcing a GitHub
+              // sign-in. Persists so returning users skip the gate.
+              if (!guestMode && !isAuthenticated) {
+                setGuestMode(true);
+                void window.electronAPI.loadPreferences().then((current) => {
+                  void window.electronAPI.savePreferences({
+                    ...current,
+                    guestMode: true,
+                    firstRunSeen: true,
+                  });
+                });
+              }
               setPrUrl(localUrl);
               void startReviewForUrl(localUrl, { localTools });
             }}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -238,6 +238,10 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   useEffect(() => {
     window.electronAPI.onUpdateAvailable((info) => setUpdateInfo(info));
     window.electronAPI.onUpdateReady((version) => setReadyVersion(version));
+    // Squirrel often completes download before this effect mounts — replay.
+    void window.electronAPI.getPendingUpdateReady().then((v) => {
+      if (v) setReadyVersion((prev) => prev ?? v);
+    });
     return () => {
       window.electronAPI.offUpdateAvailable();
       window.electronAPI.offUpdateReady();
@@ -896,7 +900,9 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
               manual platforms show a download link. */}
           {(() => {
             const supportsAutoUpdate = window.electronAPI.platform !== 'linux' && window.electronAPI.isPackaged;
-            if (supportsAutoUpdate && readyVersion) {
+            // Dev: allow GNOSIS_FAKE_UPDATE_READY to surface the banner even when unpackaged.
+            const showReadyBanner = window.electronAPI.platform !== 'linux' && readyVersion;
+            if (showReadyBanner) {
               return (
                 <div className="newspaper-extra">
                   <span className="newspaper-extra-label">Extra</span>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -22,6 +22,7 @@ import { Button } from '../../components/ui/button';
 import { Alert, AlertDescription } from '../../components/ui/alert';
 import { Badge } from '../../components/ui/badge';
 import { PRPickerDialog } from '../../components/PRPickerDialog';
+import { LocalRepoDialog } from '../../components/LocalRepoDialog';
 import { FilePickerDialog } from '../../components/FilePickerDialog';
 import { SettingsDialog } from '../../components/SettingsDialog';
 import { ShortcutOverlay } from '../../components/ShortcutOverlay';
@@ -129,6 +130,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [history, setHistory] = useState<ReviewHistoryEntry[]>([]);
   const [includeAllFiles, setIncludeAllFiles] = useState(true);
   const [prPickerOpen, setPrPickerOpen] = useState(false);
+  const [localRepoOpen, setLocalRepoOpen] = useState(false);
   const [filePickerOpen, setFilePickerOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [cliNotFound, setCliNotFound] = useState<{ provider: string } | null>(null);
@@ -335,6 +337,13 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
         group: 'Actions',
         keywords: 'pr search find',
         perform: () => setPrPickerOpen(true),
+      },
+      {
+        id: 'local-repo',
+        label: 'Review a local git diff',
+        group: 'Actions',
+        keywords: 'local git diff branch commit offline',
+        perform: () => setLocalRepoOpen(true),
       },
       {
         id: 'settings',
@@ -602,7 +611,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
     setAuthStatus('unauthenticated');
   }
 
-  async function doStartReview(excludedFiles: string[], urlOverride?: string) {
+  async function doStartReview(excludedFiles: string[], urlOverride?: string, extra?: { localTools?: boolean }) {
     const targetUrl = (urlOverride ?? prUrl).trim();
     if (!targetUrl) return;
     setSubmitting(true);
@@ -619,6 +628,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
         educationMode,
         claudeContext,
         excludedFiles: excludedFiles.length > 0 ? excludedFiles : undefined,
+        localTools: extra?.localTools,
       });
       setGenerationStartTimes((prev) => new Map(prev).set(result.reviewId, Date.now()));
       const updated = await window.electronAPI.listReviews();
@@ -635,7 +645,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   // submit AND the inline "Generate review →" link in the suggested
   // section. The latter passes a URL directly so the review starts
   // without first writing to the input field.
-  async function startReviewForUrl(targetUrl: string) {
+  async function startReviewForUrl(targetUrl: string, extra?: { localTools?: boolean }) {
     if (!targetUrl.trim() || submitting) return;
     savePrefs();
     setError(null);
@@ -653,7 +663,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
       return;
     }
 
-    void doStartReview([], targetUrl);
+    void doStartReview([], targetUrl, extra);
   }
 
   async function handleSubmit(e: React.SyntheticEvent) {
@@ -1139,25 +1149,16 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
             </span>
             <form onSubmit={handleSubmit} className="flex flex-col gap-4">
               <div className="flex items-end gap-4 flex-wrap">
-                <div className="flex-1 min-w-[280px] flex items-end gap-3">
-                  <input
-                    ref={prInputRef}
-                    id="pr-url"
-                    type="url"
-                    placeholder="Paste a pull request URL — github.com/owner/repo/pull/123"
-                    value={prUrl}
-                    onChange={(e) => setPrUrl(e.target.value)}
-                    className="flex-1 bg-transparent border-0 border-b border-border px-0 py-2.5 text-base placeholder:text-muted-foreground/60 transition-colors"
-                    required
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setPrPickerOpen(true)}
-                    className="slide-meta hover:text-foreground transition-colors pb-2.5"
-                  >
-                    Browse
-                  </button>
-                </div>
+                <input
+                  ref={prInputRef}
+                  id="pr-url"
+                  type="text"
+                  placeholder="Paste a pull request URL — github.com/owner/repo/pull/123"
+                  value={prUrl}
+                  onChange={(e) => setPrUrl(e.target.value)}
+                  className="flex-1 min-w-[280px] bg-transparent border-0 border-b border-border px-0 py-2.5 text-base placeholder:text-muted-foreground/60 transition-colors"
+                  required
+                />
                 <Button type="submit" className="gap-2 px-6 py-2.5 h-auto" disabled={submitting}>
                   {submitting ? (
                     <>
@@ -1172,6 +1173,28 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                   )}
                 </Button>
               </div>
+
+              {/* Alternative source pickers — framed as prose so they read
+                  as options, not as primary actions competing with the
+                  Generate review button. */}
+              <p className="slide-meta -mt-1">
+                or{' '}
+                <button
+                  type="button"
+                  onClick={() => setPrPickerOpen(true)}
+                  className="pb-0.5 border-b border-transparent hover:text-foreground hover:border-[var(--ring)] transition-colors"
+                >
+                  browse your pull requests
+                </button>
+                {' · '}
+                <button
+                  type="button"
+                  onClick={() => setLocalRepoOpen(true)}
+                  className="pb-0.5 border-b border-transparent hover:text-foreground hover:border-[var(--ring)] transition-colors"
+                >
+                  review a local git diff
+                </button>
+              </p>
 
               {/* Options row */}
               <div className="flex items-center gap-6 slide-meta">
@@ -1334,6 +1357,14 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
 
           {/* Dialogs (unchanged — just mounted here) */}
           <PRPickerDialog open={prPickerOpen} onOpenChange={setPrPickerOpen} onSelect={setPrUrl} />
+          <LocalRepoDialog
+            open={localRepoOpen}
+            onOpenChange={setLocalRepoOpen}
+            onSubmit={(localUrl, { localTools }) => {
+              setPrUrl(localUrl);
+              void startReviewForUrl(localUrl, { localTools });
+            }}
+          />
           <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} onReplayOnboarding={replayOnboarding} />
           <FilePickerDialog
             open={filePickerOpen}

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -15,6 +15,7 @@ import { useReviewComments } from '../../lib/use-review-comments';
 import { useSlideChat } from '../../lib/use-slide-chat';
 import { useKeyboardShortcuts, type ShortcutMap } from '../../lib/use-keyboard-shortcuts';
 import { buildFileUrlBase } from '../../lib/github-url';
+import { isLocalUrl } from '../../lib/diffSource';
 import type {
   ReviewGuide,
   ReviewEvent,
@@ -233,7 +234,11 @@ export function ReviewPage({ review: initialReview, onBack, onReReview }: Props)
     void window.electronAPI.getAuthState().then((state) => setCurrentLogin(state.login));
   }, []);
 
+  const isLocal = isLocalUrl(review.prUrl);
+
   useEffect(() => {
+    // Local reviews have no remote PR to poll or describe — skip both calls.
+    if (isLocal) return;
     let cancelled = false;
     void window.electronAPI.checkPrFreshness(review.prUrl, review.headSha).then((result) => {
       if (!cancelled) setFreshness(result);
@@ -249,7 +254,7 @@ export function ReviewPage({ review: initialReview, onBack, onReReview }: Props)
     return () => {
       cancelled = true;
     };
-  }, [review.prUrl, review.headSha]);
+  }, [review.prUrl, review.headSha, isLocal]);
 
   const handlePrev = useCallback(() => {
     setCurrentSlide((n) => Math.max(0, n - 1));
@@ -592,18 +597,20 @@ export function ReviewPage({ review: initialReview, onBack, onReReview }: Props)
         onPrev={handlePrev}
         onNext={handleNext}
         commentCount={comments.length}
-        onSubmitReview={() => setShowSubmitDialog(true)}
+        onSubmitReview={isLocal ? undefined : () => setShowSubmitDialog(true)}
       />
 
-      <SubmitReviewDialog
-        open={showSubmitDialog}
-        onOpenChange={setShowSubmitDialog}
-        comments={comments}
-        prUrl={review.prUrl}
-        headSha={review.headSha}
-        isOwnPr={currentLogin !== null && currentLogin === review.author}
-        onSubmit={handleSubmitReview}
-      />
+      {!isLocal && (
+        <SubmitReviewDialog
+          open={showSubmitDialog}
+          onOpenChange={setShowSubmitDialog}
+          comments={comments}
+          prUrl={review.prUrl}
+          headSha={review.headSha}
+          isOwnPr={currentLogin !== null && currentLogin === review.author}
+          onSubmit={handleSubmitReview}
+        />
+      )}
 
       <SettingsDialog
         open={settingsOpen}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -142,6 +142,35 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getPrState: (prUrl: string): Promise<{ prState: 'open' | 'merged' | 'closed'; headSha: string }> =>
     ipcRenderer.invoke('get-pr-state', prUrl),
   getPrFiles: (prUrl: string): Promise<ChangedFile[]> => ipcRenderer.invoke('get-pr-files', prUrl),
+  pickRepoDir: (): Promise<string | null> => ipcRenderer.invoke('pick-repo-dir'),
+  listRepoRefs: (
+    repoPath: string,
+  ): Promise<{
+    branches: string[];
+    tags: string[];
+    defaultBase: string | null;
+    defaultHead: string | null;
+    error?: string;
+  }> => ipcRenderer.invoke('list-repo-refs', repoPath),
+  validateLocalRepo: (
+    repoPath: string,
+    baseRef: string,
+    headRef: string,
+  ): Promise<
+    | {
+        ok: true;
+        baseSha: string;
+        headSha: string;
+        mergeBase: string | null;
+        changedFileCount: number;
+      }
+    | {
+        ok: false;
+        reason: 'not-a-repo' | 'same-refs' | 'unknown-ref' | 'other';
+        message: string;
+        ref?: string;
+      }
+  > => ipcRenderer.invoke('validate-local-repo', repoPath, baseRef, headRef),
   platform: process.platform,
   isPackaged: process.env.APP_IS_PACKAGED === '1',
 });

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -119,6 +119,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.removeAllListeners('update-ready');
   },
   dismissUpdate: (version: string): Promise<void> => ipcRenderer.invoke('dismiss-update', version),
+  getPendingUpdateReady: (): Promise<string | null> => ipcRenderer.invoke('get-pending-update-ready'),
   openExternal: (url: string): Promise<void> => ipcRenderer.invoke('open-external', url),
   openLogsDirectory: (): Promise<void> => ipcRenderer.invoke('open-logs-directory'),
   openReviewPrompt: (id: string): Promise<void> => ipcRenderer.invoke('open-review-prompt', id),

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -75,6 +75,35 @@ declare global {
       markReviewRead: (id: string) => Promise<void>;
       getPrState: (prUrl: string) => Promise<{ prState: 'open' | 'merged' | 'closed'; headSha: string }>;
       getPrFiles: (prUrl: string) => Promise<ChangedFile[]>;
+      pickRepoDir: () => Promise<string | null>;
+      listRepoRefs: (
+        repoPath: string,
+      ) => Promise<{
+        branches: string[];
+        tags: string[];
+        defaultBase: string | null;
+        defaultHead: string | null;
+        error?: string;
+      }>;
+      validateLocalRepo: (
+        repoPath: string,
+        baseRef: string,
+        headRef: string,
+      ) => Promise<
+        | {
+            ok: true;
+            baseSha: string;
+            headSha: string;
+            mergeBase: string | null;
+            changedFileCount: number;
+          }
+        | {
+            ok: false;
+            reason: 'not-a-repo' | 'same-refs' | 'unknown-ref' | 'other';
+            message: string;
+            ref?: string;
+          }
+      >;
       platform: NodeJS.Platform;
       isPackaged: boolean;
     };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -62,6 +62,7 @@ declare global {
       onUpdateReady: (callback: (version: string) => void) => void;
       offUpdateReady: () => void;
       dismissUpdate: (version: string) => Promise<void>;
+      getPendingUpdateReady: () => Promise<string | null>;
       openExternal: (url: string) => Promise<void>;
       openLogsDirectory: () => Promise<void>;
       openReviewPrompt: (id: string) => Promise<void>;


### PR DESCRIPTION
## Summary

- Adds a `DiffSource` abstraction so the review pipeline runs against either a GitHub PR or a local git repository (any sha/branch/tag/`HEAD~n`, three-dot diff semantics matching GitHub's PR view).
- New `LocalRepoDialog` with repo picker, branch datalist, default base that prefers `origin/main` over stale local refs, live file-count preview, humanized validation errors, and last-used path recall.
- Optional **tool mode**: when the reviewer opts in, Claude runs with `cwd = repo` so it auto-discovers the project's own `.mcp.json`, `.claude/settings.json`, and skills. Read-only + test tools (`Bash`, `Read`, `Grep`, `Glob`) are allowed; `Edit`/`Write` stay off to protect the working tree. Project context is served unfiltered in this mode since the agent can reach every entry via tools anyway.
- Renderer + IPC gated: GitHub-only features (submit review, freshness poll, CI/review status, proactive watching) are hidden or return `{ supported: false }` for `local:` URLs.
- `PRSummaryBanner` shows the actual `base → head` range inline instead of an "Open on GitHub" link for local reviews.

## Test plan

- [ ] Paste a GitHub PR URL → review generates identically to before (no regressions on the GitHub path).
- [ ] Click **"review a local git diff"** under the URL input, pick a repo, accept defaults → review runs to completion.
- [ ] Validation errors: pick a non-repo directory, unknown ref, same base/head → each shows targeted recovery copy, no raw `git:` messages leak.
- [ ] Branch datalist populates both local + remote refs; default base resolves to `origin/main` (or whatever `origin/HEAD` points at) rather than stale local `main`.
- [ ] Live file-count preview warns (red copy) when the diff exceeds 500 files.
- [ ] Dirty working tree with `HEAD` as a ref → "Working tree has uncommitted changes" phase message appears.
- [ ] Enable **"Run project tools during review"**: confirm the CLI runs in the repo's cwd (check main-process logs), the repo's `.mcp.json` / skills are available, and the phase banner surfaces the tool-mode notice.
- [ ] Open a local review from history → submit-to-GitHub / CI / freshness UI stay hidden; banner shows `base → head`.
- [ ] `pnpm tsc --noEmit` clean; `pnpm eslint .` introduces zero new errors (pre-existing warnings on `src/main.ts` / `src/pages/HomePage.tsx` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)