### PR TITLE
Polish local-git welcome + guest-mode affordances

### DIFF
--- a/components/LocalRepoDialog.tsx
+++ b/components/LocalRepoDialog.tsx
@@ -344,7 +344,7 @@ export function LocalRepoDialog({ open, onOpenChange, onSubmit }: Props) {
                   Validating…
                 </>
               ) : (
-                'Begin review'
+                'Generate review'
               )}
             </Button>
           </DialogFooter>

--- a/components/PRSummaryBanner.tsx
+++ b/components/PRSummaryBanner.tsx
@@ -3,7 +3,7 @@ import { ExternalLink, ArrowLeft, Settings, GitBranch, Check } from 'lucide-reac
 import { GitHubIcon, riskConfig, safeConfigLookup } from '@/lib/constants';
 import type { ReviewGuide } from '@/lib/types';
 import { formatDuration } from '@/lib/utils';
-import { isLocalUrl } from '@/lib/diffSource';
+import { isLocalUrl } from '@/lib/local-url';
 
 interface Props {
   review: ReviewGuide;

--- a/components/PRSummaryBanner.tsx
+++ b/components/PRSummaryBanner.tsx
@@ -1,4 +1,5 @@
-import { ExternalLink, ArrowLeft, Settings, GitCompare } from 'lucide-react';
+import { useState } from 'react';
+import { ExternalLink, ArrowLeft, Settings, GitBranch, Check } from 'lucide-react';
 import { GitHubIcon, riskConfig, safeConfigLookup } from '@/lib/constants';
 import type { ReviewGuide } from '@/lib/types';
 import { formatDuration } from '@/lib/utils';
@@ -33,6 +34,17 @@ export function PRSummaryBanner({ review, onBack, onOpenSettings }: Props) {
   const risk = safeConfigLookup(riskConfig, review.riskLevel, riskConfig.low);
   const isLocal = isLocalUrl(review.prUrl);
   const localRange = isLocal ? parseLocalRange(review.prUrl) : null;
+  const [copied, setCopied] = useState(false);
+
+  async function copyLocalUrl() {
+    try {
+      await navigator.clipboard.writeText(review.prUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard denied — silently no-op, user can still read the tooltip */
+    }
+  }
 
   return (
     <header className="border-b border-border px-6 py-3">
@@ -71,11 +83,17 @@ export function PRSummaryBanner({ review, onBack, onOpenSettings }: Props) {
             </button>
           )}
           {isLocal ? (
-            <span
-              className="flex items-center gap-1.5 text-muted-foreground font-mono tabular-nums"
-              title={review.prUrl}
+            <button
+              type="button"
+              onClick={() => void copyLocalUrl()}
+              className="flex items-center gap-1.5 text-muted-foreground hover:text-foreground font-mono tabular-nums transition-colors"
+              title={copied ? 'Copied' : `Click to copy: ${review.prUrl}`}
             >
-              <GitCompare className="h-3.5 w-3.5" />
+              {copied ? (
+                <Check className="h-3.5 w-3.5" />
+              ) : (
+                <GitBranch className="h-3.5 w-3.5" />
+              )}
               {localRange ? (
                 <span className="truncate max-w-[28ch]">
                   {localRange.base} <span className="text-muted-foreground/60">→</span> {localRange.head}
@@ -83,7 +101,7 @@ export function PRSummaryBanner({ review, onBack, onOpenSettings }: Props) {
               ) : (
                 <span>Local</span>
               )}
-            </span>
+            </button>
           ) : (
             <a
               href={review.prUrl}

--- a/lib/diffSource.ts
+++ b/lib/diffSource.ts
@@ -5,6 +5,7 @@ import type {
   ProjectClaudeContext,
   Provider,
 } from './types';
+import { isLocalUrl } from './local-url';
 
 /**
  * Abstract source of diff + repo data for the review pipeline. Concrete
@@ -37,10 +38,6 @@ export interface DiffSource {
    *  on a local source). Returned strings are surfaced as review-phase
    *  warnings; an empty array means everything is clean. */
   checkRuntimeWarnings?(): Promise<string[]>;
-}
-
-export function isLocalUrl(url: string): boolean {
-  return url.startsWith('local:');
 }
 
 /**

--- a/lib/local-url.ts
+++ b/lib/local-url.ts
@@ -1,0 +1,7 @@
+// Tiny zero-dependency helper so renderer code can check for local-review
+// URLs without pulling `lib/localGit.ts` (and its Node-only `util.promisify`
+// / `child_process` imports) into the browser bundle graph.
+
+export function isLocalUrl(url: string): boolean {
+  return url.startsWith('local:');
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,8 +14,9 @@ import {
   getCiStatus,
   getReviewStatus,
 } from '../lib/github';
-import { createDiffSource, isLocalUrl } from '../lib/diffSource';
+import { createDiffSource } from '../lib/diffSource';
 import type { DiffSource } from '../lib/diffSource';
+import { isLocalUrl } from '../lib/local-url';
 import type { CiCheck, FileMetadata, PrMetadata, PrSearchResult, PrStatus } from '../lib/types';
 import { buildContextPackage, buildPlannerContext, buildTopicContext } from '../lib/context-builder';
 import { generateReviewGuide, planReview, generateSlide } from '../lib/agent';

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -800,12 +800,14 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
             )}
 
             <p className="newspaper-lede">
-              Two ways in. Pick whichever fits the change you want to read.
+              Gnosis turns a code diff into a guided, narrated walkthrough — slides
+              grouped by theme, a short narrative on every page. Two ways to point it
+              at one.
             </p>
 
             {/* ── Path 1: GitHub ── */}
             <section className="flex flex-col gap-3">
-              <h2 className="text-base font-semibold text-foreground">
+              <h2 className="editorial-heading">
                 With a GitHub account
               </h2>
               <p className="text-sm text-muted-foreground leading-relaxed">
@@ -872,15 +874,11 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
               )}
             </section>
 
-            <div className="relative flex items-center gap-3 text-muted-foreground/60">
-              <span className="flex-1 h-px bg-border" />
-              <span className="slide-meta">or</span>
-              <span className="flex-1 h-px bg-border" />
-            </div>
+            <hr className="newspaper-rule--thin" />
 
             {/* ── Path 2: Local git ── */}
             <section className="flex flex-col gap-3">
-              <h2 className="text-base font-semibold text-foreground">
+              <h2 className="editorial-heading">
                 With any local git repository
               </h2>
               <p className="text-sm text-muted-foreground leading-relaxed">
@@ -924,34 +922,48 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
             <h1>Gnosis</h1>
             <p className="newspaper-tagline">Code Review, Narrated</p>
             <p className="newspaper-dateline">
-              No. {editionNumber} · {dateline} ·{' '}
-              {isAuthenticated ? (
-                <span className="inline-flex items-center gap-1.5">
-                  <Avatar className="h-3.5 w-3.5 inline-block align-middle">
-                    <AvatarImage
-                      src={`https://github.com/${login}.png`}
-                      alt={login}
-                    />
-                    <AvatarFallback className="text-[8px]">
-                      {login.slice(0, 2).toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
-                  @{login}
-                </span>
-              ) : (
-                <button
-                  type="button"
-                  onClick={handleSignIn}
-                  className="inline-flex items-center gap-1 hover:text-foreground transition-colors"
-                  title="Connect a GitHub account to review pull requests"
-                >
-                  <GitHubIcon className="h-3 w-3" />
-                  Guest · connect GitHub
-                </button>
+              No. {editionNumber} · {dateline}
+              {isAuthenticated && (
+                <>
+                  {' · '}
+                  <span className="inline-flex items-center gap-1.5">
+                    <Avatar className="h-3.5 w-3.5 inline-block align-middle">
+                      <AvatarImage
+                        src={`https://github.com/${login}.png`}
+                        alt={login}
+                      />
+                      <AvatarFallback className="text-[8px]">
+                        {login.slice(0, 2).toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
+                    @{login}
+                  </span>
+                </>
               )}
             </p>
             <hr className="newspaper-rule--double" />
           </header>
+
+          {/* Guest-mode upgrade affordance. Reuses the same "Extra" strip
+              as the update-available banner so the visual grammar is
+              consistent — a thin, editorial notice between masthead and
+              content. Only shown to users without a connected GitHub
+              account; one click opens the sign-in flow. */}
+          {!isAuthenticated && guestMode && (
+            <div className="newspaper-extra">
+              <span className="newspaper-extra-label">Reading locally</span>
+              <span className="newspaper-extra-text">
+                Submitting reviews and watching PRs needs a GitHub account.
+              </span>
+              <button
+                type="button"
+                onClick={handleSignIn}
+                className="text-xs text-[var(--ring)] hover:underline transition-colors"
+              >
+                Connect GitHub →
+              </button>
+            </div>
+          )}
 
           {/* ── EXTRA: Update available ── Rendered as a newspaper
               "Extra" notice strip between the masthead and content.
@@ -1228,9 +1240,9 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                   Generate review button. Guest-mode users only see the
                   local option; browsing PRs requires a GitHub account. */}
               <p className="slide-meta -mt-1">
-                or{' '}
-                {isAuthenticated && (
+                {isAuthenticated ? (
                   <>
+                    or{' '}
                     <button
                       type="button"
                       onClick={() => setPrPickerOpen(true)}
@@ -1239,15 +1251,23 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
                       browse your pull requests
                     </button>
                     {' · '}
+                    <button
+                      type="button"
+                      onClick={() => setLocalRepoOpen(true)}
+                      className="pb-0.5 border-b border-transparent hover:text-foreground hover:border-[var(--ring)] transition-colors"
+                    >
+                      review a local git diff
+                    </button>
                   </>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setLocalRepoOpen(true)}
+                    className="pb-0.5 border-b border-transparent hover:text-foreground hover:border-[var(--ring)] transition-colors"
+                  >
+                    Review a local git diff instead
+                  </button>
                 )}
-                <button
-                  type="button"
-                  onClick={() => setLocalRepoOpen(true)}
-                  className="pb-0.5 border-b border-transparent hover:text-foreground hover:border-[var(--ring)] transition-colors"
-                >
-                  review a local git diff
-                </button>
               </p>
 
               {/* Options row */}

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -15,7 +15,7 @@ import { useReviewComments } from '../../lib/use-review-comments';
 import { useSlideChat } from '../../lib/use-slide-chat';
 import { useKeyboardShortcuts, type ShortcutMap } from '../../lib/use-keyboard-shortcuts';
 import { buildFileUrlBase } from '../../lib/github-url';
-import { isLocalUrl } from '../../lib/diffSource';
+import { isLocalUrl } from '../../lib/local-url';
 import type {
   ReviewGuide,
   ReviewEvent,


### PR DESCRIPTION
## Summary

Follow-up to #100 addressing the critique items from that merge. No functional changes — all copy, typography, and visual grammar polish.

- **Welcome identity sentence**: lede now describes what Gnosis *does* before the two-path prompt. A first-time visitor with no prior context previously had to infer the product from the two buttons alone.
- **Editorial typography**: path headings use `.editorial-heading` (Fraunces serif, weight 540) instead of generic `text-base font-semibold`, matching the register of slide titles and dialog headings elsewhere in the app.
- **Editorial rule divider**: the "or" between the two paths replaced with `.newspaper-rule--thin` — same grammar as the rest of the newspaper layout.
- **Guest upgrade visibility**: `Reading locally · Connect GitHub →` moved from a barely-visible dateline chip into its own `.newspaper-extra` strip, the same treatment as the update-available banner. Users who'd accept an upgrade can now actually see the offer.
- **Compose-form sentence fix**: guests no longer see a dangling `or` with no preceding alternative.
- **PRSummaryBanner click-to-copy**: the local `base → head` chip is now a real button that copies the synthetic `local:…` URL (handy for sharing `.gr` archives). `GitCompare` icon swapped for `GitBranch` — truer semantics for a ref range. Success state shows a checkmark for 1.5s.
- **Voice consistency**: `Begin review` → `Generate review` on the dialog submit to match the main compose form.

## Test plan

- [ ] Open the app signed out → welcome screen shows the new identity sentence + serif headings + thin rule between sections.
- [ ] Click "Review a local git diff" → review a repo → return home → new `.newspaper-extra` "Reading locally" strip is visible between masthead and content.
- [ ] Click "Connect GitHub →" on that strip → existing sign-in flow opens.
- [ ] On the local review page, click the `base → head` chip → URL copies to clipboard, icon flips to checkmark for 1.5s.
- [ ] Signed-in experience: no regressions on welcome, masthead, or ReviewPage banner.
- [ ] `pnpm tsc --noEmit` clean; no new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)