### PR TITLE
Copy every check from a review as one agent prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It runs locally and uses the [Claude Code CLI](https://claude.ai/code) under the
 ## Features
 
 - **Guided slideshow** — changes are grouped by theme and ordered by dependency (foundations first, then implementations, then tests and config), not by filename
-- **Claude-native** — pick between Claude Opus 4.7, Sonnet 4.6, and Haiku 4.5
+- **Claude-native** — pick between Claude Fable 5, Opus 5, Sonnet 5, and Haiku 4.5
 - **Extended thinking** — enable deeper reasoning (slower, more thorough)
 - **Custom instructions** — steer the review with free-text prompts (e.g. _focus on security_, _explain the auth flow_)
 - **Inline review comments** — add comments on specific diff lines and submit directly to GitHub as an approval, request for changes, or comment

--- a/components/CopyAllChecksButton.tsx
+++ b/components/CopyAllChecksButton.tsx
@@ -1,0 +1,61 @@
+import { useMemo, useState } from 'react';
+import { Check, ClipboardList } from 'lucide-react';
+import { buildAllChecksPrompt } from '@/lib/all-checks-prompt';
+import type { ReviewGuide } from '@/lib/types';
+
+interface Props {
+  review: ReviewGuide;
+  /** "compact" = icon-only with a tooltip (top bar). "full" = icon + label
+   *  (overview page). The two surfaces have different density budgets so
+   *  one component covers both with a presentation flag. */
+  variant?: 'compact' | 'full';
+  className?: string;
+}
+
+export function CopyAllChecksButton({ review, variant = 'compact', className = '' }: Props) {
+  // Recompute when slides change (e.g. after re-render with new review).
+  const { prompt, count } = useMemo(() => buildAllChecksPrompt(review), [review]);
+  const [copied, setCopied] = useState(false);
+
+  // No checks anywhere → hide the affordance entirely. A grey-disabled
+  // button just adds noise.
+  if (count === 0) return null;
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    void navigator.clipboard.writeText(prompt).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  if (variant === 'compact') {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        title={copied ? 'Copied' : `Copy all ${count} check${count === 1 ? '' : 's'} as an agent prompt`}
+        aria-label={copied ? 'Copied' : `Copy all ${count} checks as an agent prompt`}
+        className={`hover:text-foreground transition-colors ${className}`}
+      >
+        {copied ? <Check className="h-3.5 w-3.5" /> : <ClipboardList className="h-3.5 w-3.5" />}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`group flex items-baseline gap-3 text-left ${className}`}
+    >
+      <span className="slide-meta flex items-center gap-1.5">
+        {copied ? <Check className="h-3 w-3" /> : <ClipboardList className="h-3 w-3" />}
+        {copied ? 'Copied' : 'Pass to an agent'}
+      </span>
+      <span className="font-serif text-lg text-foreground group-hover:opacity-80 transition-opacity">
+        Copy all {count} check{count === 1 ? '' : 's'} as one prompt →
+      </span>
+    </button>
+  );
+}

--- a/components/CopyAllChecksButton.tsx
+++ b/components/CopyAllChecksButton.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useState } from 'react';
-import { Check, ClipboardList } from 'lucide-react';
+import { useMemo } from 'react';
+import { Check, ClipboardList, ClipboardX } from 'lucide-react';
 import { buildAllChecksPrompt } from '@/lib/all-checks-prompt';
+import { useCopyToClipboard } from '@/lib/use-copy';
 import type { ReviewGuide } from '@/lib/types';
 
 interface Props {
@@ -15,7 +16,7 @@ interface Props {
 export function CopyAllChecksButton({ review, variant = 'compact', className = '' }: Props) {
   // Recompute when slides change (e.g. after re-render with new review).
   const { prompt, count } = useMemo(() => buildAllChecksPrompt(review), [review]);
-  const [copied, setCopied] = useState(false);
+  const { state, copy } = useCopyToClipboard();
 
   // No checks anywhere → hide the affordance entirely. A grey-disabled
   // button just adds noise.
@@ -23,22 +24,36 @@ export function CopyAllChecksButton({ review, variant = 'compact', className = '
 
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    void navigator.clipboard.writeText(prompt).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
+    copy(prompt);
   };
+
+  // One label string reused for title + aria-label so the tooltip and
+  // the screen-reader announcement can't disagree.
+  const label =
+    state === 'copied'
+      ? 'Copied'
+      : state === 'failed'
+        ? 'Copy failed — click to retry'
+        : `Copy all ${count} check${count === 1 ? '' : 's'} as an agent prompt`;
+  const icon =
+    state === 'copied' ? (
+      <Check className="h-3.5 w-3.5" />
+    ) : state === 'failed' ? (
+      <ClipboardX className="h-3.5 w-3.5 text-destructive" />
+    ) : (
+      <ClipboardList className="h-3.5 w-3.5" />
+    );
 
   if (variant === 'compact') {
     return (
       <button
         type="button"
         onClick={handleClick}
-        title={copied ? 'Copied' : `Copy all ${count} check${count === 1 ? '' : 's'} as an agent prompt`}
-        aria-label={copied ? 'Copied' : `Copy all ${count} checks as an agent prompt`}
+        title={label}
+        aria-label={label}
         className={`hover:text-foreground transition-colors ${className}`}
       >
-        {copied ? <Check className="h-3.5 w-3.5" /> : <ClipboardList className="h-3.5 w-3.5" />}
+        {icon}
       </button>
     );
   }
@@ -47,11 +62,18 @@ export function CopyAllChecksButton({ review, variant = 'compact', className = '
     <button
       type="button"
       onClick={handleClick}
+      aria-label={label}
       className={`group flex items-baseline gap-3 text-left ${className}`}
     >
       <span className="slide-meta flex items-center gap-1.5">
-        {copied ? <Check className="h-3 w-3" /> : <ClipboardList className="h-3 w-3" />}
-        {copied ? 'Copied' : 'Pass to an agent'}
+        {state === 'copied' ? (
+          <Check className="h-3 w-3" />
+        ) : state === 'failed' ? (
+          <ClipboardX className="h-3 w-3 text-destructive" />
+        ) : (
+          <ClipboardList className="h-3 w-3" />
+        )}
+        {state === 'copied' ? 'Copied' : state === 'failed' ? 'Copy failed' : 'Pass to an agent'}
       </span>
       <span className="font-serif text-lg text-foreground group-hover:opacity-80 transition-opacity">
         Copy all {count} check{count === 1 ? '' : 's'} as one prompt →

--- a/components/OverviewSlide.tsx
+++ b/components/OverviewSlide.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import type { ReactNode } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { Markdown } from '@/components/Markdown';
+import { CopyAllChecksButton } from '@/components/CopyAllChecksButton';
 import { riskConfig, safeConfigLookup } from '@/lib/constants';
 import type { PrStatus, ProjectClaudeContext, ReviewGuide } from '@/lib/types';
 
@@ -284,7 +285,7 @@ export function OverviewSlide({ review, prStatus, onNavigate }: Props) {
             without noticing the bottom bar. */}
         {firstSlide && (
           <section
-            className="animate-fade-in-up pt-6 mt-2 border-t border-border"
+            className="animate-fade-in-up pt-6 mt-2 border-t border-border flex flex-col gap-3"
             style={{ animationDelay: '240ms' }}
           >
             <button
@@ -296,6 +297,11 @@ export function OverviewSlide({ review, prStatus, onNavigate }: Props) {
                 {firstSlide.slideNumber.toString().padStart(2, '0')} — {firstSlide.title} →
               </span>
             </button>
+            {/* Bulk-copy escape hatch — pulls every "what to check" item into
+                one agent prompt for reviewers who'd rather hand the whole
+                investigation to Claude/Cursor in one shot. Hides itself when
+                the review has zero checks. */}
+            <CopyAllChecksButton review={review} variant="full" />
           </section>
         )}
 

--- a/components/PRSummaryBanner.tsx
+++ b/components/PRSummaryBanner.tsx
@@ -3,6 +3,7 @@ import { GitHubIcon, riskConfig, safeConfigLookup } from '@/lib/constants';
 import type { ReviewGuide } from '@/lib/types';
 import { formatDuration } from '@/lib/utils';
 import { isLocalUrl } from '@/lib/local-url';
+import { CopyAllChecksButton } from '@/components/CopyAllChecksButton';
 
 interface Props {
   review: ReviewGuide;
@@ -61,6 +62,7 @@ export function PRSummaryBanner({ review, onBack, onOpenSettings }: Props) {
           </span>
           <span>{review.totalLinesChanged} lines</span>
           {review.generationDurationMs != null && <span>{formatDuration(review.generationDurationMs)}</span>}
+          <CopyAllChecksButton review={review} variant="compact" />
           {onOpenSettings && (
             <button
               onClick={onOpenSettings}

--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -3,17 +3,13 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } f
 import { CODE_THEMES, CODE_FONTS } from '@/lib/constants';
 import type { CodeTheme, CodeFont } from '@/lib/constants';
 import { applyTheme, type ThemeChoice } from '@/lib/theme';
+import { CLAUDE_MODELS, DEFAULT_FAST_CLAUDE_MODEL } from '@/lib/models';
 import type { ModelId, Preferences, Provider, RepoSearchResult } from '@/lib/types';
 
-const PROVIDER_MODELS: Record<Provider, { label: string; models: { id: ModelId; label: string }[] }> = {
+const PROVIDER_MODELS: Record<Provider, { label: string; models: typeof CLAUDE_MODELS }> = {
   claude: {
     label: 'Claude',
-    models: [
-      { id: 'claude-fable-5', label: 'Fable 5' },
-      { id: 'claude-opus-5', label: 'Opus 5' },
-      { id: 'claude-sonnet-5', label: 'Sonnet 5' },
-      { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
-    ],
+    models: CLAUDE_MODELS,
   },
 };
 
@@ -136,7 +132,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
   const [claudeContext, setClaudeContext] = useState(true);
   const [analytics, setAnalytics] = useState(true);
   const [proactiveReviewOverrides, setProactiveReviewOverrides] = useState(false);
-  const [proactiveModel, setProactiveModel] = useState<ModelId>('claude-sonnet-5');
+  const [proactiveModel, setProactiveModel] = useState<ModelId>(DEFAULT_FAST_CLAUDE_MODEL);
   const [proactiveThinking, setProactiveThinking] = useState(false);
   const [claudePath, setClaudePath] = useState('');
   const [claudeDetected, setClaudeDetected] = useState('');

--- a/components/SlideView.tsx
+++ b/components/SlideView.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { Group as PanelGroup, Panel, Separator as PanelResizeHandle } from 'react-resizable-panels';
-import { Check, Copy, MessageCircle, MessageSquarePlus } from 'lucide-react';
+import { Check, Copy, CopyX, MessageCircle, MessageSquarePlus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { DiffHunkGroup } from '@/components/DiffHunk';
 import { InteractiveDiffHunkGroup } from '@/components/InteractiveDiffHunk';
@@ -10,6 +10,14 @@ import { FilePathLink } from '@/components/FilePathLink';
 import { Markdown } from '@/components/Markdown';
 import { MermaidDiagram } from '@/components/MermaidDiagram';
 import { slideTypeConfig, safeConfigLookup } from '@/lib/constants';
+import {
+  buildAgentPrompt,
+  buildAnchorableSet,
+  isAnchorable,
+  looksLikePackedList,
+  splitIntoProseChecks,
+} from '@/lib/review-checks';
+import { useCopyToClipboard } from '@/lib/use-copy';
 import type { CommentCallbacks } from '@/components/shared-diff-utils';
 import type { Slide, DiffHunk, FileMetadata, PendingReviewComment, Preferences, ReviewCheck } from '@/lib/types';
 
@@ -48,121 +56,44 @@ function formatFileAge(lastModified: string | null | undefined): string | null {
   return null; // modified today — not worth showing
 }
 
-// Build the set of `{filePath}:{newFileLine}` + `{filePath}:{oldFileLine}`
-// keys that any review check could resolve to inside this slide's
-// hunks. Used to pre-filter clickable anchors at render time so the
-// callout never shows a link that would silently do nothing. Parses
-// hunk headers directly (`@@ -baseStart,baseCount +headStart,headCount @@`)
-// rather than walking rendered lines — much cheaper.
-function buildAnchorableSet(hunks: DiffHunk[]): Set<string> {
-  const keys = new Set<string>();
-  for (const hunk of hunks) {
-    const m = hunk.hunkHeader.match(/@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
-    if (!m) continue;
-    const baseStart = parseInt(m[1], 10);
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- regex optional groups can be undefined at runtime
-    const baseCount = m[2] !== undefined ? parseInt(m[2], 10) : 1;
-    const headStart = parseInt(m[3], 10);
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- regex optional groups can be undefined at runtime
-    const headCount = m[4] !== undefined ? parseInt(m[4], 10) : 1;
-    for (let i = 0; i < headCount; i++) keys.add(`${hunk.filePath}:${headStart + i}`);
-    for (let i = 0; i < baseCount; i++) keys.add(`${hunk.filePath}:${baseStart + i}`);
-  }
-  return keys;
-}
-
-// A loose heuristic for "this single string is actually multiple
-// bullets jammed together". The model sometimes returns one long
-// reviewFocus or one single reviewCheck that contains its own
-// markdown list. If that happens, we want to render it as a list
-// instead of a wall of text.
-function looksLikePackedList(text: string): boolean {
-  // Markdown bullets on their own line.
-  if (/\n\s*[-*]\s+/.test(text)) return true;
-  // Numbered list items on their own line.
-  if (/\n\s*\d+[.)]\s+/.test(text)) return true;
-  return false;
-}
-
-// Try to split a prose check into its constituent sentences so a
-// model-emitted "one giant check with three topics" renders as
-// bullets instead of a paragraph. Splits on sentence terminators
-// (`.`, `?`, `!`) followed by whitespace then a capital letter or
-// a backtick (next sentence starts with an identifier). Only returns
-// multiple segments when each is a reasonable bullet length — under
-// 20 chars is probably noise, over 500 is a tell the split picked
-// the wrong boundary.
-function splitIntoProseChecks(text: string): string[] {
-  if (!text) return [];
-  const trimmed = text.trim();
-  const parts = trimmed.split(/(?<=[.?!])\s+(?=[A-Z`])/).map((s) => s.trim()).filter(Boolean);
-  if (parts.length < 2) return [trimmed];
-  if (parts.some((p) => p.length < 20 || p.length > 500)) return [trimmed];
-  return parts;
-}
-
 // Inline click affordance for a single anchored check — dotted
 // underline in brand claret so it reads as a quiet link.
 const clickableCheckClass =
   'cursor-pointer underline decoration-dotted decoration-[var(--ring)]/50 underline-offset-4 hover:decoration-[var(--ring)]';
 
-// Turn a review check into a ready-to-paste agent prompt. The agent
-// gets the bare question plus enough pointers to find the code, so
-// the user can paste into Claude Code / Cursor / similar and have it
-// investigate without further explanation.
-function buildAgentPrompt(
-  text: string,
-  slideTitle: string,
-  prUrl: string,
-  filePath?: string | null,
-  startLine?: number | null
-): string {
-  const lines = [
-    'Please investigate this code-review check against the PR and report whether the concern is valid, unclear, or handled.',
-    '',
-    `Check: ${text.trim()}`,
-    '',
-    `Slide: ${slideTitle}`,
-    `PR: ${prUrl}`,
-  ];
-  if (filePath) {
-    lines.push(`Location: ${filePath}${startLine ? `:${startLine}` : ''}`);
-  }
-  return lines.join('\n');
-}
-
 // Small icon button that copies the given text to clipboard and
-// flips to a check mark for ~1.4s as confirmation. Title attribute
-// doubles as the tooltip. Visible but quiet — brightens on hover
-// and focus-visible for keyboard users.
+// flips to a check mark (or an error mark when the clipboard write
+// fails) for ~1.5s as confirmation. Title attribute doubles as the
+// tooltip. Visible but quiet — brightens on hover and focus-visible
+// for keyboard users.
 function CopyPromptButton({ prompt, className = '' }: { prompt: string; className?: string }) {
-  const [copied, setCopied] = useState(false);
+  const { state, copy } = useCopyToClipboard();
+  const label =
+    state === 'copied'
+      ? 'Copied'
+      : state === 'failed'
+        ? 'Copy failed — click to retry'
+        : 'Copy as agent prompt';
   return (
     <button
       type="button"
       onClick={(e) => {
         e.stopPropagation();
-        void navigator.clipboard.writeText(prompt).then(() => {
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1400);
-        });
+        copy(prompt);
       }}
-      title={copied ? 'Copied.' : 'Copy as agent prompt'}
-      aria-label={copied ? 'Copied' : 'Copy as agent prompt'}
+      title={label}
+      aria-label={label}
       className={`inline-flex items-center shrink-0 text-muted-foreground/70 hover:text-foreground focus-visible:text-foreground transition-colors align-middle ${className}`}
     >
-      {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+      {state === 'copied' ? (
+        <Check className="h-3 w-3" />
+      ) : state === 'failed' ? (
+        <CopyX className="h-3 w-3 text-destructive" />
+      ) : (
+        <Copy className="h-3 w-3" />
+      )}
     </button>
   );
-}
-
-// A check is only rendered as a clickable anchor when the
-// `{filePath, line}` actually resolves to a line inside this slide's
-// hunks. Prevents silent no-op clicks on hallucinated or out-of-slide
-// anchors. `anchorable` is the pre-built set from buildAnchorableSet.
-function isAnchorable(check: ReviewCheck, anchorable: Set<string>): boolean {
-  if (!check.filePath || check.startLine == null || check.startLine <= 0) return false;
-  return anchorable.has(`${check.filePath}:${check.startLine}`);
 }
 
 // djb2 — a tiny, stable string hash. Used as the trailing segment of
@@ -259,7 +190,11 @@ function renderReviewChecks(
                     {check.text}
                   </span>
                 )}
-                {copyFor(check.text, check.filePath, check.startLine)}
+                {copyFor(
+                  check.text,
+                  isClickable ? check.filePath : null,
+                  isClickable ? check.startLine : null
+                )}
               </li>
             );
           })}
@@ -299,7 +234,11 @@ function renderReviewChecks(
                     <Markdown className="review-focus-markdown">{sentence}</Markdown>
                   </span>
                 )}
-                {copyFor(sentence, check.filePath, check.startLine)}
+                {copyFor(
+                  sentence,
+                  isClickable ? check.filePath : null,
+                  isClickable ? check.startLine : null
+                )}
               </li>
             ))}
           </ul>
@@ -322,7 +261,11 @@ function renderReviewChecks(
                 <Markdown className="review-focus-markdown">{check.text}</Markdown>
               </span>
             )}
-            {copyFor(check.text, check.filePath, check.startLine)}
+            {copyFor(
+              check.text,
+              isClickable ? check.filePath : null,
+              isClickable ? check.startLine : null
+            )}
           </div>
         </>
       );
@@ -341,7 +284,11 @@ function renderReviewChecks(
             </span>
           )}
         </span>
-        {copyFor(check.text, check.filePath, check.startLine)}
+        {copyFor(
+          check.text,
+          isClickable ? check.filePath : null,
+          isClickable ? check.startLine : null
+        )}
       </p>
     );
   }

--- a/lib/all-checks-prompt.ts
+++ b/lib/all-checks-prompt.ts
@@ -1,0 +1,56 @@
+import type { ReviewGuide } from './types';
+
+interface AllChecksSummary {
+  /** Multi-section markdown prompt ready to paste into an agent. */
+  prompt: string;
+  /** Total check count across the review — for the button label and the
+   *  zero-check guard so we don't render an empty affordance. */
+  count: number;
+}
+
+/**
+ * Walk every slide and concatenate the "What to check" items into a single
+ * agent prompt. Each section names the slide so the agent can group its
+ * findings the same way; anchored checks include `file:line` hints so it
+ * doesn't need to grep around to locate them.
+ *
+ * Slides without any checks are skipped silently — they'd just be visual
+ * noise in the prompt. Returns `count: 0` when the review has no checks
+ * anywhere; callers should hide the affordance in that case.
+ */
+export function buildAllChecksPrompt(review: ReviewGuide): AllChecksSummary {
+  const sections: string[] = [];
+  let count = 0;
+
+  for (const slide of review.slides) {
+    const checks = slide.reviewChecks ?? [];
+    if (checks.length === 0) continue;
+
+    const slideHeader = `## ${slide.slideNumber.toString().padStart(2, '0')} — ${slide.title}`;
+    const items = checks.map((c) => {
+      const anchor = c.filePath
+        ? ` _(${c.filePath}${c.startLine ? `:${c.startLine}` : ''})_`
+        : '';
+      return `- ${c.text.trim()}${anchor}`;
+    });
+    sections.push([slideHeader, ...items].join('\n'));
+    count += checks.length;
+  }
+
+  if (count === 0) {
+    return { prompt: '', count: 0 };
+  }
+
+  const intro = [
+    `You are investigating a code review of: **${review.prTitle}**`,
+    '',
+    `Source: ${review.prUrl}`,
+    '',
+    `Below is the full set of "what to check" items the reviewer surfaced — ${count} check${count === 1 ? '' : 's'} across ${sections.length} slide${sections.length === 1 ? '' : 's'}. For each one, investigate against the code and report whether the concern is **valid**, **handled**, or **unclear**, with file:line evidence. Group your response by slide so it's easy to map findings back to the review.`,
+    '',
+    '---',
+    '',
+  ].join('\n');
+
+  return { prompt: intro + sections.join('\n\n'), count };
+}

--- a/lib/all-checks-prompt.ts
+++ b/lib/all-checks-prompt.ts
@@ -1,18 +1,27 @@
+import { deriveSlideChecks, formatReviewSource } from './review-checks';
 import type { ReviewGuide } from './types';
 
 interface AllChecksSummary {
   /** Multi-section markdown prompt ready to paste into an agent. */
   prompt: string;
   /** Total check count across the review — for the button label and the
-   *  zero-check guard so we don't render an empty affordance. */
+   *  zero-check guard so we don't render an empty affordance. Counts the
+   *  same bullets SlideView renders (post prose-splitting, reviewFocus
+   *  fallback included), so the label always matches the UI. */
   count: number;
 }
 
 /**
  * Walk every slide and concatenate the "What to check" items into a single
  * agent prompt. Each section names the slide so the agent can group its
- * findings the same way; anchored checks include `file:line` hints so it
- * doesn't need to grep around to locate them.
+ * findings the same way; checks whose anchors resolve into the slide's
+ * hunks include `file:line` hints so it doesn't need to grep around to
+ * locate them (unresolvable anchors are dropped rather than passed on as
+ * wrong hints).
+ *
+ * Check derivation is shared with SlideView (see lib/review-checks.ts):
+ * structured reviewChecks when present, otherwise the reviewFocus prose
+ * fallback, with the same packed-list splitting either way.
  *
  * Slides without any checks are skipped silently — they'd just be visual
  * noise in the prompt. Returns `count: 0` when the review has no checks
@@ -23,7 +32,7 @@ export function buildAllChecksPrompt(review: ReviewGuide): AllChecksSummary {
   let count = 0;
 
   for (const slide of review.slides) {
-    const checks = slide.reviewChecks ?? [];
+    const checks = deriveSlideChecks(slide);
     if (checks.length === 0) continue;
 
     const slideHeader = `## ${slide.slideNumber.toString().padStart(2, '0')} — ${slide.title}`;
@@ -31,7 +40,7 @@ export function buildAllChecksPrompt(review: ReviewGuide): AllChecksSummary {
       const anchor = c.filePath
         ? ` _(${c.filePath}${c.startLine ? `:${c.startLine}` : ''})_`
         : '';
-      return `- ${c.text.trim()}${anchor}`;
+      return `- ${c.text}${anchor}`;
     });
     sections.push([slideHeader, ...items].join('\n'));
     count += checks.length;
@@ -44,7 +53,7 @@ export function buildAllChecksPrompt(review: ReviewGuide): AllChecksSummary {
   const intro = [
     `You are investigating a code review of: **${review.prTitle}**`,
     '',
-    `Source: ${review.prUrl}`,
+    `Source: ${formatReviewSource(review.prUrl)}`,
     '',
     `Below is the full set of "what to check" items the reviewer surfaced — ${count} check${count === 1 ? '' : 's'} across ${sections.length} slide${sections.length === 1 ? '' : 's'}. For each one, investigate against the code and report whether the concern is **valid**, **handled**, or **unclear**, with file:line evidence. Group your response by slide so it's easy to map findings back to the review.`,
     '',

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,0 +1,37 @@
+// Single source of truth for the Claude model roster. The picker UIs
+// (HomePage, SettingsDialog), the provider (`--model` passed to the
+// CLI), the `ClaudeModel` union, and the stored-preference migration
+// all derive from the tables here — a roster change is one edit in
+// this file. No React imports: this module is shared by the renderer
+// and the Electron main process.
+
+export const CLAUDE_MODELS = [
+  { id: 'claude-fable-5', label: 'Fable 5', quick: false },
+  { id: 'claude-opus-5', label: 'Opus 5', quick: false },
+  { id: 'claude-sonnet-5', label: 'Sonnet 5', quick: false },
+  { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', quick: true },
+] as const;
+
+export type ClaudeModel = (typeof CLAUDE_MODELS)[number]['id'];
+
+/** Default for manual reviews and the general model preference. */
+export const DEFAULT_CLAUDE_MODEL: ClaudeModel = 'claude-opus-5';
+/** Default for background/proactive reviews and slide chat — fast and cheap. */
+export const DEFAULT_FAST_CLAUDE_MODEL: ClaudeModel = 'claude-sonnet-5';
+
+export function isClaudeModel(id: string): id is ClaudeModel {
+  return CLAUDE_MODELS.some((m) => m.id === id);
+}
+
+/**
+ * Models we used to offer. One entry per retirement: `label` keeps old
+ * review-history rows readable, `successor` drives the stored-preference
+ * migration in loadPreferences. Stored ids that appear in neither table
+ * fall back to the defaults there, so a missed entry degrades to the
+ * default model instead of passing a retired id to the CLI.
+ */
+export const RETIRED_CLAUDE_MODELS: Record<string, { label: string; successor: ClaudeModel }> = {
+  'claude-opus-4-6': { label: 'Claude Opus 4.6', successor: 'claude-opus-5' },
+  'claude-opus-4-7': { label: 'Claude Opus 4.7', successor: 'claude-opus-5' },
+  'claude-sonnet-4-6': { label: 'Claude Sonnet 4.6', successor: 'claude-sonnet-5' },
+};

--- a/lib/providers/claude.ts
+++ b/lib/providers/claude.ts
@@ -1,4 +1,5 @@
 import os from 'os';
+import { CLAUDE_MODELS } from '../models';
 import type { LLMProvider } from '../provider';
 import { resolveBinaryPath, spawnCliStreaming, spawnCliQuick } from './shared';
 
@@ -17,12 +18,7 @@ function makeClaudeEnv(thinking: boolean): NodeJS.ProcessEnv {
 
 export const claudeProvider: LLMProvider = {
   name: 'claude',
-  models: [
-    { id: 'claude-fable-5', label: 'Fable 5' },
-    { id: 'claude-opus-5', label: 'Opus 5' },
-    { id: 'claude-sonnet-5', label: 'Sonnet 5' },
-    { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', quick: true },
-  ],
+  models: [...CLAUDE_MODELS],
 
   async generate({ content, systemPrompt, model, thinking, onChunk, onToolUse, mcpConfigPath, allowedTools, cwd, nonStrictMcp, signal }) {
     const claudePath = resolveClaudePath();

--- a/lib/review-checks.ts
+++ b/lib/review-checks.ts
@@ -1,0 +1,152 @@
+import type { DiffHunk, ReviewCheck, Slide } from './types';
+
+// Shared "what to check" logic. SlideView renders checks and the
+// all-checks prompt serializes them; both must agree on how a slide's
+// checks are derived (structured vs reviewFocus fallback, prose
+// splitting, anchor validation) or the copied prompt drifts from what
+// the reviewer sees on screen. Keep every rule here, import from both.
+
+// A loose heuristic for "this single string is actually multiple
+// bullets jammed together". The model sometimes returns one long
+// reviewFocus or one single reviewCheck that contains its own
+// markdown list. If that happens, we want to render it as a list
+// instead of a wall of text.
+export function looksLikePackedList(text: string): boolean {
+  // Markdown bullets on their own line.
+  if (/\n\s*[-*]\s+/.test(text)) return true;
+  // Numbered list items on their own line.
+  if (/\n\s*\d+[.)]\s+/.test(text)) return true;
+  return false;
+}
+
+// Try to split a prose check into its constituent sentences so a
+// model-emitted "one giant check with three topics" renders as
+// bullets instead of a paragraph. Splits on sentence terminators
+// (`.`, `?`, `!`) followed by whitespace then a capital letter or
+// a backtick (next sentence starts with an identifier). Only returns
+// multiple segments when each is a reasonable bullet length — under
+// 20 chars is probably noise, over 500 is a tell the split picked
+// the wrong boundary.
+export function splitIntoProseChecks(text: string): string[] {
+  if (!text) return [];
+  const trimmed = text.trim();
+  const parts = trimmed.split(/(?<=[.?!])\s+(?=[A-Z`])/).map((s) => s.trim()).filter(Boolean);
+  if (parts.length < 2) return [trimmed];
+  if (parts.some((p) => p.length < 20 || p.length > 500)) return [trimmed];
+  return parts;
+}
+
+// Build the set of `{filePath}:{newFileLine}` + `{filePath}:{oldFileLine}`
+// keys that any review check could resolve to inside this slide's
+// hunks. Used to pre-filter anchors so neither surface presents a
+// `file:line` that doesn't exist in the slide's diff. Parses
+// hunk headers directly (`@@ -baseStart,baseCount +headStart,headCount @@`)
+// rather than walking rendered lines — much cheaper.
+export function buildAnchorableSet(hunks: DiffHunk[]): Set<string> {
+  const keys = new Set<string>();
+  for (const hunk of hunks) {
+    const m = hunk.hunkHeader.match(/@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+    if (!m) continue;
+    const baseStart = parseInt(m[1], 10);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- regex optional groups can be undefined at runtime
+    const baseCount = m[2] !== undefined ? parseInt(m[2], 10) : 1;
+    const headStart = parseInt(m[3], 10);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- regex optional groups can be undefined at runtime
+    const headCount = m[4] !== undefined ? parseInt(m[4], 10) : 1;
+    for (let i = 0; i < headCount; i++) keys.add(`${hunk.filePath}:${headStart + i}`);
+    for (let i = 0; i < baseCount; i++) keys.add(`${hunk.filePath}:${baseStart + i}`);
+  }
+  return keys;
+}
+
+// A check's anchor only counts when the `{filePath, line}` actually
+// resolves to a line inside this slide's hunks. Prevents silent no-op
+// clicks (SlideView) and wrong-location hints in agent prompts on
+// hallucinated or out-of-slide anchors.
+export function isAnchorable(check: ReviewCheck, anchorable: Set<string>): boolean {
+  if (!check.filePath || check.startLine == null || check.startLine <= 0) return false;
+  return anchorable.has(`${check.filePath}:${check.startLine}`);
+}
+
+/** One flattened "What to check" bullet, anchor already validated. */
+export interface DerivedCheck {
+  text: string;
+  filePath?: string | null;
+  startLine?: number | null;
+}
+
+/**
+ * Flatten a slide's "What to check" content into the same bullets
+ * SlideView renders: structured reviewChecks when present, prose-split
+ * when a single check or the reviewFocus fallback packs several topics
+ * into one string. Anchors are included only when they resolve into the
+ * slide's own hunks.
+ */
+export function deriveSlideChecks(slide: Slide): DerivedCheck[] {
+  const anchorable = buildAnchorableSet(slide.diffHunks);
+  const anchorFor = (check: ReviewCheck): Partial<DerivedCheck> =>
+    isAnchorable(check, anchorable) ? { filePath: check.filePath, startLine: check.startLine } : {};
+
+  const checks = slide.reviewChecks ?? [];
+  if (checks.length > 1) {
+    return checks.map((c) => ({ text: c.text.trim(), ...anchorFor(c) }));
+  }
+  if (checks.length === 1) {
+    const check = checks[0];
+    const split =
+      looksLikePackedList(check.text) || check.text.length > 180
+        ? splitIntoProseChecks(check.text)
+        : [check.text];
+    return split.map((text) => ({ text: text.trim(), ...anchorFor(check) }));
+  }
+
+  // Fallback: reviewFocus prose, same splitting rules, never anchored.
+  const focus = (slide.reviewFocus ?? '').trim();
+  if (!focus) return [];
+  const split =
+    looksLikePackedList(focus) || focus.length > 180 ? splitIntoProseChecks(focus) : [focus];
+  return split.map((text) => ({ text: text.trim() }));
+}
+
+/**
+ * Human/agent-readable form of `review.prUrl`. GitHub URLs pass
+ * through; the internal `local:/abs/path#base..head` pseudo-URL for
+ * local-repo reviews (see lib/localGit.ts) is rewritten so an agent
+ * gets a usable repo path + ref range instead of a fake URL.
+ */
+export function formatReviewSource(prUrl: string): string {
+  if (!prUrl.startsWith('local:')) return prUrl;
+  const hashIdx = prUrl.lastIndexOf('#');
+  const repoPath = hashIdx === -1 ? prUrl.slice('local:'.length) : prUrl.slice('local:'.length, hashIdx);
+  const range = hashIdx === -1 ? '' : prUrl.slice(hashIdx + 1);
+  return range
+    ? `local repository at ${repoPath} (diff ${range})`
+    : `local repository at ${repoPath}`;
+}
+
+// Turn a review check into a ready-to-paste agent prompt. The agent
+// gets the bare question plus enough pointers to find the code, so
+// the user can paste into Claude Code / Cursor / similar and have it
+// investigate without further explanation. The verdict vocabulary
+// (valid / handled / unclear) is shared with buildAllChecksPrompt so
+// per-check and bulk copies ask for the same thing.
+export function buildAgentPrompt(
+  text: string,
+  slideTitle: string,
+  prUrl: string,
+  filePath?: string | null,
+  startLine?: number | null
+): string {
+  const lines = [
+    'Please investigate this code-review check against the change and report whether the concern is valid, handled, or unclear, with file:line evidence.',
+    '',
+    `Check: ${text.trim()}`,
+    '',
+    `Slide: ${slideTitle}`,
+    `Source: ${formatReviewSource(prUrl)}`,
+  ];
+  if (filePath) {
+    lines.push(`Location: ${filePath}${startLine ? `:${startLine}` : ''}`);
+  }
+  return lines.join('\n');
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,5 @@
+import type { ClaudeModel } from './models';
+
 export type SlideType = 'foundation' | 'feature' | 'refactor' | 'bugfix' | 'test' | 'config' | 'docs';
 
 export interface CiCheck {
@@ -237,7 +239,7 @@ export interface StartReviewResult {
 
 export type Provider = 'claude';
 
-export type ClaudeModel = 'claude-fable-5' | 'claude-opus-5' | 'claude-sonnet-5' | 'claude-haiku-4-5-20251001';
+export type { ClaudeModel };
 
 export type ModelId = ClaudeModel;
 

--- a/lib/use-copy.ts
+++ b/lib/use-copy.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type CopyState = 'idle' | 'copied' | 'failed';
+
+/**
+ * Clipboard write with a transient confirmation state, shared by every
+ * copy affordance. Handles the two failure modes a bare
+ * `writeText().then(...)` misses: the promise rejecting (in Electron,
+ * NotAllowedError when the window loses focus — surfaced as `failed`
+ * instead of silently doing nothing), and the reset timer outliving the
+ * component or a rapid re-click (cleared on unmount and before each
+ * re-arm, so state can't flicker or setState after unmount).
+ */
+export function useCopyToClipboard(resetMs = 1500): {
+  state: CopyState;
+  copy: (text: string) => void;
+} {
+  const [state, setState] = useState<CopyState>('idle');
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    []
+  );
+
+  const flash = useCallback(
+    (next: CopyState) => {
+      setState(next);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => setState('idle'), resetMs);
+    },
+    [resetMs]
+  );
+
+  const copy = useCallback(
+    (text: string) => {
+      navigator.clipboard.writeText(text).then(
+        () => flash('copied'),
+        () => flash('failed')
+      );
+    },
+    [flash]
+  );
+
+  return { state, copy };
+}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -126,7 +126,7 @@ const sections: Section[] = [
       {
         label: 'Claude-native',
         body:
-          'Claude Opus 4.7, Sonnet 4.6, or Haiku 4.5. Switch per review, or set different defaults for manual vs. proactive runs. Extended thinking available when the diff warrants it.',
+          'Claude Fable 5, Opus 5, Sonnet 5, or Haiku 4.5. Switch per review, or set different defaults for manual vs. proactive runs. Extended thinking available when the diff warrants it.',
       },
       {
         label: 'Smart context curation',

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,12 @@ import { createDiffSource } from '../lib/diffSource';
 import type { DiffSource } from '../lib/diffSource';
 import { isLocalUrl } from '../lib/local-url';
 import type { CiCheck, FileMetadata, PrMetadata, PrSearchResult, PrStatus } from '../lib/types';
+import {
+  DEFAULT_CLAUDE_MODEL,
+  DEFAULT_FAST_CLAUDE_MODEL,
+  RETIRED_CLAUDE_MODELS,
+  isClaudeModel,
+} from '../lib/models';
 import { buildContextPackage, buildPlannerContext, buildTopicContext } from '../lib/context-builder';
 import { generateReviewGuide, planReview, generateSlide } from '../lib/agent';
 import { buildArchive, parseArchive } from '../lib/review-archive';
@@ -980,7 +986,7 @@ function getPreferencesPath() {
 const DEFAULT_PREFERENCES: Preferences = {
   instructions: '',
   provider: 'claude',
-  model: 'claude-opus-5',
+  model: DEFAULT_CLAUDE_MODEL,
   thinking: true,
   smartImports: true,
   reviewSuggestions: true,
@@ -1003,7 +1009,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   analytics: true,
   proactiveReviewOverrides: false,
   proactiveProvider: 'claude',
-  proactiveModel: 'claude-sonnet-5',
+  proactiveModel: DEFAULT_FAST_CLAUDE_MODEL,
   proactiveThinking: false,
   educationMode: true,
   claudeContext: true,
@@ -1022,29 +1028,22 @@ function loadPreferences(): Preferences {
       stored.proactiveMode = stored.autoReviewOnRequest;
       delete stored.autoReviewOnRequest;
     }
-    // Migrate stored prefs from retired/superseded models to their successors.
-    const MODEL_MIGRATIONS: Record<string, string> = {
-      'claude-opus-4-6': 'claude-opus-5',
-      'claude-opus-4-7': 'claude-opus-5',
-      'claude-sonnet-4-6': 'claude-sonnet-5',
-    };
+    // Normalize stored model ids against the roster: retired models map
+    // to their successor, and anything else unknown (gemini leftovers,
+    // hand-edited prefs, a model retired without a table entry) falls
+    // back to the default rather than reaching the CLI as `--model`.
     for (const key of ['model', 'proactiveModel'] as const) {
       const value = stored[key];
-      if (typeof value === 'string' && MODEL_MIGRATIONS[value]) {
-        stored[key] = MODEL_MIGRATIONS[value];
-      }
+      if (typeof value !== 'string' || isClaudeModel(value)) continue;
+      stored[key] = Object.prototype.hasOwnProperty.call(RETIRED_CLAUDE_MODELS, value)
+        ? RETIRED_CLAUDE_MODELS[value].successor
+        : DEFAULT_PREFERENCES[key];
     }
     // Drop Gemini settings from stored prefs of users who previously
-    // selected it — provider reverts to claude, model falls back to
-    // the default, the orphaned geminiPath string is discarded.
+    // selected it — provider reverts to claude, the orphaned geminiPath
+    // string is discarded (models are covered by the normalization above).
     if (stored.provider === 'gemini') stored.provider = 'claude';
-    if (typeof stored.model === 'string' && stored.model.startsWith('gemini')) {
-      stored.model = DEFAULT_PREFERENCES.model;
-    }
     if (stored.proactiveProvider === 'gemini') stored.proactiveProvider = 'claude';
-    if (typeof stored.proactiveModel === 'string' && stored.proactiveModel.startsWith('gemini')) {
-      stored.proactiveModel = DEFAULT_PREFERENCES.proactiveModel;
-    }
     delete stored.geminiPath;
     return { ...DEFAULT_PREFERENCES, ...(stored as Partial<Preferences>) };
   } catch {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -33,6 +33,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../componen
 import { OnboardingRepoSetup } from '../../components/OnboardingRepoSetup';
 import { Avatar, AvatarFallback, AvatarImage } from '../../components/ui/avatar';
 import { riskConfig, safeConfigLookup } from '../../lib/constants';
+import { CLAUDE_MODELS, DEFAULT_CLAUDE_MODEL, RETIRED_CLAUDE_MODELS } from '../../lib/models';
 import type { ModelId, Preferences, Provider, PrSearchResult, ReviewGuide, ReviewHistoryEntry, UpdateInfo } from '../../lib/types';
 import { timeAgo, formatDuration, formatBytes, groupReviewsByPR } from '../../lib/utils';
 
@@ -46,25 +47,16 @@ type AuthStatus = 'checking' | 'unauthenticated' | 'signing-in' | { login: strin
 const PROVIDERS = {
   claude: {
     label: 'Claude',
-    models: [
-      { id: 'claude-fable-5', label: 'Fable 5' },
-      { id: 'claude-opus-5', label: 'Opus 5' },
-      { id: 'claude-sonnet-5', label: 'Sonnet 5' },
-      { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
-    ],
+    models: CLAUDE_MODELS,
   },
 } as const;
 
-// Labels for models no longer offered in the picker, so old history entries
-// still render a friendly name instead of the raw ID.
-const LEGACY_MODEL_LABELS: Record<string, string> = {
-  'claude-opus-4-6': 'Claude Opus 4.6',
-  'claude-opus-4-7': 'Claude Opus 4.7',
-  'claude-sonnet-4-6': 'Claude Sonnet 4.6',
-};
-
+// Current roster labels plus retired-model labels, so old history
+// entries still render a friendly name instead of the raw ID.
 const MODEL_LABELS: Record<string, string> = {
-  ...LEGACY_MODEL_LABELS,
+  ...Object.fromEntries(
+    Object.entries(RETIRED_CLAUDE_MODELS).map(([id, m]) => [id, m.label])
+  ),
   ...Object.fromEntries(
     Object.values(PROVIDERS).flatMap((p) => p.models.map((m) => [m.id, `${p.label} ${m.label}`]))
   ),
@@ -128,7 +120,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [authStatus, setAuthStatus] = useState<AuthStatus>('checking');
   const [prUrl, setPrUrl] = useState(prefillPrUrl ?? '');
   const [provider, setProvider] = useState<Provider>('claude');
-  const [model, setModel] = useState<ModelId>('claude-opus-5');
+  const [model, setModel] = useState<ModelId>(DEFAULT_CLAUDE_MODEL);
   const [thinking, setThinking] = useState(true);
   const [smartImports, setSmartImports] = useState(true);
   const [reviewSuggestions, setReviewSuggestions] = useState(true);

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -25,6 +25,7 @@ import type {
   Provider,
   ModelId,
 } from '../../lib/types';
+import { DEFAULT_FAST_CLAUDE_MODEL } from '../../lib/models';
 
 interface Props {
   review: ReviewGuide;
@@ -92,7 +93,7 @@ export function ReviewPage({ review: initialReview, onBack, onReReview }: Props)
   const [chatOpen, setChatOpen] = useState(false);
   const [chatQuotedCode, setChatQuotedCode] = useState<string | null>(null);
   const [chatProvider, setChatProvider] = useState<Provider>('claude');
-  const [chatModel, setChatModel] = useState<ModelId>('claude-sonnet-5');
+  const [chatModel, setChatModel] = useState<ModelId>(DEFAULT_FAST_CLAUDE_MODEL);
   const [diffLayout, setDiffLayout] = useState<Preferences['diffLayout']>('unified');
   const [slideViewMode, setSlideViewMode] = useState<'split' | 'focus'>('split');
   const [prefs, setPrefs] = useState<Preferences | null>(null);


### PR DESCRIPTION
## Summary

Reviewers who want to hand a whole investigation off to Claude / Cursor in one shot can now grab every "what to check" item across every slide as a single multi-section markdown prompt. Each section names its slide so the agent's findings map back cleanly; anchored checks include `file:line` hints so the agent doesn't have to grep around to locate them.

Two surfaces:

- **Overview page** — _"Pass to an agent · Copy all N checks as one prompt →"_ sits directly under _Start reading_, in the same visual register so the two primary post-overview actions live together.
- **Top bar** — compact icon-only button next to the Settings cog. Reachable from any slide without navigating back to the overview.

The button hides itself when the review has zero checks anywhere — an empty affordance is just visual noise. Same checkmark-confirm pattern as the existing per-check copy buttons.

Pure renderer change — no IPC, no main-process work, no new dependencies. Generated prompt format:

```
You are investigating a code review of: **<PR title>**

Source: <prUrl>

Below is the full set of "what to check" items the reviewer surfaced — N checks across M slides. For each one, investigate against the code and report whether the concern is **valid**, **handled**, or **unclear**, with file:line evidence. Group your response by slide so it's easy to map findings back to the review.

---

## 01 — <slide title>
- <check> _(file.ts:42)_
- <check>

## 02 — <slide title>
- <check>
```

## Test plan

- [ ] Open a review with multiple checks → overview shows _Pass to an agent_ row under _Start reading_.
- [ ] Click it → clipboard contains the full multi-section markdown prompt; button shows checkmark for ~1.5s.
- [ ] Navigate to a slide → top bar has a `ClipboardList` icon next to the Settings cog. Hover shows _"Copy all N checks as an agent prompt"_.
- [ ] Open a review where no slide has `reviewChecks` → both buttons are absent.
- [ ] Anchored vs unanchored checks: the prompt shows the `_(file:line)_` suffix only for anchored ones.
- [ ] `pnpm tsc --noEmit` clean; no new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)