### PR TITLE
feat: support the latest Claude models (Fable 5, Opus 5, Sonnet 5)

### DIFF
--- a/components/SettingsDialog.tsx
+++ b/components/SettingsDialog.tsx
@@ -9,8 +9,9 @@ const PROVIDER_MODELS: Record<Provider, { label: string; models: { id: ModelId; 
   claude: {
     label: 'Claude',
     models: [
-      { id: 'claude-opus-4-7', label: 'Opus 4.7' },
-      { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+      { id: 'claude-fable-5', label: 'Fable 5' },
+      { id: 'claude-opus-5', label: 'Opus 5' },
+      { id: 'claude-sonnet-5', label: 'Sonnet 5' },
       { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
     ],
   },
@@ -135,7 +136,7 @@ export function SettingsDialog({ open, onOpenChange, onThemeChange, onReplayOnbo
   const [claudeContext, setClaudeContext] = useState(true);
   const [analytics, setAnalytics] = useState(true);
   const [proactiveReviewOverrides, setProactiveReviewOverrides] = useState(false);
-  const [proactiveModel, setProactiveModel] = useState<ModelId>('claude-sonnet-4-6');
+  const [proactiveModel, setProactiveModel] = useState<ModelId>('claude-sonnet-5');
   const [proactiveThinking, setProactiveThinking] = useState(false);
   const [claudePath, setClaudePath] = useState('');
   const [claudeDetected, setClaudeDetected] = useState('');

--- a/lib/providers/claude.ts
+++ b/lib/providers/claude.ts
@@ -18,8 +18,9 @@ function makeClaudeEnv(thinking: boolean): NodeJS.ProcessEnv {
 export const claudeProvider: LLMProvider = {
   name: 'claude',
   models: [
-    { id: 'claude-opus-4-7', label: 'Opus 4.7' },
-    { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+    { id: 'claude-fable-5', label: 'Fable 5' },
+    { id: 'claude-opus-5', label: 'Opus 5' },
+    { id: 'claude-sonnet-5', label: 'Sonnet 5' },
     { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5', quick: true },
   ],
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -237,7 +237,7 @@ export interface StartReviewResult {
 
 export type Provider = 'claude';
 
-export type ClaudeModel = 'claude-opus-4-7' | 'claude-sonnet-4-6' | 'claude-haiku-4-5-20251001';
+export type ClaudeModel = 'claude-fable-5' | 'claude-opus-5' | 'claude-sonnet-5' | 'claude-haiku-4-5-20251001';
 
 export type ModelId = ClaudeModel;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -980,7 +980,7 @@ function getPreferencesPath() {
 const DEFAULT_PREFERENCES: Preferences = {
   instructions: '',
   provider: 'claude',
-  model: 'claude-opus-4-7',
+  model: 'claude-opus-5',
   thinking: true,
   smartImports: true,
   reviewSuggestions: true,
@@ -1003,7 +1003,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   analytics: true,
   proactiveReviewOverrides: false,
   proactiveProvider: 'claude',
-  proactiveModel: 'claude-sonnet-4-6',
+  proactiveModel: 'claude-sonnet-5',
   proactiveThinking: false,
   educationMode: true,
   claudeContext: true,
@@ -1022,7 +1022,18 @@ function loadPreferences(): Preferences {
       stored.proactiveMode = stored.autoReviewOnRequest;
       delete stored.autoReviewOnRequest;
     }
-    if (stored.model === 'claude-opus-4-6') stored.model = 'claude-opus-4-7';
+    // Migrate stored prefs from retired/superseded models to their successors.
+    const MODEL_MIGRATIONS: Record<string, string> = {
+      'claude-opus-4-6': 'claude-opus-5',
+      'claude-opus-4-7': 'claude-opus-5',
+      'claude-sonnet-4-6': 'claude-sonnet-5',
+    };
+    for (const key of ['model', 'proactiveModel'] as const) {
+      const value = stored[key];
+      if (typeof value === 'string' && MODEL_MIGRATIONS[value]) {
+        stored[key] = MODEL_MIGRATIONS[value];
+      }
+    }
     // Drop Gemini settings from stored prefs of users who previously
     // selected it — provider reverts to claude, model falls back to
     // the default, the orphaned geminiPath string is discarded.

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -47,16 +47,28 @@ const PROVIDERS = {
   claude: {
     label: 'Claude',
     models: [
-      { id: 'claude-opus-4-7', label: 'Opus 4.7' },
-      { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+      { id: 'claude-fable-5', label: 'Fable 5' },
+      { id: 'claude-opus-5', label: 'Opus 5' },
+      { id: 'claude-sonnet-5', label: 'Sonnet 5' },
       { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
     ],
   },
 } as const;
 
-const MODEL_LABELS: Record<string, string> = Object.fromEntries(
-  Object.values(PROVIDERS).flatMap((p) => p.models.map((m) => [m.id, `${p.label} ${m.label}`]))
-);
+// Labels for models no longer offered in the picker, so old history entries
+// still render a friendly name instead of the raw ID.
+const LEGACY_MODEL_LABELS: Record<string, string> = {
+  'claude-opus-4-6': 'Claude Opus 4.6',
+  'claude-opus-4-7': 'Claude Opus 4.7',
+  'claude-sonnet-4-6': 'Claude Sonnet 4.6',
+};
+
+const MODEL_LABELS: Record<string, string> = {
+  ...LEGACY_MODEL_LABELS,
+  ...Object.fromEntries(
+    Object.values(PROVIDERS).flatMap((p) => p.models.map((m) => [m.id, `${p.label} ${m.label}`]))
+  ),
+};
 
 function getEntryStatus(entry: ReviewHistoryEntry): 'generating' | 'completed' | 'failed' {
   return entry.status ?? 'completed';
@@ -116,7 +128,7 @@ export function HomePage({ onReviewReady, prefillPrUrl }: Props) {
   const [authStatus, setAuthStatus] = useState<AuthStatus>('checking');
   const [prUrl, setPrUrl] = useState(prefillPrUrl ?? '');
   const [provider, setProvider] = useState<Provider>('claude');
-  const [model, setModel] = useState<ModelId>('claude-opus-4-7');
+  const [model, setModel] = useState<ModelId>('claude-opus-5');
   const [thinking, setThinking] = useState(true);
   const [smartImports, setSmartImports] = useState(true);
   const [reviewSuggestions, setReviewSuggestions] = useState(true);

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -92,7 +92,7 @@ export function ReviewPage({ review: initialReview, onBack, onReReview }: Props)
   const [chatOpen, setChatOpen] = useState(false);
   const [chatQuotedCode, setChatQuotedCode] = useState<string | null>(null);
   const [chatProvider, setChatProvider] = useState<Provider>('claude');
-  const [chatModel, setChatModel] = useState<ModelId>('claude-sonnet-4-6');
+  const [chatModel, setChatModel] = useState<ModelId>('claude-sonnet-5');
   const [diffLayout, setDiffLayout] = useState<Preferences['diffLayout']>('unified');
   const [slideViewMode, setSlideViewMode] = useState<'split' | 'focus'>('split');
   const [prefs, setPrefs] = useState<Preferences | null>(null);


### PR DESCRIPTION
## What

Updates the model lineup to the Claude 5 family: **Fable 5** (`claude-fable-5`), **Opus 5** (`claude-opus-5`), **Sonnet 5** (`claude-sonnet-5`), plus the existing Haiku 4.5.

## Changes

- `lib/types.ts` — `ClaudeModel` union updated to the new model IDs
- `lib/providers/claude.ts` — provider model list (passed to the CLI via `--model`) updated; Haiku stays the `quick` model
- `src/pages/HomePage.tsx` / `components/SettingsDialog.tsx` — pickers show the four new options; defaults move to Opus 5 (review) and Sonnet 5 (proactive). Added `LEGACY_MODEL_LABELS` so old history entries generated with Opus 4.6/4.7 or Sonnet 4.6 still render a friendly name
- `src/main.ts` — default prefs updated; the one-off `opus-4-6 → opus-4-7` migration generalized into a `MODEL_MIGRATIONS` map that upgrades stored `model` and `proactiveModel` on load
- `src/pages/ReviewPage.tsx` — slide-chat default moves to Sonnet 5

## Verification

- `tsc --noEmit` passes
- eslint reports no new issues (the findings in touched files exist identically on `main`)